### PR TITLE
Date-scope 25 dead/thin Google News feeds across 11 more shows (when:1d)

### DIFF
--- a/shows/dp_pod.yaml
+++ b/shows/dp_pod.yaml
@@ -30,11 +30,11 @@ sources:
     label: IEEE Spectrum Energy
   - url: "https://phys.org/rss-feed/breaking/"
     label: Phys.org Breaking
-  - url: "https://news.google.com/rss/search?q=scientific+breakthrough+OR+%22clinical+trial%22+success&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=scientific+breakthrough+OR+%22clinical+trial%22+success+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — breakthroughs & trial results"
   - url: "https://news.google.com/rss/search?q=%22clean+energy%22+record+OR+milestone+OR+%22first+time%22&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — clean energy milestones"
-  - url: "https://news.google.com/rss/search?q=conservation+species+recovery+OR+rebound+OR+restored&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=conservation+species+recovery+OR+rebound+OR+restored+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — conservation wins"
 
 web_search_queries:

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -56,13 +56,13 @@ sources:
   - url: https://eponline.com/rss-feeds/News.aspx
     label: Environmental Protection Online
   # Google News — supplementary broad coverage
-  - url: "https://news.google.com/rss/search?q=british+columbia+environment+OR+BC+climate+policy&hl=en-CA&gl=CA&ceid=CA:en"
+  - url: "https://news.google.com/rss/search?q=british+columbia+environment+OR+BC+climate+policy+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en"
     label: Google News BC Environment
-  - url: "https://news.google.com/rss/search?q=canada+climate+change+policy&hl=en-CA&gl=CA&ceid=CA:en"
+  - url: "https://news.google.com/rss/search?q=canada+climate+change+policy+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en"
     label: Google News Canada Climate
-  - url: "https://news.google.com/rss/search?q=environmental+science+sustainability+news&hl=en-CA&gl=CA&ceid=CA:en"
+  - url: "https://news.google.com/rss/search?q=environmental+science+sustainability+news+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en"
     label: Google News Environmental Science
-  - url: "https://news.google.com/rss/search?q=clean+energy+canada+renewable&hl=en-CA&gl=CA&ceid=CA:en"
+  - url: "https://news.google.com/rss/search?q=clean+energy+canada+renewable+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en"
     label: Google News Clean Energy Canada
   # Reddit — community environmental coverage
   - url: "https://www.reddit.com/r/environment/.rss"

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -36,7 +36,7 @@ sources:
   label: Google News Space
 - url: https://news.google.com/rss/search?q=NASA+SpaceX+rocket+launch&hl=en-US&gl=US&ceid=US:en
   label: Google News NASA SpaceX
-- url: https://news.google.com/rss/search?q=astronomy+discovery+exoplanet&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=astronomy+discovery+exoplanet+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News Astronomy
 - url: https://www.reddit.com/r/space/.rss
   label: r/space

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -37,9 +37,9 @@ sources:
   label: Ukrinform Economy (Ukrainian state news agency)
 - url: https://www.cicnews.com/feed
   label: CIC News (Canadian Immigration)
-- url: https://news.google.com/rss/search?q=Canada+personal+finance+TFSA+RRSP&hl=en-CA&gl=CA&ceid=CA:en
+- url: https://news.google.com/rss/search?q=Canada+personal+finance+TFSA+RRSP+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News Canada Finance
-- url: https://news.google.com/rss/search?q=Canadian+immigration+newcomer+finance&hl=en-CA&gl=CA&ceid=CA:en
+- url: https://news.google.com/rss/search?q=Canadian+immigration+newcomer+finance+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News Immigration Finance
 - url: https://www.reddit.com/r/PersonalFinanceCanada/.rss
   label: r/PersonalFinanceCanada

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -32,7 +32,7 @@ sources:
   label: Towards Data Science
 - url: https://news.google.com/rss/search?q=artificial+intelligence+AI+news&hl=en-US&gl=US&ceid=US:en
   label: Google News AI
-- url: https://news.google.com/rss/search?q=large+language+model+LLM+GPT&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=large+language+model+LLM+GPT+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News LLM
 - url: https://news.google.com/rss/search?q=AI+agent+autonomous+agent&hl=en-US&gl=US&ceid=US:en
   label: Google News AI Agents

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -28,9 +28,9 @@ sources:
   label: Live Science
 - url: https://theconversation.com/us/articles.atom
   label: The Conversation
-- url: https://news.google.com/rss/search?q=ChatGPT+AI+chatbot+news&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=ChatGPT+AI+chatbot+news+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News ChatGPT
-- url: https://news.google.com/rss/search?q=artificial+intelligence+beginners+explained&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=artificial+intelligence+beginners+explained+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News AI Explained
 - url: https://www.reddit.com/r/ChatGPT/.rss
   label: r/ChatGPT

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -35,11 +35,11 @@ sources:
   label: CoinTelegraph
 - url: https://www.investing.com/rss/news.rss
   label: Investing.com
-- url: https://news.google.com/rss/search?q=stock+market+investing+news&hl=en-CA&gl=CA&ceid=CA:en
+- url: https://news.google.com/rss/search?q=stock+market+investing+news+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News Investing
-- url: https://news.google.com/rss/search?q=TSX+Canadian+stock+market&hl=en-CA&gl=CA&ceid=CA:en
+- url: https://news.google.com/rss/search?q=TSX+Canadian+stock+market+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News TSX
-- url: https://news.google.com/rss/search?q=ETF+index+fund+investing&hl=en-CA&gl=CA&ceid=CA:en
+- url: https://news.google.com/rss/search?q=ETF+index+fund+investing+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News ETF
 - url: https://www.reddit.com/r/CanadianInvestor/.rss
   label: r/CanadianInvestor

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -39,11 +39,11 @@ sources:
   label: CNBC
 - url: https://www.wired.com/feed/rss
   label: Wired
-- url: https://news.google.com/rss/search?q=US+politics+policy+news&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=US+politics+policy+news+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News US Politics
-- url: https://news.google.com/rss/search?q=world+news+geopolitics+today&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=world+news+geopolitics+today+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News World
-- url: https://news.google.com/rss/search?q=economy+inflation+markets+news&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=economy+inflation+markets+news+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News Economy
 - url: https://news.google.com/rss/search?q=site:reuters.com+world&hl=en-US&gl=US&ceid=US:en
   label: Reuters (via Google News)

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -37,11 +37,11 @@ sources:
   - url: https://news.mit.edu/rss/topic/health
     label: MIT Health
   # Google News — supplementary broad coverage
-  - url: "https://news.google.com/rss/search?q=longevity+anti-aging+science&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=longevity+anti-aging+science+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: Google News Longevity
-  - url: "https://news.google.com/rss/search?q=biotechnology+gene+therapy+breakthrough&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=biotechnology+gene+therapy+breakthrough+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: Google News Biotech
-  - url: "https://news.google.com/rss/search?q=medical+science+breakthrough+discovery&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=medical+science+breakthrough+discovery+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: Google News Medical Science
   # Reddit — community science coverage
   - url: "https://www.reddit.com/r/longevity/.rss"

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -34,9 +34,9 @@ sources:
   label: The Guardian World
 - url: https://feeds.washingtonpost.com/rss/world
   label: Washington Post World
-- url: https://news.google.com/rss/search?q=science+discovery+nature+animals&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=science+discovery+nature+animals+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News Science Nature
-- url: https://news.google.com/rss/search?q=Russian+culture+language+news&hl=en-US&gl=US&ceid=US:en
+- url: https://news.google.com/rss/search?q=Russian+culture+language+news+when%3A1d&hl=en-US&gl=US&ceid=US:en
   label: Google News Russian Culture
 web_search_queries:
 - interesting science news for kids

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -33,7 +33,7 @@ sources:
     label: "Google News — xAI / Grok / compute"
   - url: "https://news.google.com/rss/search?q=Cursor+AI+OR+Anysphere+OR+%22Grok+in+Cursor%22+OR+%22Cursor+Grok%22&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — Cursor / Anysphere"
-  - url: "https://news.google.com/rss/search?q=SpaceX+Dragon+OR+Crew+Dragon+OR+Starshield&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=SpaceX+Dragon+OR+Crew+Dragon+OR+Starshield+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — Dragon & Starshield"
   - url: "https://news.google.com/rss/search?q=SpaceX+Falcon+9+OR+%22Falcon+Heavy%22+launch&hl=en-US&gl=US&ceid=US:en"
     label: "Google News — Falcon launches"

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -43,7 +43,7 @@ sources:
     label: Google News Tesla Solar
   - url: "https://news.google.com/rss/search?q=tesla+Cortex+OR+tesla+Dojo+OR+%22AI+training%22+tesla+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: Google News Tesla Cortex / Dojo
-  - url: "https://news.google.com/rss/search?q=electric+vehicle+industry+news&hl=en-US&gl=US&ceid=US:en"
+  - url: "https://news.google.com/rss/search?q=electric+vehicle+industry+news+when%3A1d&hl=en-US&gl=US&ceid=US:en"
     label: Google News EV Industry
   # Reddit — community-sourced breaking stories
   - url: "https://www.reddit.com/r/teslamotors/.rss"


### PR DESCRIPTION
## Why

Follow-up to the merged #853: the operator asked whether its fixes affect other shows. Most of #853 was engine-level and covers every show automatically — but the `when:1d` feed fix was applied only to the five feeds diagnosed on Tesla/SpaceX. A live probe of **every Google News search feed across all 13 shows** found the same failure class network-wide:

**18 DEAD (0 usable articles) + 7 THIN (&lt;3) feeds.** Google News search RSS returns ~100 results ranked by *relevance over weeks*, so low-volume queries almost never land items inside the 24h fetch cutoff. Worst cases:

| Show | Dead feeds |
|---|---|
| Planetterrian | all 3 GN feeds (Longevity / Biotech / Medical Science) |
| Env Intel | all 4 (BC Environment / Canada Climate / Env Science / Clean Energy Canada) |
| Omni View | all 3 topic feeds (US Politics / World / Economy) — only the Reuters/AP proxies worked |
| MAB | both (ChatGPT / AI Explained) |
| Финансы Просто | both (Canada Finance / Immigration Finance) |
| M&A | LLM feed |

These shows have been silently living off their other sources; the feeds' curated intent (e.g. Env Intel's provincial coverage, Planetterrian's longevity beat) contributed nothing.

## Change

Added Google's `when:1d` date operator to every feed measuring &lt;3 usable items (25 URLs across 12 YAMLs). Healthy feeds (≥3 usable) left untouched to preserve proven content mixes.

**Live-verified after scoping:** Omni View World 0 → 30 usable, MAB ChatGPT 0 → 43, Planetterrian Longevity 0 → 14, M&A LLM 0 → 5, Финансы Просто Canada Finance 0 → 2. The five feeds scoped in #853 all measure healthy in production (`[when:1d]` rows in the probe).

Fetch-side only: the keyword filter still gates focus downstream; no prompt/audio path changes (same accepted class as prior fetch filters — landmine #17 not implicated). Digest content mix will shift as these beats start actually contributing — that's the point, but worth a glance at the first post-merge episodes of the worst-affected shows (PT, EI, OV, MAB).

## Review-pass notes (not changed here)

- `privet_russian` "Russian Culture" and MIT "Investing" are *additionally* keyword-limited (recent items exist but few match show keywords) — `when:1d` improves their fresh pool; a keyword review is the residual lever.
- Everything else in #853 (empty-digest retry, 429/503 backoff on both API paths, entity-aware repetition filter, Reddit UA, headline-anchored chapters, outline guard) is engine-level and already covers all shows with no per-show work.

## Tests

Full suite: 3,832 passed / 9 skipped (same four optional-dep sandbox exclusions; identical on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Show-source URL tweaks only; no auth, pipeline logic, or generation changes—main effect is richer article pools and possible first-episode content mix shifts on previously dead feeds.
> 
> **Overview**
> Extends the **#853** Google News fix network-wide: **`when%3A1d`** is appended to **25** Google News search RSS URLs in **11** show configs (`dp_pod`, `env_intel`, `fascinating_frontiers`, `finansy_prosto`, `models_agents`, `models_agents_beginners`, `modern_investing`, `omni_view`, `planetterrian`, `privet_russian`, `spacex`, `tesla`) where probes showed **0 or &lt;3** usable items inside the usual 24h fetch window.
> 
> Unscoped Google News search feeds rank by relevance over weeks, so niche queries often contributed nothing after the date cutoff; shows were effectively running on their other sources only. **Feeds that already measured healthy (≥3 usable) are unchanged.**
> 
> This is **fetch-config only**—no engine, prompt, or audio path changes. Expect **digest mix shifts** on the worst-hit shows (e.g. Env Intel, Planetterrian, Omni View, MAB) as those beats start pulling real daily items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a972b4db952da886df7b22004457fc13d18267e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->