### PR TITLE
Automate narrative topic-queue restocks via Grok (FPD is at 2.7 weeks now)

### DIFF
--- a/.github/workflows/restock-topic-queues.yml
+++ b/.github/workflows/restock-topic-queues.yml
@@ -1,0 +1,85 @@
+# Auto-restock narrative topic queues (July 24 2026).
+#
+# The narrative shows (First Principles Daily, Unintended Consequences) run
+# from shows/topic_queues/*.yaml instead of a news fetch. Restocks were
+# manual, and twice a queue drifted to within days of empty — an empty
+# queue means narrative_queue_empty skips and the show silently stops
+# publishing. scripts/restock_topic_queues.py is trigger-gated (only acts
+# when a show's runway drops below ~4-5 weeks, refills to ~8), so this
+# daily run is a cheap no-op most days and a small Grok call (~pennies)
+# when it fires. Age of AI's queue is deliberately empty and is NOT
+# registered in the script — never add it.
+#
+# The drift guards in tests/test_network_quality_pass.py
+# (TestNarrativeQueueRunway, 3.0/4.0-week floors) remain the alarm of last
+# resort: they only fire if this automation has been broken for a week+.
+name: Restock Topic Queues
+
+on:
+  schedule:
+    # Daily, off-peak (:37 per landmine #24), after the morning shows finish.
+    - cron: "37 13 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Restock to target runway even when above the trigger"
+        required: false
+        default: "false"
+
+concurrency:
+  group: restock-topic-queues
+  cancel-in-progress: false
+
+jobs:
+  restock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: "3.12"
+          requirements-file: "requirements.txt"
+          skip-checkout: "true"
+
+      - name: Restock queues (trigger-gated)
+        env:
+          GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
+          XAI_API_KEY: ${{ secrets.GROK_API_KEY }}
+        run: |
+          FORCE_FLAG=""
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            FORCE_FLAG="--force"
+          fi
+          python scripts/restock_topic_queues.py $FORCE_FLAG
+
+      - name: Verify queue integrity after restock
+        # The runway/uniqueness/alternation drift guards double as the
+        # post-restock validator: a malformed or under-filled restock
+        # fails HERE, before anything is committed.
+        run: python -m pytest tests/test_network_quality_pass.py::TestNarrativeQueueRunway -q
+
+      - uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: |
+            shows/topic_queues/first_principles.yaml
+            shows/topic_queues/unintended_consequences.yaml
+          commit-message: "Auto-restock: narrative topic queues (trigger-gated)"
+
+      - name: Notify operator
+        if: success()
+        env:
+          NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
+        run: |
+          # Ping only when something was actually committed this run
+          # (clean no-op when the webhook secret is unset).
+          if [ -n "$NOTIFICATION_WEBHOOK_URL" ] && \
+             git log -1 --pretty=%s | grep -q "Auto-restock: narrative topic queues"; then
+            STAT=$(git show --stat --oneline -1 | head -c 1200)
+            printf '{"text":"Topic queues restocked:\n%s"}' "$STAT" \
+              | tr '\n' ' ' \
+              | curl -sf -X POST -H "Content-Type: application/json" -d @- \
+                  "$NOTIFICATION_WEBHOOK_URL" || true
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1604,6 +1604,21 @@ same review ran across the other ten shows. Drift guards:
   risk): Unintended Consequences +14 → 38 unproduced (~7.6 wk runway, was
   ~4.8); First Principles +12 → 27 unproduced (~3.9 wk, was ~1.3 and
   about to dry up), preserving the concrete/opportunity alternation.
+  **July 24 2026 — restocks are now AUTOMATED** (drift guards:
+  `tests/test_queue_restock.py`): `.github/workflows/restock-topic-queues.yml`
+  (daily 13:37 UTC + dispatch, `force` input) runs
+  `scripts/restock_topic_queues.py` — trigger-gated (FPD <4wk, UC <5wk;
+  refills to ~8wk) Grok generation against per-show restock prompts
+  (`shows/prompts/*_restock.txt` — full queue history injected for dedupe,
+  category balance for FPD's alternation, an explicit never-invent honesty
+  rule since briefs become episodes). Validation rejects thin briefs, bad
+  categories, id dupes, and fuzzy near-duplicate titles vs the ENTIRE
+  history (produced included); existing entries are never modified; the
+  workflow re-runs `TestNarrativeQueueRunway` BEFORE committing, so the
+  runway floors (3.0/4.0wk) are now the alarm that the AUTOMATION broke,
+  not a manual chore. Age of AI's deliberately-empty queue is not
+  registered and must never be. Generated topics sit unproduced for weeks
+  — prune any weak ones directly in `shows/topic_queues/*.yaml`.
 - **Финансы Просто YouTube category** fixed 25 (News) → 27 (Education).
 - **Operator items (not code):** localize the Russian shows' spoken AI
   disclosure (still English on the Olya voice — A/B per #17); decide

--- a/scripts/restock_topic_queues.py
+++ b/scripts/restock_topic_queues.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Auto-restock narrative-show topic queues with Grok (July 24 2026).
+
+The narrative shows (First Principles Daily, Unintended Consequences) are
+topic-queue-driven — no news fetch. Their queues were restocked MANUALLY
+during quality passes, and twice now a show has drifted to within days of
+an empty queue (FPD was at ~1.3 weeks in June 2026 and back under 3 weeks
+in July). An empty queue means `narrative_queue_empty` skips: the show
+silently stops publishing.
+
+This script closes the loop: for each registered show it computes the
+runway (unproduced topics ÷ episodes per week) and, when it drops below
+the trigger, asks Grok for enough NEW topics to refill to the target
+runway. Generated topics are validated (schema, category, id/title dedupe
+against the ENTIRE queue history including produced entries, near-duplicate
+title similarity) and appended as ``produced: false`` entries — the same
+shape the manual restocks used. Existing entries are NEVER modified.
+
+Triggers sit comfortably ABOVE the drift-guard thresholds in
+tests/test_network_quality_pass.py::TestNarrativeQueueRunway (3.0 / 4.0
+weeks), so the alarm test only fires if this automation itself has been
+broken for a week+.
+
+Age of AI's queue is deliberately empty (its production runs through the
+Nerra Voices interview pipeline; the empty queue makes an accidental
+`run_show.py age_of_ai` a clean skip) — it is NOT registered here and must
+never be restocked.
+
+Usage::
+
+    python scripts/restock_topic_queues.py                 # all shows, trigger-gated
+    python scripts/restock_topic_queues.py --show first_principles
+    python scripts/restock_topic_queues.py --dry-run       # print, write nothing
+    python scripts/restock_topic_queues.py --force         # restock even above trigger
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import yaml
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-show restock configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RestockConfig:
+    slug: str
+    queue_file: str                  # relative to repo root
+    prompt_file: str                 # relative to repo root
+    episodes_per_week: float
+    trigger_weeks: float             # restock when runway < this
+    target_weeks: float              # refill queue up to this runway
+    allowed_categories: tuple
+    # Categories that must BOTH stay stocked (FPD's concrete/opportunity
+    # alternation). Empty = no balance requirement.
+    balanced_categories: tuple = field(default_factory=tuple)
+    max_new_per_run: int = 40        # runaway backstop
+
+
+RESTOCK_CONFIGS = {
+    "first_principles": RestockConfig(
+        slug="first_principles",
+        queue_file="shows/topic_queues/first_principles.yaml",
+        prompt_file="shows/prompts/first_principles_restock.txt",
+        episodes_per_week=7.0,
+        trigger_weeks=4.0,           # alarm test fires at 3.0
+        target_weeks=8.0,
+        allowed_categories=("concrete_example", "opportunity_area"),
+        balanced_categories=("concrete_example", "opportunity_area"),
+    ),
+    "unintended_consequences": RestockConfig(
+        slug="unintended_consequences",
+        queue_file="shows/topic_queues/unintended_consequences.yaml",
+        prompt_file="shows/prompts/unintended_consequences_restock.txt",
+        episodes_per_week=7.0,
+        trigger_weeks=5.0,           # alarm test fires at 4.0
+        target_weeks=8.0,
+        allowed_categories=("classic", "tech", "policy", "medicine",
+                            "infrastructure", "economics"),
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested)
+# ---------------------------------------------------------------------------
+
+def runway_weeks(unproduced_count: int, episodes_per_week: float) -> float:
+    if episodes_per_week <= 0:
+        return float("inf")
+    return unproduced_count / episodes_per_week
+
+
+def topics_needed(unproduced_count: int, cfg: RestockConfig) -> int:
+    """How many new topics to reach the target runway (0 when above trigger)."""
+    if runway_weeks(unproduced_count, cfg.episodes_per_week) >= cfg.trigger_weeks:
+        return 0
+    target = math.ceil(cfg.target_weeks * cfg.episodes_per_week)
+    return min(max(target - unproduced_count, 0), cfg.max_new_per_run)
+
+
+def slugify_id(title: str) -> str:
+    """Queue-id from a title: lowercase, hyphenated, trimmed to ~5 words."""
+    words = re.findall(r"[a-z0-9]+", title.lower())
+    return "-".join(words[:5]) or "topic"
+
+
+def _norm_title(title: str) -> str:
+    return " ".join(re.findall(r"[a-z0-9]+", (title or "").lower()))
+
+
+def title_too_similar(title: str, existing_norm_titles: list[str],
+                      threshold: float = 0.6) -> bool:
+    """Fuzzy near-duplicate check against every historical title."""
+    try:
+        from engine.utils import calculate_similarity
+    except Exception:  # noqa: BLE001 — degrade to exact-match only
+        calculate_similarity = None
+    norm = _norm_title(title)
+    if not norm:
+        return True
+    for other in existing_norm_titles:
+        if norm == other:
+            return True
+        if calculate_similarity is not None and \
+                calculate_similarity(norm, other) >= threshold:
+            return True
+    return False
+
+
+def parse_topics_json(text: str) -> list[dict]:
+    """Parse the model's JSON array, tolerating a fenced code block."""
+    text = (text or "").strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        if text.rstrip().endswith("```"):
+            text = text.rstrip()[:-3]
+    # Tolerate prose around the array: take the outermost [ ... ].
+    start, end = text.find("["), text.rfind("]")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON array found in model output")
+    parsed = json.loads(text[start:end + 1])
+    if not isinstance(parsed, list):
+        raise TypeError("model output is not a JSON array")
+    return [t for t in parsed if isinstance(t, dict)]
+
+
+def validate_and_dedupe(
+    candidates: list[dict],
+    queue: list[dict],
+    cfg: RestockConfig,
+    needed: int,
+) -> list[dict]:
+    """Filter candidates to valid, novel entries in queue-file shape.
+
+    Dedupe is against the ENTIRE queue (produced included — a show must
+    never re-cover a produced topic) and against earlier candidates in the
+    same batch. Never mutates ``queue``.
+    """
+    existing_ids = {e.get("id") for e in queue if isinstance(e, dict)}
+    existing_titles = [_norm_title(e.get("title", ""))
+                       for e in queue if isinstance(e, dict)]
+    accepted: list[dict] = []
+    for cand in candidates:
+        if len(accepted) >= needed:
+            break
+        title = str(cand.get("title") or "").strip()
+        brief = str(cand.get("brief") or "").strip()
+        category = str(cand.get("category") or "").strip()
+        if not title or len(brief) < 80:
+            logger.info("Rejecting candidate (missing title / thin brief): %r", title[:60])
+            continue
+        if category not in cfg.allowed_categories:
+            logger.info("Rejecting candidate (bad category %r): %r", category, title[:60])
+            continue
+        tid = slugify_id(title)
+        if tid in existing_ids:
+            logger.info("Rejecting candidate (duplicate id %s): %r", tid, title[:60])
+            continue
+        if title_too_similar(title, existing_titles):
+            logger.info("Rejecting candidate (near-duplicate title): %r", title[:60])
+            continue
+        accepted.append({
+            "id": tid,
+            "title": title,
+            "brief": brief,
+            "category": category,
+            "produced": False,
+            "episode_number": None,
+            "produced_date": None,
+        })
+        existing_ids.add(tid)
+        existing_titles.append(_norm_title(title))
+    return accepted
+
+
+def build_prompt(cfg: RestockConfig, queue: list[dict], needed: int) -> str:
+    """Render the show's restock prompt with queue history + counts."""
+    template = (ROOT / cfg.prompt_file).read_text(encoding="utf-8")
+    lines = []
+    for e in queue:
+        if isinstance(e, dict) and e.get("title"):
+            state = "produced" if e.get("produced") else "queued"
+            lines.append(f"- [{state}] ({e.get('category', '?')}) {e['title']}")
+    balance = ""
+    if cfg.balanced_categories:
+        per = math.ceil(needed / len(cfg.balanced_categories))
+        balance = (
+            f"Balance the categories: roughly {per} topics for each of "
+            f"{', '.join(cfg.balanced_categories)} (the show alternates "
+            f"between them episode by episode)."
+        )
+    return (template
+            .replace("{existing_topics}", "\n".join(lines))
+            .replace("{needed}", str(needed))
+            .replace("{category_guidance}", balance))
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+def restock_show(cfg: RestockConfig, *, dry_run: bool, force: bool) -> dict:
+    """Restock one show. Returns a result dict for the run summary."""
+    queue_path = ROOT / cfg.queue_file
+    data = yaml.safe_load(queue_path.read_text(encoding="utf-8")) or {}
+    queue = data.get("queue") or []
+    unproduced = sum(
+        1 for e in queue if isinstance(e, dict) and not e.get("produced"))
+    weeks = runway_weeks(unproduced, cfg.episodes_per_week)
+    needed = topics_needed(unproduced, cfg)
+    if force and needed == 0:
+        needed = min(
+            max(math.ceil(cfg.target_weeks * cfg.episodes_per_week) - unproduced, 0),
+            cfg.max_new_per_run,
+        )
+
+    result = {"slug": cfg.slug, "unproduced": unproduced,
+              "runway_weeks": round(weeks, 1), "needed": needed, "added": 0}
+    if needed == 0:
+        logger.info("%s: runway %.1f weeks (%d unproduced) — no restock needed",
+                    cfg.slug, weeks, unproduced)
+        return result
+
+    logger.info("%s: runway %.1f weeks (%d unproduced) — requesting %d new topics",
+                cfg.slug, weeks, unproduced, needed)
+
+    # Ask for extras so validation losses don't leave us short.
+    from engine.generator import _call_grok  # deferred: needs GROK_API_KEY
+    prompt = build_prompt(cfg, queue, needed + max(4, needed // 3))
+    text, _ = _call_grok(
+        prompt,
+        temperature=0.8,
+        max_tokens=8000,
+    )
+    candidates = parse_topics_json(text)
+    accepted = validate_and_dedupe(candidates, queue, cfg, needed)
+    result["added"] = len(accepted)
+
+    if not accepted:
+        print(f"::warning::{cfg.slug}: restock produced 0 valid topics "
+              f"(model returned {len(candidates)} candidates) — queue "
+              f"unchanged at {weeks:.1f} weeks runway.", flush=True)
+        return result
+
+    if len(accepted) < needed:
+        print(f"::warning::{cfg.slug}: restock added only {len(accepted)} of "
+              f"{needed} requested topics after validation.", flush=True)
+
+    for entry in accepted:
+        logger.info("  + (%s) %s", entry["category"], entry["title"])
+
+    if dry_run:
+        logger.info("%s: dry-run — not writing %d topics", cfg.slug, len(accepted))
+        return result
+
+    queue.extend(accepted)
+    data["queue"] = queue
+    # Same write convention as engine.topic_queue.mark_topic_produced.
+    with queue_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(data, fh, allow_unicode=True, sort_keys=False,
+                       default_flow_style=False, width=10000)
+    new_weeks = runway_weeks(unproduced + len(accepted), cfg.episodes_per_week)
+    logger.info("%s: queue restocked %d → %d unproduced (%.1f weeks runway)",
+                cfg.slug, unproduced, unproduced + len(accepted), new_weeks)
+    return result
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Auto-restock narrative topic queues via Grok")
+    parser.add_argument("--show", choices=sorted(RESTOCK_CONFIGS), help="Only this show")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true",
+                        help="Restock to target even when above the trigger")
+    args = parser.parse_args(argv)
+
+    slugs = [args.show] if args.show else sorted(RESTOCK_CONFIGS)
+    failures = 0
+    for slug in slugs:
+        cfg = RESTOCK_CONFIGS[slug]
+        try:
+            result = restock_show(cfg, dry_run=args.dry_run, force=args.force)
+        except Exception as exc:
+            failures += 1
+            logger.exception("%s restock failed", slug)
+            # Only escalate to ::error:: when the queue is ALREADY inside the
+            # drift-guard alarm zone and we failed to refill it.
+            print(f"::warning::{slug}: topic-queue restock failed: {exc}", flush=True)
+            continue
+        if result["needed"] and result["added"] == 0:
+            failures += 1
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shows/prompts/first_principles_restock.txt
+++ b/shows/prompts/first_principles_restock.txt
@@ -1,0 +1,25 @@
+You are the researcher for "First Principles Daily," a daily narrative podcast that applies first-principles cost analysis — the "magic wand number" (what would this cost if physics and materials were the only constraint?) and the "Idiot Index" (the ratio of a finished part's price to its raw-material cost) — to one topic per episode.
+
+The show alternates between two topic categories:
+- "concrete_example" — a REAL historical or modern case where first-principles thinking collapsed a cost or capability barrier (Ford's assembly line, Bessemer steel, containerization, solar, batteries, mRNA, barcodes…). Deliberately NOT Musk-only: draw from manufacturing, logistics, medicine, agriculture, computing, energy, materials, consumer goods, across eras and countries.
+- "opportunity_area" — an industry or product category whose Idiot Index is visibly high today: the material/physics floor is far below the prevailing price, and reasoning carefully about WHY (regulation, bundling, gatekeeping, incumbency, information asymmetry) is the episode.
+
+Your job: propose {needed} NEW topics for the production queue.
+
+{category_guidance}
+
+EVERY topic already used or queued by the show is listed below. Your topics must be genuinely NEW — never a repeat, a rephrase, or a near-neighbor of anything on this list (for example, if "textbooks" is listed, "college course materials" is a repeat):
+
+{existing_topics}
+
+QUALITY BAR (match the register of the show's existing briefs):
+- The brief is 3-5 sentences and must contain the analytical skeleton of the episode: what the artifact/service is, what its material or physics floor looks like, where the gap between floor and price comes from (or how it was collapsed, for historical cases), and one concrete number or ratio when honestly known. If you are not confident in a number, describe the magnitude qualitatively — never invent statistics.
+- Concrete examples must be REAL and verifiable — real people, real companies, real dates. No hypotheticals presented as history.
+- Opportunity areas must be everyday enough that a general listener has personally paid the markup (funerals, textbooks, eyeglasses…) or can immediately picture it.
+- Titles are evocative but plain-spoken — no clickbait, no colons chained twice.
+- Start each brief with "Concrete example." or "Opportunity area." followed by the analysis, matching the existing queue's style.
+
+OUTPUT — a JSON array and NOTHING else (no prose, no code fences):
+[
+  {"title": "...", "category": "concrete_example|opportunity_area", "brief": "..."}
+]

--- a/shows/prompts/unintended_consequences_restock.txt
+++ b/shows/prompts/unintended_consequences_restock.txt
@@ -1,0 +1,23 @@
+You are the researcher for "Unintended Consequences," a daily narrative podcast. Each episode tells one REAL, documented case where a well-intended intervention — a policy, technology, medicine, subsidy, or piece of infrastructure — produced a significant unintended consequence, and extracts the systems lesson (incentive design, feedback loops, Goodhart's law, risk compensation, second-order effects).
+
+Your job: propose {needed} NEW topics for the production queue.
+
+Categories (pick the best fit per topic): "classic" (the canonical historical cases), "tech", "policy", "medicine", "infrastructure", "economics".
+
+{category_guidance}
+
+EVERY topic already used or queued by the show is listed below. Your topics must be genuinely NEW — never a repeat, a rephrase, or a near-neighbor of anything on this list (if "cobra effect" is listed, any bounty-backfire story needs a materially different mechanism and setting to qualify):
+
+{existing_topics}
+
+QUALITY BAR (match the register of the show's existing briefs):
+- REAL and documented only — real interventions, real places, real dates, outcomes reported by credible sources. This show's credibility rests on the cases being true; never invent or embellish. If the strength of the evidence is contested, the brief must say so.
+- The brief is 3-5 sentences with the full causal skeleton: the intervention and its honest intent, the mechanism by which behavior or the system adapted, the unintended consequence with a concrete magnitude when honestly known, and the generalizable lesson. Qualitative magnitude beats an invented number.
+- Prefer cases with a genuine twist of mechanism over "regulation bad" or "technology bad" morality tales — the show's stance is that the interveners were usually smart and well-intentioned, which is what makes the lesson valuable.
+- Spread topics across eras, countries, and domains; avoid clustering on any single decade or country.
+- Titles are evocative but honest — the existing queue's style ("The Harvest That Drank the Wells"), never clickbait.
+
+OUTPUT — a JSON array and NOTHING else (no prose, no code fences):
+[
+  {"title": "...", "category": "classic|tech|policy|medicine|infrastructure|economics", "brief": "..."}
+]

--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -166,9 +166,13 @@ class TestPromptTicBans:
 
 
 class TestNarrativeQueueRunway:
-    # NOTE: topic-queue restocks are MANUAL (no auto-generation), and a breach
-    # here fails the full -x suite and thus blocks unrelated PRs — restock the
-    # shows/topic_queues/ YAML before the runway runs out.
+    # NOTE (July 24 2026): restocks are now AUTOMATED — the daily
+    # restock-topic-queues.yml workflow runs scripts/restock_topic_queues.py,
+    # which refills any registered queue whose runway drops below its
+    # trigger (4-5 weeks) back up to ~8 weeks via Grok. These floors are
+    # the alarm of LAST RESORT: a breach here means the automation itself
+    # has been broken for a week+ (check the workflow's recent runs), and
+    # it fails the full -x suite until fixed.
     # unintended_consequences runs 7 days/week (cron "1 9 * * *", a daily
     # narrative show per DAILY_NARRATIVE_SHOWS in test_schedule.py); per_week
     # was corrected 5→7 July 2026 to match the real cadence.

--- a/tests/test_queue_restock.py
+++ b/tests/test_queue_restock.py
@@ -1,0 +1,150 @@
+"""Drift guards for the automated topic-queue restock (July 24 2026).
+
+scripts/restock_topic_queues.py + restock-topic-queues.yml keep the
+narrative shows' queues filled via trigger-gated Grok generation, so the
+runway floors in test_network_quality_pass.py::TestNarrativeQueueRunway
+become the alarm of last resort instead of a recurring manual chore.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if str(ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(ROOT / "scripts"))
+
+import restock_topic_queues as rq  # noqa: E402
+
+
+class TestConfigRegistry:
+    def test_both_narrative_shows_registered(self):
+        assert set(rq.RESTOCK_CONFIGS) == {
+            "first_principles", "unintended_consequences"}
+
+    def test_age_of_ai_never_registered(self):
+        # Its queue is DELIBERATELY empty (Nerra Voices pipeline; the empty
+        # queue makes an accidental run_show invocation a clean skip).
+        assert "age_of_ai" not in rq.RESTOCK_CONFIGS
+
+    @pytest.mark.parametrize("slug", sorted(rq.RESTOCK_CONFIGS))
+    def test_files_exist(self, slug):
+        cfg = rq.RESTOCK_CONFIGS[slug]
+        assert (ROOT / cfg.queue_file).exists()
+        assert (ROOT / cfg.prompt_file).exists()
+
+    @pytest.mark.parametrize("slug", sorted(rq.RESTOCK_CONFIGS))
+    def test_trigger_sits_above_alarm_floor(self, slug):
+        # The alarm floors in TestNarrativeQueueRunway are 3.0 (FPD) and
+        # 4.0 (UC) weeks — the restock trigger must fire comfortably
+        # earlier so the alarm only means "automation broken".
+        floors = {"first_principles": 3.0, "unintended_consequences": 4.0}
+        cfg = rq.RESTOCK_CONFIGS[slug]
+        assert cfg.trigger_weeks >= floors[slug] + 1.0
+        assert cfg.target_weeks > cfg.trigger_weeks
+
+    @pytest.mark.parametrize("slug", sorted(rq.RESTOCK_CONFIGS))
+    def test_categories_match_live_queue(self, slug):
+        cfg = rq.RESTOCK_CONFIGS[slug]
+        q = yaml.safe_load((ROOT / cfg.queue_file).read_text())["queue"]
+        live_cats = {e.get("category") for e in q if not e.get("produced")}
+        assert live_cats <= set(cfg.allowed_categories) | {"debut"}
+
+    @pytest.mark.parametrize("slug", sorted(rq.RESTOCK_CONFIGS))
+    def test_prompt_placeholders(self, slug):
+        text = (ROOT / rq.RESTOCK_CONFIGS[slug].prompt_file).read_text()
+        for token in ("{existing_topics}", "{needed}", "{category_guidance}"):
+            assert token in text, f"{slug} restock prompt missing {token}"
+        # The honesty rule is load-bearing — generated briefs feed episodes.
+        assert "never invent" in text.lower() or "never invent or embellish" in text.lower()
+
+
+class TestRunwayMath:
+    def test_no_restock_above_trigger(self):
+        cfg = rq.RESTOCK_CONFIGS["first_principles"]
+        assert rq.topics_needed(int(cfg.trigger_weeks * 7) + 1, cfg) == 0
+
+    def test_restock_fills_to_target(self):
+        cfg = rq.RESTOCK_CONFIGS["first_principles"]
+        needed = rq.topics_needed(10, cfg)  # 10/7 ≈ 1.4 weeks — well below
+        assert needed == min(int(cfg.target_weeks * 7) - 10, cfg.max_new_per_run)
+
+    def test_backstop_cap(self):
+        cfg = rq.RESTOCK_CONFIGS["first_principles"]
+        assert rq.topics_needed(0, cfg) <= cfg.max_new_per_run
+
+
+class TestValidation:
+    def _cfg(self):
+        return rq.RESTOCK_CONFIGS["unintended_consequences"]
+
+    def _queue(self):
+        return [{"id": "cobra-effect", "title": "The Cobra Effect",
+                 "brief": "x" * 100, "category": "classic", "produced": True}]
+
+    def _cand(self, **over):
+        c = {"title": "The Bridge That Moved the Traffic",
+             "brief": "b" * 120, "category": "infrastructure"}
+        c.update(over)
+        return c
+
+    def test_accepts_valid_novel_topic(self):
+        out = rq.validate_and_dedupe([self._cand()], self._queue(), self._cfg(), 5)
+        assert len(out) == 1
+        assert out[0]["produced"] is False
+        assert out[0]["id"] == "the-bridge-that-moved-the"
+
+    def test_rejects_duplicate_and_near_duplicate(self):
+        dup = self._cand(title="The Cobra Effect")
+        near = self._cand(title="The Cobra Effect Bounty Story")
+        out = rq.validate_and_dedupe([dup, near], self._queue(), self._cfg(), 5)
+        assert out == []
+
+    def test_rejects_bad_category_and_thin_brief(self):
+        bad_cat = self._cand(category="gossip")
+        thin = self._cand(title="Another Real Case", brief="too short")
+        out = rq.validate_and_dedupe([bad_cat, thin], self._queue(), self._cfg(), 5)
+        assert out == []
+
+    def test_caps_at_needed(self):
+        titles = ["The Dam That Salted the Delta",
+                  "Antibiotics on the Feedlot Floor",
+                  "The Scrappage Scheme Price Spiral",
+                  "Helmets and the Risk Thermostat",
+                  "The Quota That Emptied the Nets"]
+        cands = [self._cand(title=t) for t in titles]
+        out = rq.validate_and_dedupe(cands, self._queue(), self._cfg(), 3)
+        assert len(out) == 3
+
+    def test_never_mutates_existing_queue(self):
+        q = self._queue()
+        before = [dict(e) for e in q]
+        rq.validate_and_dedupe([self._cand()], q, self._cfg(), 5)
+        assert q == before
+
+    def test_parse_tolerates_fences_and_prose(self):
+        text = 'Here you go:\n```json\n[{"title": "T", "brief": "b", "category": "tech"}]\n```'
+        assert rq.parse_topics_json(text) == [
+            {"title": "T", "brief": "b", "category": "tech"}]
+
+
+class TestWorkflowWiring:
+    def test_workflow_exists_and_gated(self):
+        wf = (ROOT / ".github/workflows/restock-topic-queues.yml").read_text()
+        assert "restock_topic_queues.py" in wf
+        assert "GROK_API_KEY" in wf
+        # Post-restock validation must run BEFORE the commit step.
+        assert wf.find("TestNarrativeQueueRunway") < wf.find("safe-commit-push")
+        # Both queue files whitelisted for commit (the history-file landmine).
+        assert "shows/topic_queues/first_principles.yaml" in wf
+        assert "shows/topic_queues/unintended_consequences.yaml" in wf
+
+    def test_runway_alarm_comment_updated(self):
+        src = (ROOT / "tests/test_network_quality_pass.py").read_text()
+        assert "restock-topic-queues.yml" in src


### PR DESCRIPTION
## What

Closes the recurring "narrative queue about to run dry" problem for good. First Principles is at **2.7 weeks of runway right now** (below the 3.0-week alarm floor — the failing drift guard), Unintended Consequences at 4.6 (close to its 5-week trigger). Both were restocked manually in past quality passes; twice a show drifted to within days of an empty queue, which means `narrative_queue_empty` skips — the show silently stops publishing.

## How it works

- **`scripts/restock_topic_queues.py`** — trigger-gated: computes each registered show's runway (unproduced ÷ episodes-per-week) and only acts when it drops below the trigger (**FPD &lt;4 weeks, UC &lt;5 weeks**), refilling to **~8 weeks** (40-topic backstop). Grok generates candidates against a per-show restock prompt with the **full queue history injected** (produced + queued) for dedupe context.
- **Validation before anything lands**: thin briefs (&lt;80 chars), invalid categories, duplicate ids, and *fuzzy near-duplicate titles vs the entire history* are all rejected; accepted topics append as `produced: false` in the exact shape the manual restocks used; **existing entries are never modified**.
- **`shows/prompts/*_restock.txt`** — show-calibrated: FPD keeps the concrete-example / opportunity-area alternation balanced and its "magic wand number / Idiot Index" register; UC requires real, documented cases with the full causal skeleton. Both carry an explicit **never-invent** honesty rule, since these briefs become episode substrate.
- **`.github/workflows/restock-topic-queues.yml`** — daily 13:37 UTC (off-peak per landmine #24) + `workflow_dispatch` with a `force` input. It **re-runs `TestNarrativeQueueRunway` before the commit step**, so a malformed or under-filled restock can never land; queue files are explicitly whitelisted (the history-file landmine class); webhook ping only when something was actually committed.
- **Age of AI is deliberately excluded** — its empty queue is load-bearing (makes an accidental `run_show.py age_of_ai` a clean skip; production is the Nerra Voices pipeline). A drift guard pins that it's never registered.
- The runway floors (3.0/4.0 weeks) in `test_network_quality_pass.py` stay as the **alarm of last resort** — with triggers at 4/5 weeks and a daily cron, that alarm now only fires if the automation itself has been broken for a week-plus. Comment updated accordingly.

Other queue-like surfaces reviewed and deliberately left manual: MIT's deep-dive queue (operator-scheduled `when: next` — curation is the point) and PR's vocabulary system (self-managing rotation memory, not a depleting queue).

## Operator control

Generated topics sit unproduced for weeks before airing — prune any weak ones directly in `shows/topic_queues/*.yaml` at any time. Every restock is its own commit ("Auto-restock: narrative topic queues") with a webhook ping, so you'll see exactly what was added.

## After merge

The first restock needs a run with `GROK_API_KEY` (unavailable in my environment — the generation path is untested live, though the parse/validate/write layers are unit-tested and a `--dry-run` correctly triggered on both shows). Either wait for today's 13:37 UTC cron (already passed today — tomorrow's), or **dispatch the "Restock Topic Queues" workflow manually now** to clear FPD's red runway alarm immediately. I'll dispatch it myself once this merges.

## Tests

- New `tests/test_queue_restock.py`: **21 drift guards** (registry incl. the age-of-ai exclusion, trigger-above-alarm-floor invariant, runway math, validation/dedupe/no-mutation, JSON-parse tolerance, workflow wiring incl. verify-before-commit ordering).
- 75 passed across restock + network-quality + scheduling + pipeline-safety suites. The **one failure is the FPD runway alarm itself** — the exact pre-existing condition this PR automates away; it clears on the first restock run (and the repo's `test` check is separately red on main at the lint gate, as documented on #867).
- The new script is ruff-clean (0 findings); workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X

---
_Generated by [Claude Code](https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operational publishing substrate (committed queue YAML via automation) and depends on Grok output quality; mitigated by pre-commit runway tests, strict validation, and explicit exclusion of Age of AI.
> 
> **Overview**
> **Automates** refills for First Principles Daily and Unintended Consequences topic queues so empty queues no longer silently stop daily publishing.
> 
> Adds `scripts/restock_topic_queues.py`, which computes runway from unproduced topics, restocks only when below per-show triggers (FPD &lt;4 weeks, UC &lt;5 weeks) toward ~8 weeks of runway, calls Grok with show-specific `*_restock.txt` prompts (full queue history for dedupe, category balance for FPD), validates and appends new `produced: false` rows without touching existing entries, and excludes Age of AI by design. **`.github/workflows/restock-topic-queues.yml`** runs it daily (13:37 UTC) with optional `force` dispatch, runs `TestNarrativeQueueRunway` before commit, whitelists the two queue YAML paths, and notifies on commit.
> 
> **`tests/test_queue_restock.py`** adds drift guards (registry, trigger vs alarm floors, validation, workflow wiring). **`TestNarrativeQueueRunway`** comments and **`CLAUDE.md`** now describe automation as the primary path and CI runway floors as the alarm if automation breaks for a week+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35884466227588c2aa5afdef5bfd1ab12c718905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->