### PR TITLE
Derive review rotation from ledgers — stop review PRs conflicting on review_state.yaml

### DIFF
--- a/.claude/commands/review-show.md
+++ b/.claude/commands/review-show.md
@@ -199,8 +199,13 @@ have very different real-world hit rates. Apply these rules:
 1. A review document at `docs/reviews/<slug>_review_<YYYY_MM_DD>.md`
    (P0/P1/P2 structure, what shipped vs. what's recommended, citations).
 2. The fixes + drift-guard tests.
-3. Update the target's entry in `docs/reviews/review_state.yaml` to today's
-   date (this advances the rotation when the PR merges).
+3. Do NOT edit `docs/reviews/review_state.yaml` — the rotation advances
+   automatically from your ledger entry's date when the PR merges
+   (`scripts/pick_review_target.py` reads the newer of the state file's
+   seed date and the latest `docs/reviews/ledger/<slug>.yaml` entry).
+   Concurrent review PRs used to conflict on the shared state file every
+   time; the state file is now only edited when a show joins or leaves
+   the rotation.
 4. **Append this review to `docs/reviews/ledger/<slug>.yaml`** (schema in
    `docs/reviews/ledger/README.md`): shipped fixes, deferred items (carried
    forward and re-evaluated each pass — this is the structured backlog),

--- a/scripts/pick_review_target.py
+++ b/scripts/pick_review_target.py
@@ -1,10 +1,24 @@
 #!/usr/bin/env python3
 """Pick the next target for the automated show-review agent.
 
-Reads docs/reviews/review_state.yaml and prints the least-recently-reviewed
-target slug (ties broken alphabetically, so the choice is deterministic).
-Targets with an in-flight review PR are passed via --exclude so the same
-show isn't reviewed twice while the operator considers the first PR.
+Reads docs/reviews/review_state.yaml (the rotation ROSTER + seed dates)
+and prints the least-recently-reviewed target slug (ties broken
+alphabetically, so the choice is deterministic). Targets with an in-flight
+review PR are passed via --exclude so the same show isn't reviewed twice
+while the operator considers the first PR.
+
+July 21 2026: the effective last-reviewed date is the NEWER of the state
+file's seed date and the latest entry date in the target's ledger
+(docs/reviews/ledger/<slug>.yaml). Review PRs previously advanced the
+shared state file themselves, and any two concurrently-open review PRs
+conflicted on that block every time (PRs #845/#856). The ledger entry each
+PR already carries IS the rotation advance — merging the PR advances the
+rotation with no shared-file write. review_state.yaml only needs editing
+when a show is added to (or removed from) the rotation.
+
+Ledger dates are read by regex, not yaml.safe_load — three committed
+ledgers contain unquoted ": " inside list items and must never be
+reserialized (see CLAUDE.md, review-agent section).
 
 Exit codes: 0 = slug printed, 2 = no eligible target (all excluded).
 
@@ -14,6 +28,7 @@ Usage:
 """
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
@@ -21,12 +36,26 @@ import yaml
 
 DEFAULT_STATE = Path(__file__).resolve().parents[1] / "docs" / "reviews" / "review_state.yaml"
 
+_LEDGER_DATE_RE = re.compile(r"^\s*-\s*date:\s*['\"]?(\d{4}-\d{2}-\d{2})['\"]?\s*$", re.M)
 
-def pick_target(state_path: Path, excludes: set[str]) -> str | None:
+
+def _latest_ledger_date(ledger_dir: Path, slug: str) -> str:
+    """Newest entry date in the slug's ledger, or "" when absent."""
+    path = ledger_dir / f"{slug}.yaml"
+    if not path.exists():
+        return ""
+    dates = _LEDGER_DATE_RE.findall(path.read_text(encoding="utf-8"))
+    return max(dates) if dates else ""
+
+
+def pick_target(state_path: Path, excludes: set[str],
+                ledger_dir: Path | None = None) -> str | None:
+    if ledger_dir is None:
+        ledger_dir = state_path.parent / "ledger"
     data = yaml.safe_load(state_path.read_text(encoding="utf-8"))
     targets = data.get("targets") or {}
     candidates = {
-        slug: str(last_reviewed)
+        slug: max(str(last_reviewed), _latest_ledger_date(ledger_dir, slug))
         for slug, last_reviewed in targets.items()
         if slug not in excludes
     }

--- a/scripts/run_show_review.py
+++ b/scripts/run_show_review.py
@@ -402,19 +402,13 @@ def update_ledger(slug: str, result: dict, doc: Path, cost: float,
     return path
 
 
-def advance_rotation(slug: str, today: datetime.date) -> Path:
-    """Set the slug's date in review_state.yaml via line replacement so the
-    file's explanatory comments survive."""
-    path = ROOT / "docs" / "reviews" / "review_state.yaml"
-    text = path.read_text(encoding="utf-8")
-    new_text, n = re.subn(
-        rf"(?m)^(\s*{re.escape(slug)}:\s*).*$",
-        rf"\g<1>{today.isoformat()}",
-        text,
-    )
-    if n:
-        path.write_text(new_text, encoding="utf-8")
-    return path
+# NOTE (July 21 2026): the rotation is no longer advanced here. The ledger
+# entry this script appends carries the review date, and
+# scripts/pick_review_target.py reads the effective last-reviewed date as
+# max(review_state seed, latest ledger entry) — so merging the PR advances
+# the rotation without touching the shared review_state.yaml. Two
+# concurrently-open review PRs used to conflict on that file every time
+# (PRs #845/#856).
 
 
 # ---------------------------------------------------------------------------
@@ -617,13 +611,12 @@ def main() -> int:
 
     doc = write_review_doc(slug, result, today)
     ledger = update_ledger(slug, result, doc, cost, today)
-    state = advance_rotation(slug, today)
     pytest_summary = run_show_pytest(slug)
     pr_body = build_pr_body(slug, result, cost, meta, pytest_summary)
 
     print(f"[review] wrote {doc.relative_to(ROOT)}, "
-          f"{ledger.relative_to(ROOT)}, {state.relative_to(ROOT)}")
-    open_draft_pr(slug, [doc, ledger, state], pr_body, today)
+          f"{ledger.relative_to(ROOT)}")
+    open_draft_pr(slug, [doc, ledger], pr_body, today)
     return 0
 
 

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -423,3 +423,64 @@ class TestDashboardVoiceBaseline:
             encoding="utf-8")
         assert '_VOICE_ID_RU = "0b875ae2"' in text
         assert '"ara"' in text.split("_SANCTIONED_EXTRA_VOICES", 1)[1][:80]
+
+
+class TestLedgerDrivenRotation:
+    """July 21 2026: review PRs no longer edit review_state.yaml (any two
+    concurrently-open review PRs conflicted on it every time — PRs
+    #845/#856). The effective last-reviewed date is max(state seed date,
+    latest ledger entry date), so merging a review PR advances the
+    rotation via the ledger entry it already carries."""
+
+    def test_newer_ledger_date_wins_over_state_seed(self, tmp_path):
+        picker = _load_picker()
+        state = tmp_path / "state.yaml"
+        state.write_text(
+            "targets:\n  alpha: 2026-06-01\n  beta: 2026-06-10\n"
+        )
+        ledger = tmp_path / "ledger"
+        ledger.mkdir()
+        # alpha was reviewed on 06-20 per its ledger — beta becomes oldest.
+        (ledger / "alpha.yaml").write_text(
+            "reviews:\n  - date: '2026-06-20'\n    summary: pass\n"
+        )
+        assert picker.pick_target(state, set(), ledger_dir=ledger) == "beta"
+
+    def test_missing_ledger_falls_back_to_state_date(self, tmp_path):
+        picker = _load_picker()
+        state = tmp_path / "state.yaml"
+        state.write_text("targets:\n  alpha: 2026-06-01\n  beta: 2026-06-10\n")
+        assert picker.pick_target(state, set()) == "alpha"
+
+    def test_ledger_dates_read_by_regex_not_yaml(self, tmp_path):
+        # Three committed ledgers contain unquoted ": " inside list items
+        # and cannot be safe_load-ed — the date extraction must survive that.
+        picker = _load_picker()
+        state = tmp_path / "state.yaml"
+        state.write_text("targets:\n  alpha: 2026-06-01\n  beta: 2026-06-05\n")
+        ledger = tmp_path / "ledger"
+        ledger.mkdir()
+        (ledger / "alpha.yaml").write_text(
+            "reviews:\n"
+            "  - date: '2026-06-30'\n"
+            "    summary: broken: unquoted: colons: everywhere\n"
+        )
+        assert picker.pick_target(state, set(), ledger_dir=ledger) == "beta"
+
+    def test_real_ledgers_yield_parseable_dates(self):
+        picker = _load_picker()
+        ledger_dir = ROOT / "docs" / "reviews" / "ledger"
+        found = 0
+        for path in ledger_dir.glob("*.yaml"):
+            d = picker._latest_ledger_date(ledger_dir, path.stem)
+            if d:
+                assert len(d) == 10 and d[4] == "-", (path.name, d)
+                found += 1
+        assert found >= 5  # the rotation's ledgers are being read
+
+    def test_review_runner_no_longer_writes_review_state(self):
+        text = (ROOT / "scripts" / "run_show_review.py").read_text(encoding="utf-8")
+        assert "advance_rotation" not in text.replace(
+            "rotation is no longer advanced here", ""
+        ).replace("advances the\n# rotation", "")
+        assert 'review_state.yaml"' not in text


### PR DESCRIPTION
## Why

Every pair of concurrently-open show-review PRs conflicts on the shared `targets:` block in `docs/reviews/review_state.yaml` — each PR advances its own line in the same small map. #845 and #856 both needed manual resolution today; this eliminates the class.

## How

The ledger entry each review PR already carries (`docs/reviews/ledger/<slug>.yaml`) records the review date — so the rotation derives from it, and review PRs stop touching the shared file entirely:

- **`scripts/pick_review_target.py`**: the effective last-reviewed date is now `max(review_state seed date, latest ledger entry date)`. Ledger dates are read by **regex, never `yaml.safe_load`** (three committed ledgers contain unquoted `: ` in list items and must never be reserialized — per the review-agent section of CLAUDE.md). `review_state.yaml` becomes roster + seed dates, edited only when a show joins or leaves the rotation.
- **`scripts/run_show_review.py`**: no longer writes `review_state.yaml`; review PRs ship only the review doc + ledger entry. Merging the PR advances the rotation via the ledger — conflict-free by construction, and the "merging a review PR advances the rotation" semantic is preserved exactly.
- **`.claude/commands/review-show.md`**: manual-pass deliverables updated to match (do NOT edit `review_state.yaml`); existing playbook-guardrail tests still pass.
- **`tests/test_review_agent.py::TestLedgerDrivenRotation`**: ledger date wins over seed date; missing-ledger fallback; the regex survives deliberately-unparseable ledger YAML; real committed ledgers yield dates; the runner no longer references the state file.

No behavior change for which show gets picked next — today's effective dates are identical to the state file's (all merged reviews had already advanced both), so the rotation order is unchanged.

## Tests

Full suite: 3,838 passed / 9 skipped (same four optional-dep sandbox exclusions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NALSGUm6qmoufvRdjvRJ9f)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scheduler logic change is localized and covered by new tests; intended pick order is unchanged when ledger and state dates already match.
> 
> **Overview**
> **Show-review rotation no longer updates `docs/reviews/review_state.yaml` on each PR**, which removes merge conflicts when two review branches are open at once.
> 
> **`pick_review_target.py`** treats each show’s effective last-reviewed date as the **newer** of the roster seed in `review_state.yaml` and the latest `date:` in `docs/reviews/ledger/<slug>.yaml`. Ledger dates are extracted with a **regex** (not `yaml.safe_load`) so broken ledger YAML with unquoted colons still works.
> 
> **`run_show_review.py`** drops `advance_rotation` and draft PRs now commit only the review doc and ledger entry; merging still advances rotation via the ledger date.
> 
> **`.claude/commands/review-show.md`** tells manual passes **not** to edit `review_state.yaml` (roster changes only when shows join/leave the rotation).
> 
> **`TestLedgerDrivenRotation`** locks in ledger-vs-seed behavior, regex parsing, real ledgers, and that the runner no longer writes the state file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d8b0e961561e1c2c47073ac8660ac9898dcb55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->