### PR TITLE
[show-review] Modern Investing Techniques quality pass (2026-07-24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -520,6 +520,33 @@ nerranetwork/
   items still open: recompute --apply (matched alpha retains old-window
   inflation until backfill), SnapTrade Phase-0 verification, LL-054
   family retirement.
+  **July 24 2026 operator-directed pass** (review:
+  [`docs/reviews/modern_investing_review_2026_07_24.md`](docs/reviews/modern_investing_review_2026_07_24.md);
+  drift guards: `tests/test_mit_benchmark_integrity.py::{TestSuffixedSymbolExtraction,TestCryptoSymbolCandidates,TestInstrumentScaleMismatch,TestVoidDisclosure,TestAlphaCaveatDataShaped,TestArticleCollapseAlarm}`):
+  the trade EXTRACTOR could not parse the exchange-native symbols the
+  July-3 pass taught the digest to emit — Ep111's spoken CNR.TO weekly
+  pick was silently LOST (`no_pick_extracted`) and Ep113's "BTC-USD —
+  Bitcoin" was truncated to "BTC", validated against an unrelated $28.80
+  equity (narrated stop $64,500), routed to Webull in the trade signal,
+  and would_place'd by the SHADOW executor — the wrong instrument reached
+  the execution layer. Fixed: suffixed/hyphenated symbol extraction +
+  CRYPTO market (+ latent TSX-V alternation bug), crypto candidates force
+  the `-USD` pair with no bare fallback, a wrong-instrument tripwire
+  (stop outside [ref/3, ref×3] voids at record time + self-healing
+  migration; committed tracker migrated — Ep113 BTC voided), and an
+  announced-then-voided pick is now disclosed on air exactly once. Ep115
+  fetched 9 articles (vs 222-337 median) and shipped 6/6 x.com sources —
+  new network-wide source-collapse `::warning::` + `article_count_degraded`
+  metric in run_show; digest prompt gains x.com-as-one-publication /
+  publisher-first sourcing, the Tools-header scaffold typo fix ("…Tool:
+  Source" shipped verbatim), and Today's-Pick template instructions moved
+  out of the value slot (Ep111 echoed the parenthetical on air). Length
+  attacked at the sanctioned substrate (`digest_expand_below_target` +
+  `min_digest_words: 1500`; 10/10 scripts were under the 1800 floor). The
+  significance caveat missed a SECOND time (1/6 alpha mentions) — now
+  fused into the alpha value as a data-shaped parenthetical; a third miss
+  goes to the operator as accept-or-abandon. Prompt/caveat/digest-lever
+  edits change output — A/B-listen per landmine #17.
 
 **Tesla Shorts Time Recursive Memory System (May 2026+)**  
 TST received a full recursive improvement architecture (analogous to MIT):

--- a/digests/modern_investing/investment_tracker.json
+++ b/digests/modern_investing/investment_tracker.json
@@ -1124,12 +1124,12 @@
       "confidence": "Medium",
       "target_range": "+2% to +5% over the week if the breakout follows through.",
       "trade_type": "weekly",
-      "status": "open",
+      "status": "voided",
       "entry_price": null,
       "exit_price": null,
       "pnl_pct": null,
       "pnl_dollars": null,
-      "lesson": "",
+      "lesson": "Trade voided — the price tracker resolved the wrong instrument for this symbol.",
       "sector": "other",
       "stop_loss": {
         "price": 64500.0
@@ -1143,7 +1143,8 @@
       ],
       "resolved_symbol": "BTC",
       "pick_reference_price": 28.8,
-      "current_price": 29.14
+      "current_price": 29.14,
+      "void_reason": "instrument_scale_mismatch"
     }
   ],
   "benchmark": {

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -334,18 +334,121 @@ reviews:
         expected: ">=1 Monday weekly pick per week under regime v2; no
           pick drought longer than 7 days while SELECTIVE RESET is
           reachable"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-07-24: the escape valve produced a weekly pick 3 days
+          after v2 merged (Jul 21, ending an 11-day mostly-pre-fix drought) —
+          but on TUESDAY (Mon Jul 20 was an explicit no-trade), and the pick
+          was lost to the suffixed-symbol extraction bug (BTC-USD -> 'BTC',
+          wrong instrument, voided)."
+
       - metric: weekly holds with entry_bar_date == exit_bar_date
         baseline: "1 (Ep101 COST, the Thursday degenerate)"
         expected: "0 new one-bar weekly holds"
         verdict: pending
-        evidence: null
+        evidence: "2026-07-24: no weekly hold closed in the window (the only
+          new pick voided on the wrong-instrument tripwire) — carry forward."
+
       - metric: episodes quoting the matched-window alpha with the
           significance qualifier in the same breath
         baseline: "0 of ~8 alpha mentions (hedge separate -> dropped)"
         expected: "inline caveat echoed in >=70% of alpha mentions while
           t<2"
+        verdict: miss
+        evidence: "2026-07-24: post-merge alpha mentions Ep111 0/1, Ep112 1/2,
+          Ep113 0/1, Ep114 0/2 = 1/6 (17%) — the em-dash instruction form is
+          stripped during paraphrase. Second miss on this metric; third
+          mechanism shipped (caveat fused into the alpha VALUE as a
+          data-shaped parenthetical); a third miss goes to the operator as
+          accept-or-abandon."
+
+    agent_cost_usd: null
+
+  - date: 2026-07-24
+    pr: null
+    doc: docs/reviews/modern_investing_review_2026_07_24.md
+    reviewer: claude-code (/review-show, operator-directed out of rotation)
+    summary: >
+      Operator-reported issues in latest episodes / source referencing /
+      pick reviews / performance reporting — all four verified. P0: the
+      extractor could not parse the exchange-native symbols the July-3
+      pass taught the digest to emit — Ep111's spoken CNR.TO weekly pick
+      was silently LOST (signal: no_pick_extracted) and Ep113's
+      "BTC-USD — Bitcoin" was truncated to "BTC", validated against an
+      unrelated equity at $28.80 (narrated stop $64,500 — above entry),
+      routed to Webull in the trade signal, and would_place'd by the
+      shadow executor at $29.62: the wrong instrument reached the
+      execution layer. P0: Ep115 fetched 9 articles (vs 222-337 median)
+      and shipped 6/6 x.com sources incl. a duplicate unusual_whales URL
+      + the Tools header scaffold typo rendered verbatim ("...Tool:
+      Source"). P1: alpha quoted without the significance caveat (miss
+      #2), chronic under-length (10/10 below floor, median ~1382w),
+      "no newly closed trade" in 9/10 episodes (drought + lost picks).
+    shipped:
+      - suffixed/hyphenated symbol extraction (CNR.TO / BTC-USD / .V) +
+        CRYPTO market recognition + TSX-V alternation-order fix
+      - crypto candidates force the -USD Yahoo pair with NO bare
+        fallback; pre-suffixed symbols pass through verbatim
+      - "wrong-instrument tripwire — stop outside [ref/3, ref*3] voids
+        the pick at record time (instrument_scale_mismatch), writes an
+        explicit no-trade signal, + self-healing migration (committed
+        tracker migrated: Ep113 BTC voided)"
+      - void transparency — an announced-then-voided pick is disclosed
+        on air exactly once via the trade-review block
+      - "source-collapse alarm in run_show (article_count_degraded +
+        a GitHub warning annotation when count < 25% of the show's recent
+        median; log-only, all shows)"
+      - digest-substrate length lever — digest_expand_below_target true,
+        min_digest_words 1500 (A/B)
+      - digest prompt (A/B) — x.com = one publication / publisher-first
+        sourcing / thin-day depth rule; Tools header scaffold typo fixed;
+        Today's Pick template instructions moved out of the value slot
+        (Ep111 echoed the parenthetical on air) + explicit ticker format
+      - alpha caveat mechanism 3 (A/B) — qualifier fused into the alpha
+        value as a data-shaped parenthetical
+      - 18 new drift guards in tests/test_mit_benchmark_integrity.py
+    deferred:
+      - "operator: Ep31 'BTC' flash (April, closed +0.42% @ $33.67) is
+        the same wrong-instrument class historically; no stop recorded so
+        the tripwire cannot catch it — adjudicate via recompute report"
+      - "operator: Ep111 lost CNR.TO pick was spoken on air but never
+        recorded; optional one-line on-air acknowledgment"
+      - "carried: recompute --apply (matched alpha retains old-window
+        inflation), SnapTrade Phase-0 verification, closing-price lesson
+        retirement, shadow-executor cron delay (landmine #24 class)"
+    predictions:
+      - metric: suffixed/crypto picks recorded correctly (tracker symbol
+          matches the digest's Today's Pick symbol verbatim)
+        baseline: "Ep111 CNR.TO lost; Ep113 BTC-USD truncated to BTC"
+        expected: "0 lost or mangled suffixed picks; every crypto pick
+          resolves to the -USD pair"
+        verdict: pending
+        evidence: null
+      - metric: non-voided trades with stop/reference ratio outside
+          [1/3, 3]
+        baseline: "1 (Ep113 BTC, open, stop 2240x reference)"
+        expected: "0 — the tripwire voids at record time and the
+          migration self-heals any that slip through"
+        verdict: pending
+        evidence: null
+      - metric: alpha mentions carrying the significance qualifier
+          (while t<2)
+        baseline: "1/6 (17%) with the em-dash instruction form"
+        expected: ">=70% with the data-shaped parenthetical; a third
+          miss escalates to an operator accept-or-abandon decision
+          instead of a fourth mechanism"
+        verdict: pending
+        evidence: null
+      - metric: median script words, last-10 snapshot
+        baseline: "~1382w (all 10 below the 1800 floor)"
+        expected: ">=1550w within 10 episodes of the digest retry
+          shipping (digest-substrate lever, min_digest_words 1500)"
+        verdict: pending
+        evidence: null
+      - metric: episodes with >2 x.com Source citations on a
+          normal-fetch day (article_count > 100)
+        baseline: "Ep115: 6/6 x.com (collapsed-fetch day)"
+        expected: "0; collapsed-fetch days additionally emit
+          article_count_degraded"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/modern_investing_review_2026_07_24.md
+++ b/docs/reviews/modern_investing_review_2026_07_24.md
@@ -1,0 +1,158 @@
+# Modern Investing — Review 2026-07-24 (operator-directed, out of rotation)
+
+Operator request: review the latest episodes, **how sources are referenced**,
+the **performance review of individual picks**, and **overall performance
+reporting** — "all of those items have had recent issues." All four concerns
+verified real. Method per `.claude/commands/review-show.md`; numbers from
+`scripts/review_snapshot.py modern_investing` (2026-07-24) and the raw
+episode/tracker files.
+
+## Scoring the 2026-07-18 predictions (ledger updated)
+
+| Prediction | Verdict | Evidence |
+|---|---|---|
+| ≥1 Monday weekly pick/week under regime v2; no >7-day drought while SELECTIVE RESET reachable | **partial** | The escape valve worked — a weekly pick resumed 2026-07-21, three days after v2 merged (drought had reached 11 days, mostly pre-fix). But it landed on **Tuesday**, not Monday (Mon 07-20 was an explicit no-trade), and the pick itself was lost to the extraction bug below. |
+| 0 new one-bar weekly holds | **pending** | No weekly hold closed in the window (the only new pick was voided — see P0-1). |
+| Inline significance caveat in ≥70% of alpha mentions | **miss** (second miss on this metric) | Post-merge mentions: Ep111 0/1, Ep112 1/2, Ep113 0/1, Ep114 0/2 → **1/6 ≈ 17%**. Even riding the data line as an em-dash instruction, the model strips it. Third mechanism shipped (below); a third miss should go to the operator as an accept-or-abandon decision. |
+
+## P0 — record integrity: the extractor can't parse the symbols the digest now emits
+
+The July 3 pass taught the **digest** to emit exchange-native symbols
+(`CNR.TO`, `BTC-USD`). The **extractor** still only accepted bare
+`[A-Z]{1,5}` (`shows/hooks/modern_investing.py:2633`). Both recent picks hit
+this within three days:
+
+- **Ep111 (Sun 07-19): the spoken pick was never recorded.** The digest
+  (and the aired episode — "Today's practice investment is a weekly hold on
+  CNR… Canadian National Railway") picked `CNR.TO`. The extraction regexes
+  choke on the `.` and returned None; the trade signal shipped
+  `no_trade / no_pick_extracted`. Listeners heard a pick that does not
+  exist in the tracker, the signal, or the shadow ledger.
+- **Ep113 (Tue 07-21): the wrong instrument reached the execution layer.**
+  `**Today's Pick:** BTC-USD — Bitcoin` was truncated to `BTC`;
+  `**Market:** Crypto` fell through the market regex (`TSX|NYSE|NASDAQ|TSX-V`)
+  to UNKNOWN; `_probe_pick` then **validated** bare `BTC` — an unrelated
+  equity at **$28.80** — while the narrated stop was **$64,500** (Bitcoin
+  levels; stop 2,240× the reference, and *above* entry, violating the
+  July-4 stop invariant on shipped state). The signal routed an equity BUY
+  to Webull with `pick_validated: true`, and the **shadow executor
+  would_place'd $1,000 of the wrong instrument at $29.62**
+  (`shadow_ledger.json`, 2026-07-21). Had the live layer been armed, real
+  money would have bought the wrong asset. The trade sat open and was on
+  course to be **closed against the wrong instrument at today's (Fri 07-24)
+  evaluation**.
+
+**Shipped (deterministic, no A/B):**
+- Extraction accepts suffixed/hyphenated symbols (`CNR.TO`, `BTC-USD`,
+  `ABC.V`); market regex gains `CRYPTO` and fixes a latent alternation bug
+  (`TSX|…|TSX-V` could never match TSX-V).
+- `_yf_symbol_candidates`: pre-suffixed symbols pass through verbatim;
+  `CRYPTO` market forces the `-USD` Yahoo pair with **no bare fallback**
+  (bare "BTC" is an equity — the exact trap).
+- **Wrong-instrument tripwire**: a narrated stop outside `[ref/3, ref×3]`
+  of the resolved listing's price voids the pick at record time
+  (`instrument_scale_mismatch`), writes an explicit no-trade signal
+  (`override_reason`), and a self-healing migration voids any
+  already-recorded trade in that state — the committed tracker is migrated
+  in this PR (Ep113 BTC → voided; nothing else changed).
+- **Void transparency**: when a pick the show announced on air is voided,
+  the next episode's trade-review block instructs one plain-spoken
+  correction ("tracking error, not a market outcome, excluded from
+  totals"), stamped so it is said exactly once.
+
+**Not done (deliberate):** retro-recording the lost Ep111 CNR.TO pick or
+re-opening Ep113 as `BTC-USD` — both would price entries with the benefit
+of a known 3–5-day price path, the hindsight class the July 3 pass
+eliminated. The record honestly shows: one lost pick (documented), one
+voided pick (disclosed on air).
+
+## P0 — sources: Ep115 shipped with a collapsed source pool
+
+`metrics_ep115.json`: **9 articles fetched** vs 222–337 on the four prior
+days (fetch stage "succeeded"; Tesla/PT/M&A were normal that day, Omni View
+also degraded — likely a shared Google-News throttle). Consequences in the
+shipped digest: **6/6 `Source:` citations are x.com posts** (unusual_whales
+×3 — one URL cited twice, violating the prompt's own one-URL-once and
+2-per-publication rules), portfolio "Action:" advice hung off second-hand
+X commentary, and the episode ran thin (1,346 words). Nothing surfaced
+because 9 > `min_articles_skip` (3).
+
+**Shipped:**
+- **Source-collapse alarm** (`run_show.py`, all shows): when today's
+  article count falls below 25% of the show's own recent median (median
+  ≥40, ≥5 samples), the run records `article_count_degraded` and emits a
+  GitHub `::warning::`. Log-only — never blocks (house fail-loud pattern).
+- **Prompt (⚠️ A/B)**: x.com counts as ONE publication for the 2-max rule;
+  publisher citation preferred when both exist; x.com acceptable as a
+  Source only when the post is the primary source; thin days must prefer
+  fewer/deeper sections over stretching X posts across the template.
+- **Prompt (⚠️ A/B)**: the Tools & Techniques header template contained a
+  literal scaffold typo — `**[Tool/Technique Name]: Source**` — which
+  Ep115 rendered verbatim as "**OptionsPlay IV Color-Coding Tool:** Source"
+  on the blog. Header fixed to `**[Tool/Technique Name]**`.
+- **Prompt (⚠️ A/B)**: the Today's Pick template carried its instruction
+  *inside the value slot* — Ep111 echoed "(only for new picks on Monday or
+  Flash Trades)" verbatim after the company name. Instructions moved to
+  their own rules lines; the Market menu gains TSX-V/Crypto; ticker format
+  (bare US / `.TO` / `.V` / `-USD`) is now stated explicitly, aligned with
+  the extractor.
+
+## P1 — performance reporting
+
+- **Significance caveat (second miss, third mechanism).** The alpha is
+  quoted in most episodes at t=0.31 with no qualifier. The caveat is now a
+  **data-shaped parenthetical fused to the value** — the block renders
+  `alpha +6.59% (early, not yet statistically significant, t=+0.31)` — so
+  quoting the number without the qualifier requires actively editing the
+  statistic, plus one short "the parenthetical is part of the statistic"
+  note. ⚠️ A/B. If this misses a third time, stop prompt-side attempts and
+  put the accept/abandon call to the operator.
+- **Chronic under-length, attacked at the sanctioned substrate.** 10/10
+  recent scripts run 1,158–1,746w against the 1,800 floor (median ~1,382).
+  Podcast-side levers are ledger-banned network-wide; MIT never opted into
+  the digest-stage lever. Shipped: `digest_expand_below_target: true`,
+  `min_digest_words: 1500` (FPD/OV precedent). ⚠️ A/B when the retry fires.
+- Carried operator items: `scripts/recompute_mit_benchmarks.py --apply`
+  still not run (current +6.59% matched alpha retains old-window inflation);
+  SnapTrade Phase-0 verification; closing-price lesson-family retirement.
+
+## P1 — pick-performance review cadence
+
+"No newly closed trade since the last review" ran in **9/10** episodes.
+Root causes, in order: the regime-v1 deadlock (fixed 07-18), then the two
+extraction losses above (the only post-fix pick never became a priceable
+trade). With extraction fixed, the weekly cadence (pick → mid-week
+snapshots → Friday close → review) can resume; no additional lever shipped
+here — measured by the predictions below.
+
+## P2 / deferred
+
+- **Ep31 "BTC" flash trade (April, closed +0.42% at $33.67)** is the same
+  wrong-instrument class historically (labeled a macro/crypto play, priced
+  as an equity). No stop was recorded, so the tripwire can't catch it
+  mechanically — adjudicate via the recompute script's wrong-instrument
+  report (operator, carried).
+- Shadow-executor cron delay (runs 15:04–16:48 UTC vs the 13:50 slot) —
+  carried (landmine #24 class).
+- The Ep111 lost pick cannot be disclosed automatically (it was never
+  recorded); if the operator wants an on-air acknowledgment, it's a
+  one-line note for the next episode.
+
+## Verification
+
+- `tests/test_mit_benchmark_integrity.py` +18 new drift guards
+  (suffixed-symbol extraction incl. the exact shipped Ep111/Ep113 lines,
+  crypto candidate resolution, scale-mismatch tripwire + migration, void
+  disclosure once-only, data-shaped caveat, collapse-alarm source pin,
+  YAML lever pin); 2 stale July-18 caveat guards updated to the new
+  contract. Full MIT suites: **136 passed**. Smoke suites
+  (`test_prompt_fidelity`, `test_generator`, `test_snaptrade_execution`,
+  `test_config`, `test_episode_validity`, `test_dashboard_mit_section`,
+  `test_schedule`): **260 passed**.
+- `GROK_API_KEY` unset in this environment — the digest-prompt changes
+  were not exercised live; `test_prompt_fidelity` confirms they render.
+  Operator: the first post-merge episode is the A/B set.
+- Time-sensitive note: merging **before the next 08:16 UTC run** prevents
+  the voided-BTC state from being re-evaluated with stale code; if a run
+  lands first and closes "BTC" wrongly, the shipped migration voids that
+  close on the next load — either order self-heals.

--- a/run_show.py
+++ b/run_show.py
@@ -1013,7 +1013,7 @@ def run(args: argparse.Namespace) -> None:
                         "counters", {}).get("article_count")
                     if isinstance(_mc, (int, float)) and _mc > 0:
                         _recent_counts.append(int(_mc))
-                except Exception:
+                except (json.JSONDecodeError, OSError, ValueError):
                     continue
             if len(_recent_counts) >= 5:
                 _median = sorted(_recent_counts)[len(_recent_counts) // 2]
@@ -1030,7 +1030,8 @@ def run(args: argparse.Namespace) -> None:
                         "Article fetch collapsed: %d vs recent median %d",
                         len(articles), _median,
                     )
-        except Exception as exc:  # noqa: BLE001 — alarm must never break a run
+        except (OSError, TypeError, ValueError, AttributeError) as exc:
+            # Alarm must never break a run — degrade to a debug line.
             logger.debug("article-collapse check failed: %s", exc)
 
         if not articles and not _topic_driven:

--- a/run_show.py
+++ b/run_show.py
@@ -997,6 +997,42 @@ def run(args: argparse.Namespace) -> None:
         )
         metrics.record("article_count", len(articles))
 
+        # Source-collapse alarm (July 24 2026, MIT Ep115): a show that
+        # normally fetches 200-350 articles shipped a day on 9 — the
+        # digest then sourced every section from the X-post block (6/6
+        # x.com citations, duplicate URLs) and ran thin. Above the
+        # min_articles_skip floor nothing surfaced. Compare today's count
+        # against the show's own recent median and warn loudly (GitHub
+        # annotation) so a degraded-fetch day is visible the same morning.
+        # Log-only — never blocks the episode.
+        try:
+            _recent_counts = []
+            for _mf in sorted(Path(config.episode.output_dir).glob("metrics_ep*.json"))[-10:]:
+                try:
+                    _mc = json.loads(_mf.read_text(encoding="utf-8")).get(
+                        "counters", {}).get("article_count")
+                    if isinstance(_mc, (int, float)) and _mc > 0:
+                        _recent_counts.append(int(_mc))
+                except Exception:
+                    continue
+            if len(_recent_counts) >= 5:
+                _median = sorted(_recent_counts)[len(_recent_counts) // 2]
+                if _median >= 40 and len(articles) < _median * 0.25:
+                    metrics.record("article_count_degraded", True)
+                    print(
+                        f"::warning::{config.slug}: article fetch collapsed — "
+                        f"{len(articles)} articles vs recent median {_median}. "
+                        f"Digest will lean on X/web-search sources; check feed "
+                        f"health.",
+                        flush=True,
+                    )
+                    logger.warning(
+                        "Article fetch collapsed: %d vs recent median %d",
+                        len(articles), _median,
+                    )
+        except Exception as exc:  # noqa: BLE001 — alarm must never break a run
+            logger.debug("article-collapse check failed: %s", exc)
+
         if not articles and not _topic_driven:
             logger.warning("No articles found even after expanded search. Skipping episode.")
             _skip_episode("no_articles", "No articles found even after expanded search.")

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -1976,7 +1976,7 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
     # exactly once (stamped), only for recent voids so old migrations
     # don't resurface.
     void_note = ""
-    today = datetime.date.today()
+    today = datetime.date.today()  # noqa: DTZ011 — matches the tracker's naive dates
     for t in tracker["trades"]:
         if t.get("status") != "voided" or t.get("void_disclosed_in_episode"):
             continue

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -602,6 +602,25 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
             _probe_pick(trade)
         except Exception as exc:
             logger.warning("Pick validation probe failed for %s: %s", trade.get("symbol"), exc)
+        # Wrong-instrument tripwire (July 24 2026, Ep113 BTC): if the
+        # narrated stop and the resolved listing's price are on different
+        # scales, the resolution is wrong — void at record time so the
+        # sim never prices it and the execution layers never see it.
+        if _instrument_scale_mismatch(trade):
+            logger.error(
+                "PICK VOIDED AT RECORD: %s stop $%s vs reference $%s — the "
+                "resolved listing is not the instrument the show discussed. "
+                "Check the digest's Today's Pick symbol format.",
+                trade.get("symbol"),
+                (trade.get("stop_loss") or {}).get("price"),
+                trade.get("pick_reference_price"),
+            )
+            trade["status"] = "voided"
+            trade["void_reason"] = "instrument_scale_mismatch"
+            trade["lesson"] = (
+                "Trade voided — the price tracker resolved the wrong "
+                "instrument for this symbol."
+            )
         tracker["trades"].append(trade)
         tracker["metadata"]["last_updated"] = datetime.date.today().isoformat()
         tracker["sectors"] = _compute_sector_exposure(tracker)
@@ -619,7 +638,16 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
     # digest prose — so LLM formatting drift can't reach an order ticket.
     # Best-effort: a signal-write failure must never block the pipeline.
     try:
-        _write_trade_signal(output_dir, trade, digest_text, episode_num, tracker)
+        # A trade voided at record time must never reach the execution
+        # layers — the signal carries an explicit no_trade with the void
+        # reason instead (fail-closed for shadow AND live).
+        if trade is not None and trade.get("status") == "voided":
+            _write_trade_signal(
+                output_dir, None, digest_text, episode_num, tracker,
+                override_reason=trade.get("void_reason") or "pick_voided",
+            )
+        else:
+            _write_trade_signal(output_dir, trade, digest_text, episode_num, tracker)
     except Exception as exc:
         logger.warning("Trade-signal write failed (non-fatal): %s", exc)
 
@@ -741,6 +769,7 @@ def _ensure_schema(tracker: dict) -> None:
     tracker.setdefault("monthly_snapshots", [])
     tracker.setdefault("trades", [])
     _void_nonfinite_closed_trades(tracker)
+    _void_instrument_scale_mismatch_trades(tracker)
 
 
 def _void_nonfinite_closed_trades(tracker: dict) -> None:
@@ -813,11 +842,20 @@ def _yf_symbol_candidates(symbol: str, market: str = "") -> list[str]:
     sym = (symbol or "").upper().strip()
     if not sym:
         return []
+    # Already exchange-suffixed or crypto-quoted (CNR.TO, BTC-USD): the
+    # digest named the exact listing — use it verbatim, never re-suffix.
+    if "." in sym or sym.endswith("-USD"):
+        return [sym]
     m = (market or "").upper().replace("_", "-").strip()
     if m in ("TSX-V", "TSXV"):
         return [f"{sym}.V", f"{sym}.TO", sym]
     if m == "TSX":
         return [f"{sym}.TO", sym]
+    if m == "CRYPTO":
+        # Yahoo quotes spot crypto as <SYM>-USD. The bare symbol is NOT a
+        # safe fallback here — "BTC" resolves to an unrelated equity
+        # (the Ep113 wrong-instrument shape), so crypto never falls back.
+        return [f"{sym}-USD"]
     return [sym]
 
 
@@ -955,6 +993,61 @@ _EXPLICIT_NO_TRADE_RE = re.compile(
 )
 
 
+_SCALE_MISMATCH_FACTOR = 3.0
+
+
+def _instrument_scale_mismatch(trade: dict) -> bool:
+    """True when the narrated stop and the resolved instrument's price are
+    on wildly different scales — the wrong-instrument tripwire.
+
+    July 24 2026 (Ep113): the digest picked Bitcoin ("BTC-USD", stop
+    $64,500) but the tracker resolved bare "BTC" to an equity at $28.80
+    and marked the pick VALIDATED; the shadow executor then would_place'd
+    $1,000 of the wrong instrument. A stop 2,200× the reference price is
+    not a stop — it's proof the resolved listing is not the instrument
+    the show talked about. Anything outside [ref/3, ref*3] trips.
+    """
+    stop = trade.get("stop_loss")
+    ref = trade.get("pick_reference_price") or trade.get("entry_price")
+    if not (isinstance(stop, dict) and isinstance(ref, (int, float)) and ref > 0):
+        return False
+    price = stop.get("price")
+    if not (isinstance(price, (int, float)) and price > 0):
+        return False
+    ratio = price / ref
+    return ratio > _SCALE_MISMATCH_FACTOR or ratio < 1.0 / _SCALE_MISMATCH_FACTOR
+
+
+def _void_instrument_scale_mismatch_trades(tracker: dict) -> None:
+    """One-time/self-healing migration: void trades whose stop price and
+    reference/entry price sit on different scales (wrong instrument).
+
+    Covers the shipped Ep113 BTC state (open, resolved to the wrong
+    equity) AND any close that happened against the wrong listing before
+    this fix merged. Mirrors ``_void_nonfinite_closed_trades``: voided
+    trades leave every aggregate and are never narrated as outcomes.
+    """
+    for trade in tracker.get("trades", []):
+        if trade.get("status") == "voided":
+            continue
+        if _instrument_scale_mismatch(trade):
+            logger.error(
+                "VOIDING trade Ep%s %s: stop $%s vs reference $%s — "
+                "instrument scale mismatch (wrong listing resolved).",
+                trade.get("episode_num"), trade.get("symbol"),
+                (trade.get("stop_loss") or {}).get("price"),
+                trade.get("pick_reference_price") or trade.get("entry_price"),
+            )
+            trade["status"] = "voided"
+            trade["void_reason"] = "instrument_scale_mismatch"
+            trade["pnl_pct"] = None
+            trade["pnl_dollars"] = None
+            trade["lesson"] = (
+                "Trade voided — the price tracker resolved the wrong "
+                "instrument for this symbol."
+            )
+
+
 def _no_trade_reason(digest_text: str) -> str:
     """Classify why today's signal carries no trade.
 
@@ -986,6 +1079,8 @@ def _write_trade_signal(
     digest_text: str,
     episode_num: int | None,
     tracker: dict,
+    *,
+    override_reason: str | None = None,
 ) -> None:
     """Write the per-episode machine-readable trade signal.
 
@@ -1021,7 +1116,7 @@ def _write_trade_signal(
 
     if trade is None:
         signal["action"] = "no_trade"
-        signal["reason"] = _no_trade_reason(digest_text)
+        signal["reason"] = override_reason or _no_trade_reason(digest_text)
         signal["trade"] = None
     else:
         symbol = trade.get("symbol", "")
@@ -1874,11 +1969,38 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
     if episode_num and episode_num <= 1:
         return ""  # No review for Episode 1
 
+    # Void transparency (July 24 2026): when a pick the show ANNOUNCED on
+    # air gets voided (wrong-instrument resolution, data failure), say so
+    # once instead of silently dropping it — listeners heard the pick and
+    # deserve to know no simulated result is being claimed. Disclosed
+    # exactly once (stamped), only for recent voids so old migrations
+    # don't resurface.
+    void_note = ""
+    today = datetime.date.today()
+    for t in tracker["trades"]:
+        if t.get("status") != "voided" or t.get("void_disclosed_in_episode"):
+            continue
+        try:
+            age = (today - datetime.date.fromisoformat(t.get("date", ""))).days
+        except ValueError:
+            continue
+        if age <= 7:
+            if episode_num is not None:
+                t["void_disclosed_in_episode"] = episode_num
+            void_note = (
+                f"**Correction first:** the {t.get('symbol', '?')} practice "
+                f"pick from episode {t.get('episode_num', '?')} was VOIDED — "
+                f"a tracking error (not a market outcome), so no simulated "
+                f"result is claimed for it and it is excluded from the "
+                f"running totals. State this plainly and briefly.\n"
+            )
+            break
+
     closed = [t for t in tracker["trades"] if t.get("status") == "closed"]
     open_trades = [t for t in tracker["trades"] if t.get("status") == "open"]
     if not closed:
         # Check for open weekly hold — provide mid-week update
-        return _weekly_hold_update(open_trades)
+        return void_note + _weekly_hold_update(open_trades)
 
     last = closed[-1]
 
@@ -1887,8 +2009,8 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
     if already is not None and already != episode_num:
         hold_update = _weekly_hold_update(open_trades)
         if hold_update:
-            return hold_update
-        return (
+            return void_note + hold_update
+        return void_note + (
             "**No newly closed trade since the last review.** The most "
             "recent Practice Investment has already been reviewed; current "
             "holdings remain open and pending their scheduled evaluation, "
@@ -1929,7 +2051,7 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
         pass
 
     if entry is None or exit_ is None:
-        return (
+        return void_note + (
             f"**Last {type_label}:** {symbol}\n"
             f"**Result:** Market data was unavailable for evaluation.\n"
             f"**Running Total:** ${summary.get('cumulative_pnl', 0):.2f}\n"
@@ -1947,7 +2069,7 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
             f"position exited at the stop — say so plainly; stop discipline "
             f"working as designed is a teachable win.\n"
         )
-    return (
+    return void_note + (
         f"**Last {type_label}:** {symbol} — {strategy}\n"
         f"{stop_note}"
         f"**Entry:** ${entry:.2f} ({entry_label}) → **Exit:** ${exit_:.2f} ({exit_label})\n"
@@ -2003,27 +2125,34 @@ def _build_benchmark_block(tracker: dict) -> str:
         # model quoted the alpha in most episodes while speaking the
         # hedge in zero — models echo data lines and drop instructions,
         # so the hedge must be part of the data line it qualifies.
+        # July 24 2026 (second miss on this metric): the em-dash
+        # instruction caveat ("never quote this alpha without…") was
+        # dropped by the model in 5 of 6 alpha mentions since July 18 —
+        # instruction-shaped text gets stripped during paraphrase even
+        # when it rides the data line. Third mechanism: make the caveat
+        # part of the alpha VALUE itself, a data-shaped parenthetical the
+        # model has to copy to quote the number at all.
         t_stat = summary.get("alpha_t_stat")
         if summary.get("alpha_statistically_significant"):
-            caveat = (
-                f" — statistically significant (t={t_stat:+.2f}); the record "
-                f"shows genuine outperformance and you may say so plainly"
+            alpha_phrase = (
+                f"{_sign(matched_alpha)} (statistically significant, "
+                f"t={t_stat:+.2f})"
             )
         elif t_stat is not None:
-            caveat = (
-                f" — EARLY AND NOT YET STATISTICALLY SIGNIFICANT "
-                f"(t={t_stat:+.2f}); never quote this alpha without that "
-                f"qualifier in the same sentence"
+            alpha_phrase = (
+                f"{_sign(matched_alpha)} (early, not yet statistically "
+                f"significant, t={t_stat:+.2f})"
             )
         else:
-            caveat = ""
+            alpha_phrase = _sign(matched_alpha)
         matched_line = (
             f"1) MATCHED-WINDOW SCORE (the honest head-to-head — each $1,000 "
             f"trade vs the NASDAQ over the SAME holding window, compounded): "
             f"portfolio {_sign(summary.get('compounded_return_pct'))} vs NASDAQ "
             f"{_sign(summary.get('compounded_nasdaq_matched_pct'))} → alpha "
-            f"{_sign(matched_alpha)} across {matched_n} benchmarked trades"
-            f"{caveat}. "
+            f"{alpha_phrase} across {matched_n} benchmarked trades. The "
+            f"parenthetical after the alpha number is PART OF the statistic "
+            f"— speak them together. "
         )
         # Index sweep — only from samples big enough to mean something.
         # July 18 2026: before the gate, the sweep compared a 37-trade
@@ -2628,15 +2757,23 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
     if not digest_text:
         return None
 
-    # Extract ticker symbol
+    # Extract ticker symbol. July 24 2026: the pattern must accept
+    # exchange-suffixed and hyphenated symbols — the July 3 integrity pass
+    # taught the DIGEST to emit "CNR.TO" / "BTC-USD", but the extractor
+    # still only took bare [A-Z]{1,5}: Ep111 spoke a CNR.TO weekly pick
+    # that was silently LOST (signal: no_pick_extracted), and Ep113's
+    # "BTC-USD — Bitcoin" was truncated to "BTC", which _probe_pick then
+    # validated against the WRONG INSTRUMENT (an equity at $28.80 vs the
+    # spoken Bitcoin pick with a $64,500 stop).
+    _SYM = r"([A-Z]{1,5}(?:[.-][A-Z]{1,4})?)"
     ticker_match = re.search(
-        r"\*\*Today's Pick:\*\*\s*\[?([A-Z]{1,5})\]?\s*[-—]",
+        r"\*\*Today's Pick:\*\*\s*\[?" + _SYM + r"\]?\s*[-—]",
         digest_text,
     )
     if not ticker_match:
         # Fallback: try alternative patterns
         ticker_match = re.search(
-            r"Today's Pick[:\s]+([A-Z]{1,5})\s",
+            r"Today's Pick[:\s]+" + _SYM + r"\s",
             digest_text,
         )
     if not ticker_match:
@@ -2660,9 +2797,11 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
 
     symbol = ticker_match.group(1).strip()
 
-    # Extract market
+    # Extract market. CRYPTO added July 24 2026 — Ep113's "**Market:**
+    # Crypto" line fell through to UNKNOWN, so the candidate resolver had
+    # no signal that the bare symbol needed the -USD crypto quote.
     market_match = re.search(
-        r"\*\*Market:\*\*\s*(TSX|NYSE|NASDAQ|TSX-V)",
+        r"\*\*Market:\*\*\s*(TSX-V|TSX|NYSE|NASDAQ|CRYPTO)",
         digest_text, re.IGNORECASE,
     )
     market = market_match.group(1).upper() if market_match else "UNKNOWN"

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -125,6 +125,13 @@ llm:
   podcast_max_tokens: 8000
   min_podcast_words: 1800
   podcast_expand_below_target: true
+  # Digest-substrate length lever (July 24 2026 review): all 10 recent
+  # scripts ran 1158-1746w against the 1800 floor, and the podcast-side
+  # expand retry can't add facts the digest doesn't carry (network-wide
+  # ledger lesson — podcast-side length levers are banned). The digest
+  # retry deepens the brief when it lands under 1500w (FPD/OV precedent).
+  digest_expand_below_target: true
+  min_digest_words: 1500
   podcast_chain: true
 tts: {}
 audio:

--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -94,6 +94,8 @@ Use this analysis to inform today's Practice Investment pick. Favor sectors and 
 - Each article URL may appear ONLY ONCE in the entire briefing. Do NOT reference the same source URL in multiple sections.
 - Strategy Spotlight, Practice Investment, Tools & Techniques, and Quick Hits MUST each use DIFFERENT source articles — zero overlap between sections.
 - Maximum 2 articles from any single publication (e.g., max 2 from Finextra, max 2 from MarketWatch). If your source pool is dominated by one outlet, use only the 2 strongest articles and omit the rest.
+- X/Twitter counts as ONE publication for the 2-max rule (x.com in total, not per account). When a story is covered by both a news outlet and an X post, cite the news outlet. An x.com URL is acceptable as a Source ONLY when the post itself is the primary source (an official company/agency announcement, or original data published by the account) — never for second-hand market commentary.
+- On a thin-source day (few fetched articles), do NOT stretch X posts across every section to fill the template. Prefer fewer, deeper sections per the fewer-than-5-articles rule below.
 - Tools & Techniques must feature actual tools, platforms, or software that investors can USE (apps, screeners, APIs, brokerages). Regulatory events, webinars, and rule changes are NOT tools — those belong in Quick Hits.
 - If a story was already covered in Strategy Spotlight, do NOT repeat it in Quick Hits — find different stories.
 
@@ -108,14 +110,18 @@ This is the show's signature segment. Uses a HYBRID model — NOT financial advi
 
 **FRIDAY EVALUATION:** Close the weekly hold using Friday's closing price. Report P&L. Extract the lesson.
 
+**Format rules (do NOT copy these sentences into the output):**
+- The Today's Pick line names a ticker ONLY for new picks (Monday Weekly Hold or a Flash Trade). On Mid-Week Update or deliberate no-trade days write exactly: **Today's Pick:** None — monitoring [TICKER].
+- TICKER uses the exchange-native symbol the price tracker resolves: US symbols bare (LMT), TSX with the .TO suffix (CNR.TO), TSX-V with .V, crypto as the Yahoo pair (BTC-USD). Never a bare crypto symbol.
+
 **Format:**
 ━━━━━━━━━━━━━━━━━━━━
 ### Practice Investment of the Day
 **Disclaimer:** This is a SIMULATED trade for educational purposes only. No real money is involved. This is NOT financial advice.
 
 **Trade Type:** [Weekly Hold / Flash Trade / Mid-Week Update]
-**Today's Pick:** [TICKER] — [Company/ETF Name] (only for new picks on Monday or Flash Trades)
-**Market:** [TSX / NYSE / NASDAQ]
+**Today's Pick:** [TICKER] — [Company/ETF Name]
+**Market:** [TSX / TSX-V / NYSE / NASDAQ / Crypto]
 **Sector:** [REQUIRED — one of: precious_metals, energy, tech, financials, healthcare, consumer, crypto, industrials, utilities, other. MUST NOT match any sector listed in the sector-concentration warning above.]
 **Strategy:** [Brief 1-sentence description: e.g., "Momentum play on earnings beat", "Mean reversion after oversold RSI"]
 **Hold Period:** [Monday-Friday / Same-day (Flash Trade only)]
@@ -195,7 +201,7 @@ Write 6-8 sentences following this "Market Mechanics" framework:
 ━━━━━━━━━━━━━━━━━━━━
 ### Tools & Techniques
 2-3 items about modern investing tools, AI platforms, or techniques. For each:
-**[Tool/Technique Name]: Source**
+**[Tool/Technique Name]**
 3-4 sentences: What it does, how it gives investors an edge, who should use it, and how to access it. Be specific — name the platform, the feature, the pricing tier.
 Source: [EXACT URL]
 

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -916,8 +916,9 @@ class TestAlphaTStat:
         }
         block = mi._build_benchmark_block(tracker)
         # July 18: the caveat moved INLINE with the alpha number (models
-        # echo data lines and drop separate instructions).
-        assert "NOT YET STATISTICALLY SIGNIFICANT" in block
+        # echo data lines and drop separate instructions). July 24: after
+        # a second miss, it fused into the value as a data parenthetical.
+        assert "(early, not yet statistically significant" in block
 
     def test_signal_carries_stop_loss(self, tmp_path, monkeypatch):
         monkeypatch.delenv("NERRA_HOOKS_READONLY", raising=False)
@@ -1062,11 +1063,12 @@ class TestSweepGating:
     def test_hedge_is_inline_with_the_alpha_number(self):
         # Two weeks of transcripts: alpha quoted in most episodes, hedge
         # spoken in zero — the caveat must be part of the quoted line.
+        # July 24 2026 (second miss): even the em-dash instruction form
+        # was dropped in 5/6 mentions; the qualifier is now a data-shaped
+        # parenthetical fused to the alpha value itself.
         block = mi._build_benchmark_block(self._tracker(sp_trades=2))
-        alpha_sentence = [ln for ln in block.split(". ")
-                         if "+6.59%" in ln][0]
-        assert "NOT YET STATISTICALLY SIGNIFICANT" in alpha_sentence
-        assert "never quote this alpha without" in alpha_sentence
+        assert "+6.59% (early, not yet statistically significant" in block
+        assert "never quote" not in block.lower()
 
 
 class TestNoTradeReasonTaxonomy:
@@ -1098,3 +1100,215 @@ class TestNoTradeReasonTaxonomy:
             "### Practice Investment of the Day\n"
             "**Today's Pick** is Nvidia at current levels.\n"
         ) == "no_pick_extracted"
+
+
+# ---------------------------------------------------------------------------
+# July 24 2026 review — suffixed-symbol extraction + wrong-instrument
+# tripwire (Ep111 CNR.TO lost pick / Ep113 BTC-USD → equity "BTC" class)
+# ---------------------------------------------------------------------------
+
+class TestSuffixedSymbolExtraction:
+    """The July 3 pass taught the DIGEST to emit exchange-native symbols
+    (CNR.TO, BTC-USD) but the extractor still only accepted bare
+    [A-Z]{1,5}: Ep111's spoken CNR.TO weekly pick was silently lost
+    (signal reason no_pick_extracted) and Ep113's BTC-USD was truncated
+    to "BTC" and validated against the wrong equity."""
+
+    def _digest(self, pick_line, market="NYSE"):
+        return (
+            "### Practice Investment of the Day\n"
+            f"**Trade Type:** Weekly Hold\n"
+            f"**Today's Pick:** {pick_line}\n"
+            f"**Market:** {market}\n"
+            "**Strategy:** test strategy\n"
+            "- **Confidence Level:** Medium\n"
+        )
+
+    def test_crypto_pair_symbol_survives(self):
+        trade = mi._extract_trade_from_digest(
+            self._digest("BTC-USD — Bitcoin", market="Crypto"), 999)
+        assert trade is not None
+        assert trade["symbol"] == "BTC-USD"
+        assert trade["market"] == "CRYPTO"
+
+    def test_tsx_suffixed_symbol_survives(self):
+        trade = mi._extract_trade_from_digest(
+            self._digest("CNR.TO — Canadian National Railway", market="TSX"), 999)
+        assert trade is not None
+        assert trade["symbol"] == "CNR.TO"
+
+    def test_ep111_real_pick_line_extracts(self):
+        # The exact shipped Ep111 line, prompt-echo parenthetical included.
+        trade = mi._extract_trade_from_digest(self._digest(
+            "CNR.TO — Canadian National Railway (only for new picks on "
+            "Monday or Flash Trades)", market="TSX"), 111)
+        assert trade is not None
+        assert trade["symbol"] == "CNR.TO"
+
+    def test_bare_us_symbol_unchanged(self):
+        trade = mi._extract_trade_from_digest(
+            self._digest("LMT — Lockheed Martin"), 999)
+        assert trade is not None
+        assert trade["symbol"] == "LMT"
+
+    def test_no_trade_day_still_returns_none(self):
+        trade = mi._extract_trade_from_digest(
+            self._digest("None — monitoring Lockheed Martin ($LMT)"), 999)
+        assert trade is None
+
+    def test_tsx_v_market_no_longer_shadowed_by_tsx(self):
+        # Latent bug: (TSX|NYSE|NASDAQ|TSX-V) matched "TSX" inside
+        # "TSX-V", so TSX-V could never be extracted. Alternation order
+        # now puts TSX-V first.
+        trade = mi._extract_trade_from_digest(
+            self._digest("ABC.V — Test Venture Co", market="TSX-V"), 999)
+        assert trade is not None
+        assert trade["market"] == "TSX-V"
+
+
+class TestCryptoSymbolCandidates:
+    def test_crypto_pair_passes_through(self):
+        assert mi._yf_symbol_candidates("BTC-USD", "CRYPTO") == ["BTC-USD"]
+
+    def test_suffixed_tsx_passes_through(self):
+        assert mi._yf_symbol_candidates("CNR.TO", "TSX") == ["CNR.TO"]
+
+    def test_bare_crypto_symbol_gets_pair_and_never_falls_back(self):
+        # Bare "BTC" resolves to an unrelated equity on Yahoo — the
+        # crypto market must force the -USD pair with NO bare fallback.
+        assert mi._yf_symbol_candidates("BTC", "CRYPTO") == ["BTC-USD"]
+
+
+class TestInstrumentScaleMismatch:
+    def _btc_trade(self, **over):
+        trade = {
+            "episode_num": 113, "date": "2026-07-21", "symbol": "BTC",
+            "status": "open", "trade_type": "weekly",
+            "stop_loss": {"price": 64500.0},
+            "pick_reference_price": 28.8,
+            "entry_price": None, "exit_price": None,
+            "pnl_pct": None, "pnl_dollars": None,
+        }
+        trade.update(over)
+        return trade
+
+    def test_ep113_shape_trips(self):
+        assert mi._instrument_scale_mismatch(self._btc_trade()) is True
+
+    def test_normal_stop_does_not_trip(self):
+        t = self._btc_trade(stop_loss={"price": 27.0}, pick_reference_price=28.8)
+        assert mi._instrument_scale_mismatch(t) is False
+
+    def test_pct_stop_does_not_trip(self):
+        assert mi._instrument_scale_mismatch(
+            self._btc_trade(stop_loss={"pct": 6.0})) is False
+
+    def test_no_reference_does_not_trip(self):
+        assert mi._instrument_scale_mismatch(
+            self._btc_trade(pick_reference_price=None)) is False
+
+    def test_migration_voids_mismatched_open_trade(self):
+        tracker = {"trades": [self._btc_trade()]}
+        mi._void_instrument_scale_mismatch_trades(tracker)
+        t = tracker["trades"][0]
+        assert t["status"] == "voided"
+        assert t["void_reason"] == "instrument_scale_mismatch"
+        assert t["pnl_pct"] is None
+
+    def test_migration_voids_wrongly_closed_trade(self):
+        # If the wrong listing already CLOSED before the fix merged, the
+        # migration still voids it — never narrated as a market outcome.
+        t = self._btc_trade(status="closed", entry_price=28.9,
+                            exit_price=29.4, pnl_pct=1.7, pnl_dollars=17.0)
+        tracker = {"trades": [t]}
+        mi._void_instrument_scale_mismatch_trades(tracker)
+        assert tracker["trades"][0]["status"] == "voided"
+
+    def test_migration_leaves_healthy_trades_alone(self):
+        healthy = self._btc_trade(
+            symbol="COST", stop_loss={"price": 880.0},
+            pick_reference_price=934.94, status="closed",
+            entry_price=934.94, exit_price=912.97, pnl_pct=-2.35)
+        tracker = {"trades": [healthy]}
+        mi._void_instrument_scale_mismatch_trades(tracker)
+        assert tracker["trades"][0]["status"] == "closed"
+
+
+class TestVoidDisclosure:
+    def _tracker_with_recent_void(self):
+        return {
+            "trades": [{
+                "episode_num": 113,
+                "date": datetime.date.today().isoformat(),
+                "symbol": "BTC-USD", "status": "voided",
+                "void_reason": "instrument_scale_mismatch",
+            }],
+            "summary": {},
+        }
+
+    def test_recent_void_disclosed_once(self):
+        tracker = self._tracker_with_recent_void()
+        block = mi._build_trade_review(tracker, episode_num=116)
+        assert "VOIDED" in block
+        assert tracker["trades"][0]["void_disclosed_in_episode"] == 116
+        # Second episode: already disclosed — never repeated.
+        block2 = mi._build_trade_review(tracker, episode_num=117)
+        assert "VOIDED" not in block2
+
+    def test_old_void_not_resurfaced(self):
+        tracker = self._tracker_with_recent_void()
+        tracker["trades"][0]["date"] = "2026-06-01"
+        block = mi._build_trade_review(tracker, episode_num=116)
+        assert "VOIDED" not in block
+
+
+class TestAlphaCaveatDataShaped:
+    """Third mechanism for the twice-missed significance caveat: the
+    qualifier is now a data-shaped parenthetical inside the alpha value
+    itself, not an instruction sentence the model can drop."""
+
+    def _tracker(self, significant=False):
+        tracker = mi._fresh_tracker()
+        tracker["benchmark"] = {"current_close": 25873.0, "ytd_pct": 11.0,
+                                "inception_to_date_pct": 15.0,
+                                "last_updated": "2026-07-23"}
+        tracker["summary"] = {
+            "matched_window_alpha_pct": 6.59,
+            "matched_window_trades": 37,
+            "compounded_return_pct": 18.94,
+            "compounded_nasdaq_matched_pct": 12.35,
+            "alpha_t_stat": 0.31,
+            "alpha_statistically_significant": significant,
+            "benchmark_scores": {},
+        }
+        return tracker
+
+    def test_insignificant_alpha_carries_inline_parenthetical(self):
+        block = mi._build_benchmark_block(self._tracker())
+        assert "+6.59% (early, not yet statistically significant" in block
+        # The old imperative phrasing is gone (it was dropped 5/6 times).
+        assert "never quote" not in block.lower()
+
+    def test_significant_alpha_says_so_inside_the_value(self):
+        block = mi._build_benchmark_block(self._tracker(significant=True))
+        assert "+6.59% (statistically significant" in block
+
+
+class TestArticleCollapseAlarm:
+    """run_show warns when a show's article fetch collapses vs its own
+    recent median (MIT Ep115: 9 articles vs 222-337 — the digest then
+    sourced every section from x.com posts). Log-only, never blocking."""
+
+    def test_alarm_source_present(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "article_count_degraded" in src
+        assert "article fetch collapsed" in src
+        # Non-blocking contract: the alarm must not call _skip_episode.
+        block = src.split("Source-collapse alarm")[1].split("if not articles")[0]
+        assert "_skip_episode" not in block
+
+    def test_mit_yaml_has_digest_length_lever(self):
+        import yaml as _yaml
+        y = _yaml.safe_load((_ROOT / "shows/modern_investing.yaml").read_text())
+        assert y["llm"]["digest_expand_below_target"] is True
+        assert y["llm"]["min_digest_words"] == 1500


### PR DESCRIPTION
## TLDR

Operator-directed pass on the four reported problem areas — all four verified real, with two P0s:

1. **The trade extractor can't parse the symbols the digest now emits.** The July-3 pass taught the digest to write exchange-native symbols (`CNR.TO`, `BTC-USD`) but the extractor still only accepted bare `[A-Z]{1,5}`. Within three days both failure modes shipped:
   - **Ep111 (Sun 07-19):** the show *spoke* a CNR.TO weekly pick on air ("Today's practice investment is a weekly hold on CNR… Canadian National Railway") — the tracker recorded nothing (`trade_signal_ep111.json: no_pick_extracted`). Listeners heard a pick that doesn't exist in the record.
   - **Ep113 (Tue 07-21):** `BTC-USD — Bitcoin` was truncated to `BTC`, which `_probe_pick` validated against an **unrelated equity trading at $28.80** while the narrated stop was **$64,500** (2,240× the reference, and *above* entry — violating the July-4 stop invariant on shipped state). The trade signal routed an equity BUY to Webull with `pick_validated: true`, and the **shadow executor `would_place`'d $1,000 of the wrong instrument at $29.62**. If the live layer had been armed, real money would have bought the wrong asset. The trade sat open and was on course to be closed against the wrong instrument at today's Friday evaluation.
2. **Ep115's sources collapsed.** The fetch returned **9 articles** (vs a 222–337 recent median); the digest then cited **x.com for 6 of 6 sources** (unusual_whales ×3, one URL twice — violating the prompt's own one-URL-once and 2-per-publication rules), and shipped the Tools-header scaffold typo verbatim: "**OptionsPlay IV Color-Coding Tool:** Source".

Also scored the 07-18 ledger predictions: regime-v2 escape valve **partial** (a pick resumed 3 days post-merge, but on Tuesday, and it was then lost to bug #1), one-bar holds **pending** (no closes in window), significance caveat **miss #2** (1/6 alpha mentions carried it).

## What shipped (deterministic, no A/B)

- Extraction accepts suffixed/hyphenated symbols (`CNR.TO`, `BTC-USD`, `ABC.V`); `**Market:**` gains CRYPTO and fixes the latent `TSX|…|TSX-V` alternation bug (TSX-V could never match).
- `_yf_symbol_candidates`: pre-suffixed symbols pass through verbatim; CRYPTO forces the `-USD` pair with **no bare fallback** (bare "BTC" *is* an equity — the exact trap).
- **Wrong-instrument tripwire**: a narrated stop outside `[ref/3, ref×3]` of the resolved listing's price voids the pick at record time (`instrument_scale_mismatch`) and writes an explicit no-trade signal, so shadow/live never see it. A self-healing migration voids any already-recorded trade in that state — **the committed tracker is migrated in this PR** (only change: Ep113 BTC → voided). Either merge order self-heals: if a run closes "BTC" wrongly before this merges, the migration voids that close on next load.
- **Void transparency**: an announced-then-voided pick gets one plain-spoken on-air correction via the trade-review block (stamped, said exactly once).
- **Source-collapse alarm** (`run_show.py`, all shows): `article_count_degraded` metric + GitHub `::warning::` when today's fetch is <25% of the show's own recent median. Log-only, never blocks.
- Deliberately **not** done: retro-recording the lost Ep111 pick or re-opening Ep113 as BTC-USD — both would price entries with a known 3–5-day price path (the hindsight class the July-3 pass eliminated).

## ⚠️ A/B-listen required (landmine #17)

`GROK_API_KEY` is unset in this environment, so these were **not exercised live** (`test_prompt_fidelity` confirms they render). The first post-merge episode is the A/B set:

1. **Digest prompt — source hierarchy**: x.com counts as ONE publication for the 2-max rule; publisher citation preferred; x.com only when the post is the primary source; thin days prefer fewer/deeper sections.
2. **Digest prompt — Tools & Techniques header** template typo fixed (`**[Tool/Technique Name]: Source**` → `**[Tool/Technique Name]**`) — this literal "Source" shipped on Ep115's blog.
3. **Digest prompt — Today's Pick template**: instructions moved out of the value slot (Ep111 echoed "(only for new picks on Monday or Flash Trades)" after the company name); explicit ticker-format rules (bare US / `.TO` / `.V` / `-USD`); Market menu gains TSX-V/Crypto.
4. **Alpha significance caveat, third mechanism** (miss #2 scored this pass): the qualifier is now fused into the alpha value as a data-shaped parenthetical — `alpha +6.59% (early, not yet statistically significant, t=+0.31)` — instead of an instruction the model keeps dropping. **If this misses a third time, the ledger entry escalates it to an operator accept-or-abandon decision — no fourth mechanism.**
5. **Digest-substrate length lever**: `digest_expand_below_target: true`, `min_digest_words: 1500` (10/10 recent scripts under the 1,800 floor, median ~1,382w; podcast-side levers are ledger-banned network-wide; FPD/OV precedent).

## Test results

- `tests/test_mit_benchmark_integrity.py`: **+18 new drift guards** (including the exact shipped Ep111/Ep113 pick lines), 2 stale July-18 caveat guards updated to the new contract — 110 passed.
- Combined MIT + smoke + execution suites (`test_mit_*`, `test_review_agent`, `test_prompt_fidelity`, `test_generator`, `test_snaptrade_execution`, `test_config`, `test_episode_validity`, `test_dashboard_mit_section`): **419 passed, 2 skipped, 0 failed**.
- Ledger `docs/reviews/ledger/modern_investing.yaml`: 07-18 predictions scored, new entry with 5 measurable predictions.

## Deferred / operator items

- **Ep31 "BTC" flash trade** (April, closed +0.42% @ $33.67) is the same wrong-instrument class historically; no stop recorded so the tripwire can't catch it — adjudicate via `scripts/recompute_mit_benchmarks.py`'s wrong-instrument report.
- **Ep111's lost CNR.TO pick** was spoken but never recorded — optional one-line on-air acknowledgment if you want it (the Ep113 Bitcoin void will disclose automatically).
- Carried: `recompute --apply` (the quoted +6.59% matched alpha retains old-window inflation until backfill), SnapTrade Phase-0 verification, closing-price lesson-family retirement, shadow-executor cron delay.
- **Time-sensitive**: merging before the next 08:16 UTC MIT run prevents the voided BTC state from being evaluated by stale code (self-heals either way, but earlier is cleaner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X

---
_Generated by [Claude Code](https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch trade recording, void logic, and execution-facing signals—bugs could suppress valid picks or still route wrong instruments; prompt/config edits need post-merge A/B validation.
> 
> **Overview**
> **P0 execution integrity:** Trade extraction now accepts exchange-native symbols (`CNR.TO`, `BTC-USD`, `.V`) and `CRYPTO` markets; Yahoo resolution passes suffixed symbols through and forces crypto to `-USD` with no bare `BTC` fallback. A **wrong-instrument tripwire** voids picks when narrated stop vs reference price is outside `[ref/3, ref×3]`, blocks voided picks from trade signals, migrates bad tracker rows (Ep113 BTC voided), and adds a one-time on-air void disclosure in trade review.
> 
> **Operational visibility:** `run_show` emits `article_count_degraded` and a GitHub warning when article fetch falls below 25% of the show’s recent median (log-only).
> 
> **Content levers (A/B):** Digest prompt updates for x.com sourcing rules, Tools header typo, Today’s Pick template/ticker format; alpha significance caveat fused into the quoted value; `digest_expand_below_target` + `min_digest_words: 1500` in show config. Review docs, ledger scoring, and **+18** drift guards in `test_mit_benchmark_integrity.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5344cfe8ce72495bce1ded207b5d49d07ab2e832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->