### PR TITLE
Align audit cadences with production CRON_MAP; fix reviewer false positives (issue #855)

### DIFF
--- a/review_episodes.py
+++ b/review_episodes.py
@@ -156,7 +156,13 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
-        "schedule": "odd_weekday",
+        # July 21 2026: aligned to the production CRON_MAP in
+        # .github/workflows/run-show.yml ("7 8 * * 1" = Monday-only).
+        # The stale "odd_weekday" belief made the audit flag a phantom
+        # "missed episode" on every non-Monday odd weekday AND dispatch an
+        # off-schedule episode via the retry path (the July 18 network
+        # review's open P0 — same class as FP/PR below).
+        "schedule": "monday",
     },
     "models_agents": {
         "name": "Models & Agents",
@@ -192,7 +198,8 @@ SHOW_REGISTRY = {
         "min_audio_s": 180,
         "max_audio_s": 1200,
         "required_sections": [],
-        "schedule": "even",
+        # Aligned to CRON_MAP Monday-only (July 21 2026, see env_intel note).
+        "schedule": "monday",
     },
     "modern_investing": {
         "name": "Modern Investing Techniques",
@@ -216,7 +223,8 @@ SHOW_REGISTRY = {
         "min_audio_s": 180,
         "max_audio_s": 1200,
         "required_sections": [],
-        "schedule": "even",
+        # Aligned to CRON_MAP Monday-only (July 21 2026, see env_intel note).
+        "schedule": "monday",
     },
     "spacex": {
         "name": "SpaceX Daily",
@@ -242,6 +250,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 240,
         "max_audio_s": 1500,
         "required_sections": [],
+        "narrative": True,   # topic-queue show — fetches no articles by design
         "schedule": "daily",
     },
     "unintended_consequences": {
@@ -254,6 +263,7 @@ SHOW_REGISTRY = {
         "min_audio_s": 300,
         "max_audio_s": 1200,
         "required_sections": [],
+        "narrative": True,   # topic-queue show — fetches no articles by design
         "schedule": "weekday",
     },
 }
@@ -279,6 +289,8 @@ def _should_run_on(schedule: str, target_date: datetime.date) -> bool:
         return is_weekday
     if schedule == "odd_weekday":
         return day % 2 == 1 and is_weekday
+    if schedule == "monday":
+        return weekday == 0
     return True  # unknown schedule → assume should run
 
 
@@ -885,8 +897,12 @@ def check_intro_outro(ep: EpisodeReview) -> None:
             file_path=str(ep.tts_path),
         ))
 
-    # Check last 500 chars for closing indicators
-    last_text = text_lower[-500:]
+    # Check the script tail for closing indicators. The window must cover
+    # the code-appended post-sign-off tail (rotating network cross-promo +
+    # summaries CTA + AI disclosure — up to ~700 chars since July 16 2026),
+    # which pushed the real spoken closing out of the old 500-char window
+    # and fired this info on 6 of 9 shows in the July 21 audit.
+    last_text = text_lower[-1500:]
     closing_indicators = [
         "tomorrow", "next episode", "next time", "see you",
         "until then", "that's it for", "that's all for",
@@ -945,7 +961,12 @@ def check_pipeline_metrics(ep: EpisodeReview) -> None:
             f"Verify it sounds natural and doesn't reveal the slow news status.",
         ))
 
-    # Check article count — too few may indicate feed issues
+    # Check article count — too few may indicate feed issues. Narrative
+    # (topic-queue) shows fetch zero articles BY DESIGN — the July 21
+    # audit warned "Zero articles fetched: RSS feeds may be down" on
+    # First Principles and Unintended Consequences every day.
+    if SHOW_REGISTRY.get(ep.show_slug, {}).get("narrative"):
+        return
     article_count = counters.get("article_count")
     if article_count is None:
         article_count = counters.get("articles_fetched")

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -82,3 +82,32 @@ def test_run_job_has_post_concurrency_duplicate_recheck():
     2026). The run job must re-check after the lock + fresh checkout."""
     assert "Post-concurrency duplicate re-check" in _WF
     assert "Duplicate re-check" in _WF
+
+
+def test_review_schedules_match_cron_day_filters():
+    """July 21 2026: review_episodes.py believed env_intel ran on odd
+    weekdays while the production CRON_MAP is Monday-only — so the daily
+    audit flagged a phantom "missed episode" every non-Monday odd weekday
+    AND dispatched an off-schedule episode via the retry path (the July 18
+    network review's open P0; FP/PR had the same drift as "even"). Any
+    show whose cron carries a Monday day-filter must be "monday" in the
+    reviewer registry so the audit's cadence beliefs track production.
+    """
+    import review_episodes
+
+    cron_map = _cron_map()
+    for show, (_h, _m, day_filter) in cron_map.items():
+        info = review_episodes.SHOW_REGISTRY.get(show)
+        if info is None:
+            continue  # not all shows are audited (e.g. age_of_ai)
+        if day_filter == "monday":
+            assert info.get("schedule") == "monday", (
+                f"{show}: CRON_MAP is Monday-only but review_episodes "
+                f"says {info.get('schedule')!r} — the audit will flag "
+                "phantom missed episodes and dispatch off-schedule runs"
+            )
+        else:
+            assert info.get("schedule") != "monday", (
+                f"{show}: review_episodes says Monday-only but the cron "
+                "has no Monday day-filter"
+            )

--- a/tests/test_skip_markers.py
+++ b/tests/test_skip_markers.py
@@ -255,8 +255,9 @@ class TestCheckMissedEpisodes:
 
     def test_not_scheduled_not_flagged(self):
         """A show not scheduled for the target date should not be flagged."""
-        # Day 13 is odd — finansy_prosto (even schedule) should not be flagged
-        target = datetime.date(2026, 4, 13)
+        # 2026-04-14 is a Tuesday — finansy_prosto (Monday-only per the
+        # production CRON_MAP, aligned July 21 2026) should not be flagged
+        target = datetime.date(2026, 4, 14)
         found: list[EpisodeReview] = []
         issues = check_missed_episodes(target, found, show_filter="finansy_prosto")
         assert len(issues) == 0


### PR DESCRIPTION
## The Env Intel "missed episode" was a phantom — and it dispatched an unplanned episode

The July 21 daily audit (issue #855) flagged Environmental Intelligence as a CRITICAL miss. Forensics: **EI was never scheduled today.** The production CRON_MAP in `run-show.yml` runs it Monday-only (`"7 8 * * 1"`), but `review_episodes.py` still believed `odd_weekday` — so on every non-Monday odd weekday the audit flags a phantom miss **and its retry path auto-dispatches an off-schedule episode** (both 17:45 `workflow_dispatch` runs today were `github-actions[bot]`: the SpaceX re-run was legitimate, the EI one was unplanned). This is precisely the July 18 network review's open P0 ("FP/PR publish off-schedule via the daily-audit retry path … pick a cadence and align all three") — FP/PR carried the same drift as `even`.

### Fixes

- **`review_episodes.py`**: `env_intel` / `finansy_prosto` / `privet_russian` aligned to a new `"monday"` schedule type — the production CRON_MAP is the truth source (it and the Cloudflare Worker SLOTS already agree, guarded by CI).
- **`tests/test_scheduling_punctuality.py`**: new drift guard — any show whose cron carries a Monday day-filter must be `"monday"` in the reviewer registry, and vice versa. This extends the existing CRON_MAP↔Worker sync guard to the third cadence authority, closing the class permanently.
- **`tests/test_skip_markers.py`**: the not-scheduled fixture moved to a Tuesday (its old "even-schedule" date, April 13 2026, is a Monday).

## Two reviewer false positives from the same audit

- **"Script may be missing closing section"** fired on 6 of 9 shows: the code-appended post-sign-off tail (rotating network cross-promo + summaries CTA + AI disclosure — up to ~700 chars since July 16) pushed the real spoken closing out of the 500-char scan window. Widened to 1,500 chars.
- **"Zero articles fetched: RSS feeds may be down"** warned on First Principles and Unintended Consequences — narrative topic-queue shows that fetch nothing *by design*. The registry gains a `narrative` flag that skips the article-count checks.

## Not changed (context for the remaining audit findings)

- **SpaceX miss** = the already-fixed July 21 crash (#853); its retry re-dispatch was correct and was running at audit time.
- **"Repetitive" AI-review criticals on 5 shows** (near-verbatim restatements) — editorial class for the review-agent rotation; prompt changes are A/B-gated. Omni View's chronic slow-news (6/6) + 20 cross-episode repeats should also ease as #854's revived feeds (its 3 dead topic feeds) start contributing.
- FP's public description still says "daily" while production is Monday-only — editorial copy for the operator's cadence decision.

## Tests

Full suite: 3,833 passed / 9 skipped (same four optional-dep sandbox exclusions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes missed-episode detection and auto-retry eligibility for three shows; incorrect schedule logic could still page or skip retries, but behavior is now aligned with production crons and guarded by a new drift test.
> 
> **Overview**
> **Daily audit cadence drift** — `review_episodes.py` treated Environmental Intelligence, Finansy Prosto, and Privet Russian as `odd_weekday` / `even` while production runs them **Monday-only** (`run-show.yml` `CRON_MAP`). That produced phantom “missed episode” criticals and could trigger **off-schedule auto-retries**. Those shows now use a new **`monday`** schedule in `_should_run_on`, with a CI test that Monday-filtered crons match the reviewer registry (and non-Monday shows are not marked Monday-only).
> 
> **Reviewer noise from the same audit** — Closing detection scans the last **1,500** characters (was 500) so appended post-sign-off tails don’t hide the real sign-off. **First Principles** and **Unintended Consequences** get a **`narrative`** registry flag so zero article counts are not warned as RSS failures.
> 
> **Tests** — `test_not_scheduled_not_flagged` uses a Tuesday for Monday-only Finansy Prosto instead of a Monday that matched the old `even` schedule.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a7ffc6004e1cd8c90c6158ac01c82829809dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->