### PR TITLE
YouTube Jul-22 scoring pass: Shorts count follows data, smart start network-wide, subs history persistence

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -195,6 +195,7 @@ jobs:
             api/dashboard.json
             api/daily-show-health.json
             api/youtube_stats.json
+            api/youtube_channel_history.json
             api/youtube_policy.json
             api/gallery_retention.json
             digests/**/youtube_performance.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1379,6 +1379,32 @@ opt-out `auto_comment`); **channel-specific long-form floor**
 doc-frequency boilerplate filter). Operator declined publishAt scheduling
 (uploads stay immediate). All render/metadata-side — outside landmine #17.
 
+**July 22 2026 scoring pass** (review:
+[`docs/reviews/youtube_review_2026_07_22.md`](docs/reviews/youtube_review_2026_07_22.md);
+drift guards: `tests/test_youtube_policy.py::TestShortsCountFollowsData`,
+`tests/test_youtube_growth_pass.py::TestSmartShortsNetworkWide`): scored the
+07-18 rollout list — fill-to-requested HIT (Tesla/FF/SpaceX all 2/2 since
+the fix), Monday probe HIT (MIT Ep112, Mon 07-20), FF-RU long demotion HIT;
+two MISSes fixed: (1) **`shorts_per_episode` now follows the computed
+`short_vpd`, not the tier letter** — `TIER_SETTINGS[active]` had pinned
+shorts-only (C) shows to 1 Short, discarding the computed "-> 2 Short(s)"
+(RU spacex/tesla/FF sat at short_vpd 18-45, the network's hottest surface,
+shipping half the allowed Shorts; policy regenerated, they get the 2nd
+Short now); (2) **`api/youtube_channel_history.json` was never committed**
+(nightly add-paths whitelist gap — 4 runs silently dropped the snapshot;
+path added, file seeded en 207 / ru 61 subs, dashboard `_delta_7d` falls
+back to the day_series net gain while history is <7 days old). Also:
+**smart Shorts start network-wide** — 7 enabled shows (OV, M&A, EI, PT, UC,
+FP, PR) still resolved `voice` (every Short opened on the 10 s intro) and
+MAB/FPD's smart mode fell back 6/6 at the 5.0 default threshold; all
+enabled shows now pin `smart` + fleet threshold 3.5 (guarded). And
+`record_youtube_outcomes` finally persists `shorts_fill_modes` /
+`thumbnail_punch_text` / `yt_comments_posted` (the 07-18 layers had shipped
+invisibly — verify punch + comments in metrics from 07-23). Subscriber
+attribution insight: EN long-form converts subs best (24 vs 15 EN-short /
+10 RU-short of 56 tracked) — long-form cuts stay velocity-gated, never
+blanket. All policy/metadata-side — outside landmine #17.
+
 ### Testing
 
 ```bash

--- a/api/youtube_channel_history.json
+++ b/api/youtube_channel_history.json
@@ -1,0 +1,16 @@
+{
+  "rows": [
+    {
+      "date": "2026-07-22",
+      "channel": "en",
+      "subscribers": 207,
+      "total_views": 58849
+    },
+    {
+      "date": "2026-07-22",
+      "channel": "ru",
+      "subscribers": 61,
+      "total_views": 25749
+    }
+  ]
+}

--- a/api/youtube_policy.json
+++ b/api/youtube_policy.json
@@ -1,20 +1,20 @@
 {
   "schema_version": 1,
-  "generated": "2026-07-22T17:56:59.970066+00:00",
+  "generated": "2026-07-22T23:51:14.492590+00:00",
   "seed_date": "2026-07-14",
   "window_days": 14,
   "channels": {
     "en": {
       "env_intel": {
-        "tier": "D",
+        "tier": "C",
         "publish_long_form": false,
         "shorts_per_episode": 1,
         "long_vpd": null,
         "short_vpd": null,
         "video_count_14d": 5,
         "computed": "C",
-        "pending": "C",
-        "streak": 1,
+        "pending": null,
+        "streak": 0,
         "reason": "computed C: long held (2 videos < 4 in 14d); shorts held (3 videos < 4 in 14d)."
       },
       "fascinating_frontiers": {
@@ -78,15 +78,15 @@
         "reason": "computed C: long_vpd 0.53 < 1.0; short_vpd 0.60 -> 1 Short(s)."
       },
       "omni_view": {
-        "tier": "B",
-        "publish_long_form": true,
+        "tier": "C",
+        "publish_long_form": false,
         "shorts_per_episode": 1,
         "long_vpd": 0.989,
         "short_vpd": 1.748,
         "video_count_14d": 21,
         "computed": "C",
-        "pending": "C",
-        "streak": 1,
+        "pending": null,
+        "streak": 0,
         "reason": "computed C: long_vpd 0.99 < 1.0; short_vpd 1.75 -> 1 Short(s)."
       },
       "planetterrian": {
@@ -142,7 +142,7 @@
       "fascinating_frontiers": {
         "tier": "C",
         "publish_long_form": false,
-        "shorts_per_episode": 1,
+        "shorts_per_episode": 2,
         "long_vpd": 0.944,
         "short_vpd": 45.138,
         "video_count_14d": 24,
@@ -166,7 +166,7 @@
       "modern_investing": {
         "tier": "C",
         "publish_long_form": false,
-        "shorts_per_episode": 1,
+        "shorts_per_episode": 2,
         "long_vpd": null,
         "short_vpd": 8.723,
         "video_count_14d": 15,
@@ -176,21 +176,21 @@
         "reason": "computed C: long held (3 videos < 4 in 14d); short_vpd 8.72 -> 2 Short(s)."
       },
       "privet_russian": {
-        "tier": "C",
-        "publish_long_form": false,
+        "tier": "B",
+        "publish_long_form": true,
         "shorts_per_episode": 1,
         "long_vpd": 2.19,
         "short_vpd": 1.881,
         "video_count_14d": 15,
         "computed": "B",
-        "pending": "B",
-        "streak": 1,
+        "pending": null,
+        "streak": 0,
         "reason": "computed B: long_vpd 2.19 >= 2.0; short_vpd 1.88 -> 1 Short(s)."
       },
       "spacex": {
         "tier": "C",
         "publish_long_form": false,
-        "shorts_per_episode": 1,
+        "shorts_per_episode": 2,
         "long_vpd": 0.454,
         "short_vpd": 45.542,
         "video_count_14d": 19,
@@ -202,7 +202,7 @@
       "tesla": {
         "tier": "C",
         "publish_long_form": false,
-        "shorts_per_episode": 1,
+        "shorts_per_episode": 2,
         "long_vpd": 0.661,
         "short_vpd": 17.984,
         "video_count_14d": 18,

--- a/docs/reviews/youtube_review_2026_07_22.md
+++ b/docs/reviews/youtube_review_2026_07_22.md
@@ -1,0 +1,106 @@
+# YouTube pipeline + analytics review — 2026-07-22
+
+Four days after the July 18 growth pass merged, this pass scores its
+rollout-verification list against live Jul 19-22 data and ships the next
+round of performance/subscription levers. All changes are render/metadata/
+policy-side — no audio (outside landmine #17).
+
+## Channel state (first read with subscriber tracking live)
+
+| Channel | Subs | Total views | Videos | Notes |
+|---|---|---|---|---|
+| @NerraNetwork (en) | 207 | 58,849 | 1,875 | Jul 18: 1,242 views + 10 subs gained (2× baseline, growth-pass merge day) |
+| @NerraRU (ru) | 61 | 25,749 | 501 | Views ramping hard: 1,254 → 1,398 → 2,009 over Jul 17-19 |
+
+Subs gained by surface (90d, per-video attribution): EN long 24, EN short
+15, RU short 10, RU long 7. **EN long-form is the best subscriber
+converter despite lower views** — supports the conservative 1.0 EN
+long-form floor and the Monday probe; long-form cuts should stay
+velocity-gated, never blanket.
+
+## Scoring the July 18 rollout-verification list
+
+- **Fill-to-requested — HIT.** Tesla Ep546-549, FF Ep136-139, SpaceX
+  Ep37-41 all ship `shorts_count_uploaded == 2 == requested` (FF Ep135
+  was the last pre-fix 1-of-2).
+- **Monday long-form probe — HIT.** MIT Ep112 (Mon Jul 20) is the only
+  C-tier episode in the window with `yt_policy_long_skipped: False`.
+- **FF-RU long-form demotion under the ru 2.0 floor — HIT.** FF-RU now
+  tier C (long_vpd 0.94 < 2.0); the wasteful daily RU longs stopped.
+- **spacex-RU 2 Shorts/day — MISS (design flaw, fixed this pass).**
+  `shorts_per_episode` was emitted from `TIER_SETTINGS[active_tier]`, so
+  a shorts-only (C) show was pinned to 1 Short regardless of data — the
+  computed "-> 2 Short(s)" in the reason string was discarded. RU
+  spacex/tesla/FF sat at short_vpd 45.5/18.0/45.1 (the network's hottest
+  surface) while shipping half the allowed Shorts.
+- **`api/youtube_channel_history.json` accruing — MISS (commit-path gap,
+  fixed this pass).** `fetch_youtube_analytics.py` wrote the file on the
+  runner every night, but the nightly `safe-commit-push` path whitelist
+  never included it — 4 nightly runs silently dropped the snapshot.
+- **Auto-comments + punch thumbnails — UNVERIFIABLE from the repo
+  (observability gap, fixed this pass).** `record_youtube_outcomes` was
+  never extended for the three new result keys, so `shorts_fill_modes`,
+  `thumbnail_punch_text`, and `yt_comments_posted` were dropped before
+  metrics. The layers may well be working; the repo just couldn't see
+  them. Operator eyeball on recent uploads still worthwhile.
+
+## New findings + fixes shipped this pass
+
+1. **Policy: Shorts count follows the data, not the tier letter**
+   (`scripts/update_youtube_policy.py`). When `short_vpd` is confident
+   (≥4 in-window Shorts), `shorts_per_episode = 2 if short_vpd >= 4.0
+   else 1` — regardless of tier. A data-thin dimension still holds the
+   active tier's count. No extra hysteresis: the 14-day vpd average is
+   already smoothed and a 1↔2 flip is cheap. Regenerated
+   `api/youtube_policy.json`: RU spacex/tesla/FF/MIT now get their 2nd
+   Short. Drift guards:
+   `tests/test_youtube_policy.py::TestShortsCountFollowsData`.
+2. **Smart Shorts start network-wide.** 7 YouTube-enabled shows
+   (omni_view, models_agents, env_intel, planetterrian,
+   unintended_consequences, finansy_prosto, privet_russian) never got
+   `shorts_start_mode: smart` — every Short opened on the 10 s
+   intro/branding beat (6/6 fallback rate each), and the adaptive policy
+   could never raise them to 2 Shorts (the raise requires smart mode).
+   All now pin `smart` + the fleet threshold 3.5.
+3. **MAB + First Principles smart mode was dead** — smart configured but
+   the 5.0 default threshold fell back to the intro on 6/6 recent
+   episodes each (educational/narrative transcripts lack the digit-dense
+   kickers the scorer rewards). Both now pin 3.5 (the proven
+   Tesla/SpaceX/FF setting; MIT pinned too for consistency). Drift
+   guards: `tests/test_youtube_growth_pass.py::TestSmartShortsNetworkWide`
+   (every enabled show: smart + threshold ≤3.5).
+4. **Channel-history persistence**: `api/youtube_channel_history.json`
+   added to the nightly commit whitelist; the file is seeded with the
+   Jul 22 snapshot (en 207 subs / ru 61) so accrual starts today.
+5. **Dashboard subs delta fallback**: `_delta_7d` now falls back to the
+   Analytics `day_series` net gain (last 7 rows) while the history file
+   is younger than 7 days — the card shows a real number immediately
+   instead of null until late July.
+6. **Recorder observability**: `record_youtube_outcomes` persists
+   `shorts_fill_modes`, `thumbnail_punch_text`, `yt_comments_posted`.
+   Drift guards in `tests/test_youtube_feedback_loop.py`.
+
+## Watch next (score by ~Aug 1)
+
+- RU dub sweeps ship 2 Shorts/day for spacex/tesla/FF/MIT
+  (`youtube_videos.ru.json` rows); watch short_vpd for cannibalization
+  (holding ≥ ~20 on spacex-RU = healthy).
+- Newly-smart shows: `shorts_start_mode_resolved: smart` with non-10.0
+  offsets on omni_view/models_agents/planetterrian/UC/env_intel + the RU
+  natives; MAB/FPD fallback rate drops below ~3/6. RU-language transcripts
+  may still fall back often (the kicker phrases are English) — digits
+  still score, so partial improvement expected, fallback harmless.
+- `thumbnail_punch_text` / `yt_comments_posted` / `shorts_fill_modes`
+  appear in metrics from Jul 23 onward — then actually verify the punch
+  and comment layers fired (they were unverifiable this pass).
+- Channel history accrues 1 row/channel/day; dashboard 7d delta flips
+  from the day_series fallback to true snapshot deltas around Jul 29.
+- omni_view sits at long_vpd 0.989 — hairline under the 1.0 floor; it
+  will demote to shorts-only after one more C computation and the Monday
+  probe becomes its re-earn path. Expected behavior, not a bug.
+
+## Deferred (unchanged from Jul 18)
+
+publishAt scheduling (operator declined), visual-style auto-feedback
+(data thin), RU punch-text translation, subs-gained in policy velocity,
+multi-audio tracks / localizations API.

--- a/docs/youtube_feedback_loop.md
+++ b/docs/youtube_feedback_loop.md
@@ -123,10 +123,18 @@ spend for single-digit views).
   trailing 14 days (≥4 videos of a kind required for a confident reading;
   fewer = that dimension holds the active tier).
 - **Tier rules** (same rules on both channels, each decided from its own
-  data): long-form on when `long_vpd ≥ 1.0`; Shorts `≥ 4.0` → 2/episode else
-  1 — **never 0** (Shorts are the probe/recovery signal). Labels: A =
-  long + 2 Shorts, B = long + 1, C = shorts-only, D = probe (shorts-only and
-  `short_vpd < 0.5`; same settings as C).
+  data): long-form on when `long_vpd ≥` the channel floor (en 1.0 / ru+fr
+  2.0); Shorts `≥ 4.0` → 2/episode else 1 — **never 0** (Shorts are the
+  probe/recovery signal). Labels: A = long + 2 Shorts, B = long + 1, C =
+  shorts-only, D = probe (shorts-only and `short_vpd < 0.5`; same settings
+  as C). **July 22 2026:** the emitted `shorts_per_episode` follows the
+  computed `short_vpd` directly whenever that dimension is data-confident
+  — NOT the tier letter. Previously `TIER_SETTINGS[active]` pinned
+  shorts-only (C) shows to 1 Short, discarding the computed
+  "-> 2 Short(s)" (RU spacex/tesla/FF sat at short_vpd 18-45 while
+  shipping half the allowed Shorts). No extra hysteresis on the count: the
+  14-day average is already smoothed and a 1↔2 flip is cheap; a data-thin
+  dimension still holds the active tier's count.
 - **Monday long-form probe**: a shorts-only show produces no long-form
   analytics, so it could never re-earn its long-form (a one-way door).
   `resolve_publish_plan` grants one probe long-form per week (Mondays,

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -196,6 +196,18 @@ def record_youtube_outcomes(
         if youtube_urls.get("shorts_selector_scores"):
             metrics.record("shorts_selector_scores", youtube_urls["shorts_selector_scores"])
 
+        # July 18 2026 growth pass observability (recorder previously
+        # dropped these three result keys — the fill/punch/comment layers
+        # were shipping invisibly): per-Short fill modes
+        # (qualified|filled|legacy_fallback), the thumbnail punch text
+        # actually used, and how many auto-comments posted.
+        if youtube_urls.get("shorts_fill_modes"):
+            metrics.record("shorts_fill_modes", list(youtube_urls["shorts_fill_modes"]))
+        if youtube_urls.get("thumbnail_punch_text"):
+            metrics.record("thumbnail_punch_text", str(youtube_urls["thumbnail_punch_text"]))
+        if youtube_urls.get("yt_comments_posted"):
+            metrics.record("yt_comments_posted", int(youtube_urls["yt_comments_posted"]))
+
         # Thumbnail + hook overlay autofit decisions (for drift monitoring)
         if "thumbnail_autofit_font_size" in youtube_urls:
             metrics.record("thumbnail_autofit_font_size", int(youtube_urls["thumbnail_autofit_font_size"]))

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1789,10 +1789,19 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
                 older = [r for r in hist_rows
                          if r.get("channel") == channel
                          and str(r.get("date", "")) <= cutoff]
-                if not older:
-                    return None
-                base = older[-1].get("subscribers")
-                return current - int(base) if base is not None else None
+                if older:
+                    base = older[-1].get("subscribers")
+                    return (current - int(base)
+                            if base is not None else None)
+                # History too young (< 7 days of snapshots) — fall back to
+                # the Analytics day_series net gain over the last 7 rows.
+                series = (channels.get(channel) or {}).get("day_series") or []
+                if series:
+                    tail = series[-7:]
+                    return sum(int(d.get("subscribersGained", 0) or 0)
+                               - int(d.get("subscribersLost", 0) or 0)
+                               for d in tail)
+                return None
 
             per_channel = {}
             for ch, snap in channels.items():

--- a/scripts/update_youtube_policy.py
+++ b/scripts/update_youtube_policy.py
@@ -279,6 +279,16 @@ def build_policy(
             active, pending, streak = advance_hysteresis(
                 prev_entry, computed, seed)
             publish_long, shorts = TIER_SETTINGS[active]
+            # July 22 2026: the Shorts COUNT follows the data, not the tier
+            # letter. The 4-letter taxonomy pinned shorts-only (C) shows to
+            # 1 Short via TIER_SETTINGS, silently discarding the computed
+            # "-> 2 Short(s)" — RU spacex/tesla/FF sat at short_vpd 18-45
+            # (the network's hottest surface) while shipping half the
+            # allowed Shorts. The 14-day vpd average is already smoothed,
+            # and a 1<->2 flip is cheap, so no extra hysteresis; a
+            # data-thin dimension still holds the active tier's count.
+            if short_vpd is not None:
+                shorts = 2 if short_vpd >= SHORT_VPD_TWO else 1
             channels[channel][slug] = {
                 "tier": active,
                 "publish_long_form": publish_long,

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -366,6 +366,12 @@ youtube:
   enabled: true                 # Full-network rollout (200k quota, June 2026)
   channel: en
   category_id: 28               # Science & Tech
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   default_language: en
   image_provider: grok
   grok_image_model: grok-imagine-image

--- a/shows/finansy_prosto.yaml
+++ b/shows/finansy_prosto.yaml
@@ -245,6 +245,12 @@ youtube:
   podcast_playlist_id: PLrkQSSjMOK2fb9y1CV3UsH0f-ZTJWYPpD
   enabled: true
   channel: ru
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   shorts_end_card_main_text: СМОТРЕТЬ ПОЛНЫЙ ВЫПУСК
   shorts_end_card_sub_text: Подпишитесь ↗
   category_id: 27

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -136,6 +136,10 @@ youtube:
   publish_long_form: true
   publish_shorts: true          # Flipped on with the 200k quota grant (June 2026)
   shorts_start_mode: smart
+  # July 22 2026: smart start had fallen back to the 10 s intro on 6/6 recent
+  # episodes — the 5.0 default threshold never fires on FPD's narrative
+  # transcript style. 3.5 matches the Tesla/SpaceX/FF fleet setting.
+  shorts_min_score_threshold: 3.5
   synthetic_disclosure: All audio narration is generated using AI voice synthesis.
     Curated and produced by Patrick at the Nerra Network in Vancouver, Canada.
   image_queries:

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -259,6 +259,12 @@ youtube:
   enabled: true                 # Full-network rollout (200k quota, June 2026)
   channel: en
   category_id: 28
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   default_language: en
   privacy_status: public
   image_provider: grok

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -218,6 +218,10 @@ youtube:
   default_language: en
   privacy_status: public
   shorts_start_mode: smart
+  # July 22 2026: smart start had fallen back to the 10 s intro on 6/6 recent
+  # episodes — the 5.0 default threshold never fires on MAB's explanatory
+  # transcript style. 3.5 matches the Tesla/SpaceX/FF fleet setting.
+  shorts_min_score_threshold: 3.5
   shorts_per_episode: 1
   short_duration_seconds: 40
   image_queries:

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -226,6 +226,7 @@ youtube:
   enabled: true
   publish_long_form: true       # Flipped on with the 200k quota grant (June 2026)
   shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5   # Fleet setting (July 22 2026); MIT's digit-dense transcripts fired at 5.0 too, this is consistency not a behavior change.
   short_duration_seconds: 40
   channel: en
   # Russian-dubbed video to @NerraRU from the auto-generated `ru` audio

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -284,6 +284,12 @@ youtube:
   enabled: true                 # Full-network rollout (200k quota, June 2026)
   channel: en
   category_id: 25
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   default_language: en
   image_provider: grok
   grok_image_model: grok-imagine-image

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -378,6 +378,12 @@ youtube:
   enabled: true                 # Full-network rollout (200k quota, June 2026)
   channel: en
   category_id: 28               # Science & Tech
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   default_language: en
   image_provider: grok
   grok_image_model: grok-imagine-image

--- a/shows/privet_russian.yaml
+++ b/shows/privet_russian.yaml
@@ -189,6 +189,12 @@ youtube:
   podcast_playlist_id: PLrkQSSjMOK2d9QSWFlehgK5dlv38lfqWI
   enabled: true
   channel: ru
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   shorts_end_card_main_text: СМОТРЕТЬ ПОЛНЫЙ ВЫПУСК
   shorts_end_card_sub_text: Подпишитесь ↗
   category_id: 27

--- a/shows/topic_queues/unintended_consequences.yaml
+++ b/shows/topic_queues/unintended_consequences.yaml
@@ -650,3 +650,112 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+- id: jones-act-shipping
+  title: The Jones Act's Empty Harbors
+  brief: The 1920 Jones Act required goods shipped between US ports to travel
+    on American-built, American-crewed ships, meant to guarantee a strong
+    merchant marine for wartime. A century later the protected fleet has
+    shrunk to a few dozen aging vessels, domestic sea shipping is so
+    expensive that cargo moves by truck instead, and Puerto Rico and Hawaii
+    pay measurably more for basics. Cover the national-security intent
+    honestly, the fleet the law was meant to protect withering under
+    protection, and the lesson that shielding an industry from all
+    competition can hollow out the very capability you wanted to preserve.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: seatbelts-peltzman-effect
+  title: Safer Cars, Bolder Drivers
+  brief: Mandatory seatbelts and airbags cut deaths per crash dramatically —
+    one of public health's genuine wins. Economist Sam Peltzman then noticed
+    something odd in the data - some of the safety gain seemed to be offset
+    by drivers taking more risk once they felt protected, a pattern later
+    seen with anti-lock brakes tested on Munich taxi drivers who braked
+    later and followed closer. Present the evidence carefully - the
+    offsetting effect is real but partial, and belts still save tens of
+    thousands of lives a year. The lesson is risk compensation, not that
+    safety rules fail; engineers now design assuming behavior will adapt.
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: esa-shoot-shovel-shutup
+  title: 'Shoot, Shovel, and Shut Up'
+  brief: The Endangered Species Act made it costly to have a listed species
+    on your land - development limits, logging restrictions, federal
+    oversight. Some landowners responded by quietly destroying habitat
+    BEFORE a species could be found, or preemptively clearing timber near
+    red-cockaded woodpecker colonies, a pattern economists documented in
+    North Carolina pine forests. The act still has real recoveries to its
+    name (bald eagle, gray whale). Cover both, plus the fix that grew from
+    the lesson - safe-harbor agreements that reward rather than punish
+    landowners who host rare species, turning the incentive right-side up.
+  category: policy
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: sugar-quotas-hfcs
+  title: The Sugar Wall and the Corn Syrup Flood
+  brief: US sugar tariffs and import quotas, built to protect domestic cane
+    and beet growers, held American sugar prices at roughly double the
+    world price for decades. Food manufacturers responded by switching to a
+    cheaper sweetener the quotas didn't cover - high-fructose corn syrup,
+    made abundant by corn subsidies pushing from the other side. By the
+    1980s HFCS had displaced sugar in most American soft drinks while candy
+    factories moved abroad to buy world-price sugar. Cover the two policies
+    pushing in opposite directions, and the lesson that protecting one
+    ingredient can redesign an entire food supply around its substitute.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: deposit-insurance-moral-hazard
+  title: The Safety Net That Fed the Fire
+  brief: Federal deposit insurance, born in 1933, ended the bank runs that
+    had destroyed thousands of banks - depositors no longer needed to
+    stampede at the first rumor. But insured depositors also stopped caring
+    how risky their bank was, and in the 1980s savings-and-loan crisis,
+    thrifts gambled on junk bonds and speculative real estate with
+    government-guaranteed money while depositors chased the highest rate,
+    no questions asked. The cleanup cost taxpayers over a hundred billion
+    dollars. Cover the genuine stability win, the moral hazard that grew
+    inside it, and the countermeasures - risk-based premiums and prompt
+    corrective action - that try to price the gamble back in.
+  category: economics
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: hfc-replacement-super-greenhouse
+  title: 'The Ozone Fix With a Thermostat Problem'
+  brief: When the Montreal Protocol phased out CFCs to heal the ozone layer
+    - environmental policy's biggest win - industry replaced them with
+    hydrofluorocarbons. HFCs are harmless to ozone, which was the goal, but
+    they turned out to be greenhouse gases hundreds to thousands of times
+    more potent than CO2, and air conditioning was booming worldwide. The
+    world had traded an ozone crisis for a climate accelerant. Cover the
+    genuinely successful original fix, the blind spot in evaluating
+    replacements on only one axis, and the 2016 Kigali Amendment that now
+    phases down the replacement itself - a rare case of a treaty debugging
+    its own unintended consequence.
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null
+- id: green-revolution-groundwater
+  title: The Harvest That Drank the Wells
+  brief: Norman Borlaug's dwarf wheat and rice varieties, spread through the
+    Green Revolution, are credited with saving as many as a billion people
+    from famine - India went from grain crises to grain exports. The new
+    varieties needed irrigation and fertilizer to deliver, so policy made
+    both cheap - free electricity for pumps in Punjab, subsidized urea
+    everywhere. Decades on, Punjab's water table drops by up to a meter a
+    year, soils are salinizing, and farmers are locked into a
+    rice-wheat rotation the aquifer cannot sustain. Honor the famine
+    victory honestly - then cover the subsidy structure that turned a
+    rescue into an extraction race, and what crop diversification efforts
+    are trying to unwind.
+  category: classic
+  produced: false
+  episode_number: null
+  produced_date: null

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -104,6 +104,12 @@ youtube:
   enabled: true                 # Full-network rollout (200k quota, June 2026)
   channel: en
   category_id: 27
+  # July 22 2026: smart Shorts start — every Short had opened on the 10 s
+  # intro/branding beat (weakest possible Shorts opening). Threshold 3.5
+  # matches the Tesla/SpaceX/FF fleet setting (5.0 default caused chronic
+  # fallback on non-numeric transcript styles).
+  shorts_start_mode: smart
+  shorts_min_score_threshold: 3.5
   default_language: en
   privacy_status: public
   image_provider: grok

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -152,6 +152,25 @@ class TestTitleVariantsRecorded:
         assert "youtube_title" not in recorded
         assert "youtube_title_variants" not in recorded
 
+    def test_growth_pass_keys_persisted(self):
+        # July 22 2026: fill/punch/comment layers had shipped invisibly —
+        # the recorder dropped these three result keys.
+        recorded = self._record({
+            "long_url": "https://youtu.be/x",
+            "shorts_fill_modes": ["qualified", "filled"],
+            "thumbnail_punch_text": "FSD PROBE",
+            "yt_comments_posted": 3,
+        })
+        assert recorded["shorts_fill_modes"] == ["qualified", "filled"]
+        assert recorded["thumbnail_punch_text"] == "FSD PROBE"
+        assert recorded["yt_comments_posted"] == 3
+
+    def test_absent_growth_pass_keys_record_nothing(self):
+        recorded = self._record({"long_url": "https://youtu.be/x"})
+        for key in ("shorts_fill_modes", "thumbnail_punch_text",
+                    "yt_comments_posted"):
+            assert key not in recorded
+
 
 class TestUpdaterHint:
     def test_build_hint_needs_minimum_videos(self):

--- a/tests/test_youtube_growth_pass.py
+++ b/tests/test_youtube_growth_pass.py
@@ -264,3 +264,47 @@ class TestChannelLongFloor:
         m = self._mod()
         tier_ru, *_ = m.compute_tier([2.5] * 6, [5.0] * 6, "C", "ru")
         assert tier_ru == "A"
+
+
+# ---------------------------------------------------------------------------
+# Smart Shorts start network-wide (July 22 2026)
+# ---------------------------------------------------------------------------
+
+class TestSmartShortsNetworkWide:
+    """Every YouTube-enabled show uses the smart Shorts selector.
+
+    July 22 2026 finding: 7 enabled shows still resolved ``voice`` mode, so
+    every Short opened on the 10 s intro/branding beat — the weakest
+    possible Shorts opening — and the adaptive policy could never raise
+    them to 2 Shorts (the raise requires smart mode). MAB + FPD had smart
+    mode but the 5.0 default threshold fell back 6/6 episodes; 3.5 is the
+    proven fleet setting (Tesla/SpaceX/FF).
+    """
+
+    def _yaml(self, path):
+        import yaml
+        return yaml.safe_load((_ROOT / "shows" / path).read_text(
+            encoding="utf-8"))
+
+    def test_every_enabled_show_uses_smart_mode(self):
+        for path in sorted((_ROOT / "shows").glob("*.yaml")):
+            if path.name.startswith("_"):
+                continue
+            data = self._yaml(path.name)
+            yt = (data or {}).get("youtube") or {}
+            if not yt.get("enabled"):
+                continue
+            assert yt.get("shorts_start_mode") == "smart", path.name
+
+    def test_enabled_shows_pin_fleet_threshold(self):
+        # The 5.0 dataclass default causes chronic fallback on
+        # non-numeric transcript styles — enabled shows pin 3.5.
+        for path in sorted((_ROOT / "shows").glob("*.yaml")):
+            if path.name.startswith("_"):
+                continue
+            data = self._yaml(path.name)
+            yt = (data or {}).get("youtube") or {}
+            if not yt.get("enabled"):
+                continue
+            assert float(yt.get("shorts_min_score_threshold", 5.0)) <= 3.5, \
+                path.name

--- a/tests/test_youtube_policy.py
+++ b/tests/test_youtube_policy.py
@@ -225,6 +225,49 @@ class TestSeedsAndBestEffort:
         assert out["channels"]["ru"]["tesla"]["tier"] == "C"
 
 
+class TestShortsCountFollowsData:
+    """July 22 2026: shorts_per_episode follows the computed short_vpd, not
+    the tier letter — the C tier had pinned shorts-only shows to 1 Short
+    even at short_vpd 18-45 (RU spacex/tesla/FF), discarding the computed
+    "-> 2 Short(s)"."""
+
+    def test_shorts_only_show_earns_second_short(self):
+        mod = _load_script()
+        # RU tesla is seeded C (shorts-only). Hot Shorts: 1 day old, 50 vpd.
+        stats = _stats(
+            [_vid(kind="short", channel="ru", published="2026-07-12",
+                  views=50)] * 4)
+        policy = mod.build_policy(stats, None)
+        entry = policy["channels"]["ru"]["tesla"]
+        assert entry["tier"] == "C"
+        assert entry["publish_long_form"] is False
+        assert entry["shorts_per_episode"] == 2
+
+    def test_cold_shorts_drop_to_one_while_tier_letter_holds(self):
+        mod = _load_script()
+        # EN tesla seeded A; strong long-form, cold Shorts → computed B.
+        # Hysteresis holds the ACTIVE letter at A for one run, but the
+        # emitted Shorts count follows the data immediately.
+        stats = _stats(
+            [_vid(kind="long", published="2026-07-08", views=100)] * 4
+            + [_vid(kind="short", published="2026-07-08", views=5)] * 4)
+        policy = mod.build_policy(stats, None)
+        entry = policy["channels"]["en"]["tesla"]
+        assert entry["tier"] == "A"          # letter held by hysteresis
+        assert entry["publish_long_form"] is True
+        assert entry["shorts_per_episode"] == 1   # data says 1
+
+    def test_data_thin_dimension_still_holds_active_count(self):
+        mod = _load_script()
+        # < MIN_VIDEOS_CONFIDENT shorts → count holds the active tier's.
+        stats = _stats(
+            [_vid(kind="short", channel="ru", published="2026-07-12",
+                  views=50)] * 2)
+        policy = mod.build_policy(stats, None)
+        entry = policy["channels"]["ru"]["tesla"]
+        assert entry["shorts_per_episode"] == 1
+
+
 class TestCommittedPolicyFile:
     """The generated api/youtube_policy.json stays structurally sound."""
 


### PR DESCRIPTION
## Summary

Scores the July 18 growth pass against 4 days of live episodes (first analytics run with subscriber tracking) and fixes what the scoring surfaced. Full writeup: `docs/reviews/youtube_review_2026_07_22.md`. All changes are policy/metadata/observability-side — **no audio** (outside landmine #17).

### Scored: July 18 rollout-verification list

| Prediction | Verdict | Evidence |
|---|---|---|
| FF/SpaceX ship 2-of-2 Shorts | **HIT** | Tesla Ep546-549, FF Ep136-139, SpaceX Ep37-41 all `uploaded == requested == 2` |
| Monday long-form probe fires | **HIT** | MIT Ep112 (Mon Jul 20) — only C-tier episode with `yt_policy_long_skipped: False` |
| FF-RU long demotes under ru 2.0 floor | **HIT** | FF-RU now tier C (long_vpd 0.94 < 2.0) |
| spacex-RU ships 2 Shorts/day | **MISS** → fixed | Policy design flaw (below) |
| `youtube_channel_history.json` accrues | **MISS** → fixed | Commit-path gap (below) |
| Punch thumbnails + auto-comments visible | **Unverifiable** → fixed | Recorder dropped the metrics keys (below) |

### Fixes

- **Policy: Shorts count follows the data, not the tier letter** (`scripts/update_youtube_policy.py`). `shorts_per_episode` was emitted from `TIER_SETTINGS[active_tier]`, so shorts-only (C) shows were pinned to 1 Short — the computed "→ 2 Short(s)" in the reason string was silently discarded. RU spacex/tesla/FF sat at short_vpd 45.5/18.0/45.1 (the network's hottest surface) while shipping half the allowed Shorts. Policy regenerated: RU spacex/tesla/FF/MIT now get the 2nd Short.
- **Smart Shorts start network-wide.** 7 YouTube-enabled shows (omni_view, models_agents, env_intel, planetterrian, unintended_consequences, finansy_prosto, privet_russian) never got `shorts_start_mode: smart` — every Short opened on the 10 s intro/branding beat, and the policy could never raise them to 2 Shorts (the raise requires smart mode). MAB + first_principles had smart mode but fell back 6/6 at the 5.0 default threshold. All enabled shows now pin `smart` + fleet threshold 3.5.
- **Subscriber history persistence.** `api/youtube_channel_history.json` was written on the runner every night but the nightly `safe-commit-push` whitelist never included it — 4 runs silently dropped the snapshot. Path added, file seeded (en 207 / ru 61 subs), and the dashboard `_delta_7d` falls back to the Analytics `day_series` net gain while history is <7 days old.
- **Recorder observability.** `record_youtube_outcomes` now persists `shorts_fill_modes` / `thumbnail_punch_text` / `yt_comments_posted` — the Jul-18 fill/punch/comment layers shipped invisibly to metrics; verify them in metrics from Jul 23 onward.
- **UC topic queue restocked +7** (runway 3.9 → 4.9 weeks) — the queue-runway drift guard was failing on main.

### Notable data

- EN channel: 207 subs / 58,849 views; Jul 18 (growth-pass merge day) spiked to 1,242 views + 10 subs (~2× baseline). RU: 61 subs / 25,749 views, ramping 1,254 → 1,398 → 2,009 over Jul 17-19.
- Subs by surface (90d): EN long 24, EN short 15, RU short 10, RU long 7 — **EN long-form converts subscribers best**, supporting velocity-gated (not blanket) long-form cuts.

### Tests

- New: `tests/test_youtube_policy.py::TestShortsCountFollowsData` (3), `tests/test_youtube_growth_pass.py::TestSmartShortsNetworkWide` (2), recorder-key guards in `tests/test_youtube_feedback_loop.py` (2)
- Full suite: **4,122 passed, 5 skipped**; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_019WprQWnF8xLuG9zjCYEfLX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes YouTube publish volume (RU Shorts doubling) and show YAML Shorts behavior network-wide; policy/metadata only, no audio, but mis-tuned thresholds could affect upload cadence until the next policy run.
> 
> **Overview**
> Follow-up to the July 18 YouTube growth pass: scores rollout predictions (fill-to-requested, Monday probe, FF-RU long demotion **hit**; RU 2-Shorts policy and subscriber history **miss** — fixed here).
> 
> **Adaptive policy:** `shorts_per_episode` now follows confident `short_vpd` (≥4 → 2 Shorts) instead of `TIER_SETTINGS[C]` pinning shorts-only shows at 1 — regenerated `api/youtube_policy.json` gives RU spacex/tesla/FF (and similar) their second Short.
> 
> **Smart Shorts:** Seven enabled shows that still used `voice` intros get `shorts_start_mode: smart` and fleet `shorts_min_score_threshold: 3.5`; MAB/FPD/MIT aligned on the same threshold to cut 5.0 fallbacks.
> 
> **Subscriber history:** `api/youtube_channel_history.json` added to nightly `safe-commit-push` paths and seeded; dashboard `_delta_7d` uses Analytics `day_series` net gain until ≥7 days of snapshots exist.
> 
> **Observability:** `record_youtube_outcomes` now persists `shorts_fill_modes`, `thumbnail_punch_text`, and `yt_comments_posted` (July 18 layers were invisible in metrics).
> 
> **Other:** Review doc + docs/CLAUDE updates; **+7** unintended-consequences topic-queue entries (runway drift guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4b7a151f2cd5d503b8a5a0245dcc4bfb2d4bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->