### PR TITLE
Queue restock: interleave the unproduced tail (first live run was correctly blocked by the verify gate)

### DIFF
--- a/scripts/restock_topic_queues.py
+++ b/scripts/restock_topic_queues.py
@@ -211,6 +211,56 @@ def validate_and_dedupe(
     return accepted
 
 
+def interleave_by_category(entries: list[dict], seed_prev: str | None = None) -> list[dict]:
+    """Order *entries* so no two adjacent share a category (greedy).
+
+    Repeatedly picks from the category with the most remaining entries,
+    excluding the previous pick's category; when only the previous
+    category remains, its overflow trails at the end (the unavoidable
+    tail the drift guards allow). ``seed_prev`` — the category of the
+    most recently produced episode — prevents a same-category seam at
+    the produced/unproduced boundary. Stable within each category.
+    """
+    from collections import OrderedDict
+    buckets: OrderedDict[str, list[dict]] = OrderedDict()
+    for e in entries:
+        buckets.setdefault(e.get("category") or "?", []).append(e)
+    out: list[dict] = []
+    prev = seed_prev
+    while any(buckets.values()):
+        candidates = sorted(
+            (cat for cat, items in buckets.items() if items and cat != prev),
+            key=lambda cat: (-len(buckets[cat]), cat),
+        )
+        cat = candidates[0] if candidates else prev  # only prev left: overflow tail
+        out.append(buckets[cat].pop(0))
+        prev = cat
+    return out
+
+
+def resequence_unproduced(queue: list[dict]) -> None:
+    """Re-interleave the unproduced tail IN PLACE (produced entries fixed).
+
+    The queue drift guards (July 2 2026 hygiene pass) require the
+    unproduced sequence to be category-interleaved — FPD's alternation
+    continues from the produced tail, UC has no adjacent same-category
+    pair before the dominant category's unavoidable overflow. A restock
+    appends in model order, so the whole unproduced set is re-sequenced
+    afterward: unproduced entries are re-placed into the SAME list
+    positions in interleaved order, leaving produced entries (and the
+    file layout) untouched. Reordering unproduced entries is safe — only
+    their relative consumption order changes, which is the point.
+    """
+    idxs = [i for i, e in enumerate(queue)
+            if isinstance(e, dict) and not e.get("produced")]
+    produced_cats = [e.get("category") for e in queue
+                     if isinstance(e, dict) and e.get("produced")]
+    seed = produced_cats[-1] if produced_cats else None
+    ordered = interleave_by_category([queue[i] for i in idxs], seed_prev=seed)
+    for i, entry in zip(idxs, ordered):
+        queue[i] = entry
+
+
 def build_prompt(cfg: RestockConfig, queue: list[dict], needed: int) -> str:
     """Render the show's restock prompt with queue history + counts."""
     template = (ROOT / cfg.prompt_file).read_text(encoding="utf-8")
@@ -292,6 +342,9 @@ def restock_show(cfg: RestockConfig, *, dry_run: bool, force: bool) -> dict:
         return result
 
     queue.extend(accepted)
+    # Keep the unproduced tail category-interleaved (drift-guard contract;
+    # first live run failed the verify step without this — the guard held).
+    resequence_unproduced(queue)
     data["queue"] = queue
     # Same write convention as engine.topic_queue.mark_topic_produced.
     with queue_path.open("w", encoding="utf-8") as fh:

--- a/tests/test_queue_restock.py
+++ b/tests/test_queue_restock.py
@@ -148,3 +148,61 @@ class TestWorkflowWiring:
     def test_runway_alarm_comment_updated(self):
         src = (ROOT / "tests/test_network_quality_pass.py").read_text()
         assert "restock-topic-queues.yml" in src
+
+
+class TestResequenceUnproduced:
+    """The first live restock run (2026-07-24) generated valid topics but
+    appended them in model order — long same-category runs that failed the
+    queue-interleave drift guards, and the workflow's verify-before-commit
+    step correctly blocked the commit. The script now re-interleaves the
+    whole unproduced tail in place after appending."""
+
+    def _entry(self, i, cat, produced=False):
+        return {"id": f"t{i}", "title": f"T{i}", "brief": "b" * 90,
+                "category": cat, "produced": produced}
+
+    def test_fpd_shape_alternates_within_imbalance_bound(self):
+        # Replicates the failed run: 2 categories, imbalanced (33 C / 23 O
+        # style), appended as one big C-block then an O-block.
+        queue = [self._entry(0, "concrete_example", produced=True)]
+        queue += [self._entry(i + 1, "concrete_example") for i in range(12)]
+        queue += [self._entry(i + 20, "opportunity_area") for i in range(8)]
+        rq.resequence_unproduced(queue)
+        seq = [e["category"] for e in queue if not e["produced"]]
+        pairs = sum(1 for a, b in zip(seq, seq[1:]) if a == b)
+        imbalance = abs(seq.count("concrete_example") - seq.count("opportunity_area"))
+        assert pairs <= imbalance
+        # Seam: first unproduced differs from the last produced category.
+        assert seq[0] != "concrete_example"
+
+    def test_uc_shape_no_adjacent_repeat_before_overflow(self):
+        import itertools
+        from collections import Counter
+        queue = [self._entry(0, "classic", produced=True)]
+        cats = ["economics"] * 10 + ["policy"] * 5 + ["classic"] * 4 + \
+               ["medicine"] * 3 + ["infrastructure"] * 2 + ["tech"] * 1
+        queue += [self._entry(i + 1, c) for i, c in enumerate(cats)]
+        rq.resequence_unproduced(queue)
+        seq = [e["category"] for e in queue if not e["produced"]]
+        counts = Counter(seq)
+        dominant = counts.most_common(1)[0][0]
+        head = seq[: len(seq) - counts[dominant]]
+        runs = [sum(1 for _ in g) for _, g in itertools.groupby(head)]
+        assert max(runs, default=0) <= 1, f"clustered head: {seq}"
+
+    def test_produced_entries_and_positions_untouched(self):
+        queue = [self._entry(0, "classic", produced=True),
+                 self._entry(1, "policy"),
+                 self._entry(2, "classic", produced=True),
+                 self._entry(3, "policy"),
+                 self._entry(4, "tech")]
+        before_produced = [(i, e["id"]) for i, e in enumerate(queue) if e["produced"]]
+        before_ids = sorted(e["id"] for e in queue)
+        rq.resequence_unproduced(queue)
+        after_produced = [(i, e["id"]) for i, e in enumerate(queue) if e["produced"]]
+        assert after_produced == before_produced
+        assert sorted(e["id"] for e in queue) == before_ids  # nothing lost/duped
+
+    def test_restock_flow_calls_resequence(self):
+        src = (ROOT / "scripts/restock_topic_queues.py").read_text()
+        assert "resequence_unproduced(queue)" in src


### PR DESCRIPTION
## What happened

I dispatched the first live restock after #869 merged. **The safety gate worked exactly as designed**: Grok generated and validation accepted a full refill for both shows, but the script appended them in model order — long same-category blocks — which violated the queue-interleave drift guards from the July 2 hygiene pass (FPD's alternation must continue from the produced tail; UC must have no adjacent same-category topics before the dominant category's unavoidable overflow). The workflow's **verify-before-commit step blocked the commit** — nothing landed, the queues on main are untouched, run [30098703592](https://github.com/Planetterrian/nerranetwork/actions/runs/30098703592) shows the exact failure.

## Fix

`resequence_unproduced()` re-interleaves the **whole unproduced tail in place** after appending: greedy most-remaining-category-first, seeded with the last *produced* episode's category so the produced/unproduced seam never repeats; the dominant category's overflow trails at the end (the shape the guards explicitly allow). Unproduced entries are re-placed into the same list positions, so produced entries and the file layout are untouched — this is the same re-sequencing the July 2 pass performed manually, now automatic on every restock.

## Verification

- 4 new drift guards replicate **both live failure shapes** (FPD's 2-category imbalanced block-append, UC's 6-category dominant-cluster) and assert the exact predicates from `TestNarrativeQueueRunway` on the resequenced output, plus produced-positions-untouched and nothing-lost invariants. **25/25 restock tests pass**; script stays ruff-clean.
- End-to-end simulation (mocked Grok, worst-case single-category blocks, against a copy of the real FPD queue): restock → resequence → both live guard predicates pass, seam correct, ids unique. The simulation also confirmed the fuzzy near-duplicate title rejection is working aggressively.

## After merge

I'll re-dispatch the **Restock Topic Queues** workflow — this time the verify step should pass and the first real refill (FPD 2.7 → ~8 weeks, UC 4.6 → ~8 weeks) commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X

---
_Generated by [Claude Code](https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only how unproduced topic order is written after restock; wrong interleaving could still fail verify or skew episode category cadence until caught by existing guards.
> 
> **Overview**
> After a live restock appended new topics in **model order**, the workflow’s **verify-before-commit** step correctly blocked the commit because the unproduced tail violated **category-interleave drift guards** (same issue the July hygiene pass fixed manually).
> 
> **`resequence_unproduced()`** runs immediately after `queue.extend(accepted)`: it greedily reorders only unproduced entries **in place** via **`interleave_by_category()`** (most-remaining category first, skip repeating the previous pick, **`seed_prev`** from the last produced category so the seam doesn’t repeat). Produced rows and list positions for produced slots stay fixed; dominant-category overflow still trails at the end as the guards allow.
> 
> **`tests/test_queue_restock.py`** adds **`TestResequenceUnproduced`** with FPD/UC-shaped cases matching **`TestNarrativeQueueRunway`** predicates, plus invariants that produced indices/ids are unchanged and that the restock write path calls **`resequence_unproduced(queue)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6eba81262913113cacd2fc797afa40c30213e6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->