### PR TITLE
Bound the analytics-connector fetches; count Age of AI in OP3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1922,6 +1922,33 @@ operator checklist). Shipped, all no-ops when secrets unset:
   OP3 response shapes are pinned in `tests/test_op3_stats.py` — verified
   live June 2026 (`monthlyDownloads`/`weeklyDownloads`; episode
   `downloads1/3/7/30/All` keys are OMITTED when the data span is young).
+  **July 25 2026 nightly-fetch hardening** (drift guards:
+  `tests/test_connector_budget.py`; contract:
+  [`docs/analytics.md`](docs/analytics.md)): a live run surfaced two
+  issues the JSON outputs had been hiding. (1) The Spotify step ran for
+  **over an hour** — `spotifyconnector` retries a failing endpoint 6×
+  with unbounded exponential backoff (~124 s each), and a registered
+  feed with no plays yet answers `500` on `/metadata` + `/aggregate`
+  *every* night (18 of 24 feeds were in that state, ~32 dead endpoints).
+  New `engine/connector_budget.py` clamps the connectors' retry
+  constants (3 attempts / 1 s base ≈ 6 s per dead endpoint, measured)
+  and adds a wall-clock budget (`SPOTIFY_/APPLE_FETCH_BUDGET_SECONDS`,
+  default 900 s) as the backstop; unreached shows keep their previous
+  entry tagged `not_refreshed_this_run`, so a budget stop never shrinks
+  the file. Applied to the Apple fetcher too (its constant is
+  `MAX_RETRY_ATTEMPTS`, not `MAX_REQUEST_ATTEMPTS` — a copy-paste would
+  clamp nothing). (2) **Age of AI's enclosures carried no OP3 prefix**:
+  the prefix is applied by each publish path, never by
+  `update_rss_feed`, and the Nerra Voices publisher
+  (`pipelines/voices/publish_episode.py`) bypasses run_show — so its
+  downloads were invisible. Fixed for new episodes; the published Ep001
+  URL is deliberately left unprefixed (rewriting a live enclosure
+  re-downloads it for every subscriber). Any future show that bypasses
+  run_show must apply the prefix in its own publish step. The `dp_pod` /
+  `age_of_ai` OP3 **404s are an indexing lag**, not a bug — OP3's docs
+  define 404 as "OP3 doesn't know about the show"; downloads attach
+  retroactively once it indexes the feed. A 404 persisting for weeks
+  means check the prefix first.
 - **Adjacency-map bug fixed.** `newsletter.network_adjacencies` (and the
   other newsletter composition keys) had been mis-indented under
   `cost_circuit_breakers:` in `shows/_defaults.yaml` — newsletter +

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -69,6 +69,40 @@ Public, display-safe extracts live in `site/data/` (e.g.
   show YAML.
 * **OP3 history** starts the day the prefix went live — no backfill of
   earlier listens.
+* **A show only appears in OP3 once OP3 knows the feed.** The lookup is
+  `GET /shows/<base64 feed URL>`, and per OP3's docs a 404 means "OP3
+  doesn't know about the show" — not that there were no downloads. New
+  feeds therefore 404 for a while after launch (`op3: <slug> fetch
+  failed: 404` in the nightly log) while their prefixed downloads are
+  still being recorded; they attach retroactively once OP3 indexes the
+  feed. Observed 2026-07-25 for `dp_pod` and `age_of_ai`, both of which
+  had only gone LIVE on Apple two days earlier. **A 404 that persists
+  for weeks is different** — check the feed's enclosures actually carry
+  the `https://op3.dev/e/` prefix before assuming it's an indexing lag.
+* **The prefix is applied by each publish path, not by
+  `update_rss_feed`.** `run_show.py`, `engine/pipeline.py`,
+  `engine/language_feeds.py` and `pipelines/voices/publish_episode.py`
+  each call `apply_op3_prefix` themselves. Age of AI publishes outside
+  run_show and was missing that call, so its Ep001 enclosure is
+  unprefixed and its downloads were never counted (fixed 2026-07-25 for
+  new episodes; the published Ep001 URL is deliberately left alone —
+  rewriting a live enclosure re-downloads the episode for every
+  subscriber). Any future show that bypasses `run_show` must apply the
+  prefix in its own publish step.
+* **Both cookie connectors are runtime-bounded.** `spotifyconnector`
+  and `appleconnector` retry a failing endpoint 6 times with unbounded
+  exponential backoff (~124s per endpoint). A registered feed with no
+  plays yet returns `500` on `/metadata` and `/aggregate` *every* night,
+  so this is a stable cost, not a transient one: with 18 of 24 Spotify
+  feeds in that state the nightly fetch step ran for over an hour
+  (measured 2026-07-25) before the rest of maintenance could start.
+  `engine/connector_budget.py` clamps the retry constants (3 attempts,
+  1s base ≈ 6s per dead endpoint) and enforces a wall-clock budget
+  (`SPOTIFY_FETCH_BUDGET_SECONDS` / `APPLE_FETCH_BUDGET_SECONDS`,
+  default 900s); shows not reached before the budget expires keep their
+  previous entry, tagged `not_refreshed_this_run`, so the file never
+  silently shrinks. Watch for the `::warning::…budget…expired`
+  annotation — it means the platform got slower, not that a feed died.
 * **YouTube quota** is shared between publishing and analytics;
   `scripts/backfill_dub_playlists.py` (manual workflow) also spends it —
   50 units per playlist insert.

--- a/engine/connector_budget.py
+++ b/engine/connector_budget.py
@@ -1,0 +1,120 @@
+"""Runtime guards for the unofficial cookie-auth analytics connectors.
+
+The Spotify and Apple creator dashboards ship no official API, so the
+network reads them through the community ``spotifyconnector`` /
+``appleconnector`` packages (see ``docs/analytics.md``). Both embed a
+fixed retry loop with *unbounded* exponential backoff: on a failing
+endpoint they sleep 4s, 8s, 16s, 32s, 64s before giving up.
+
+That is fine when a failure is transient. It is pathological when the
+failure is **stable** — and for these platforms it usually is. A show
+whose feed is registered but has no plays yet answers ``500`` on
+``/metadata`` and ``/aggregate`` every single night. Measured
+2026-07-25: 18 of 24 registered Spotify feeds were in that state,
+~32 failing endpoints × ~124s of backoff each, so the nightly fetch
+step ran for well over an hour before the rest of maintenance could
+start. Nothing surfaced it, because the output JSON only records the
+final error — never the wall-clock cost of getting there.
+
+Two guards, both used by the fetchers:
+
+``clamp_connector_retries``
+    Rewrites the connector module's retry constants in place so a dead
+    endpoint costs seconds, not minutes. Defensive by contract: a
+    package upgrade that renames or drops the constants is a silent
+    no-op, never a crash.
+
+``FetchBudget``
+    A wall-clock backstop. Whatever the retry constants end up being,
+    the fetch stops and reports partial results once the budget is
+    spent — so a future upstream behaviour change can never again turn
+    one nightly step into an hours-long stall.
+"""
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def clamp_connector_retries(
+    module: Any,
+    *,
+    attempts_attr: str,
+    delay_attr: str,
+    attempts: int,
+    delay_base: float,
+) -> dict[str, Any]:
+    """Bound a connector module's retry budget, in place.
+
+    ``spotifyconnector`` and ``appleconnector`` both read module-level
+    constants inside their request loop, so assigning to them is enough
+    — there is no per-instance knob to pass.
+
+    Returns a dict describing what was applied (empty values when an
+    attribute is absent), so callers can log the effective settings
+    rather than assume them.
+    """
+    applied: dict[str, Any] = {}
+    for attr, value in ((attempts_attr, attempts), (delay_attr, delay_base)):
+        if hasattr(module, attr):
+            setattr(module, attr, value)
+            applied[attr] = value
+    return applied
+
+
+@dataclass
+class FetchBudget:
+    """Wall-clock budget for a multi-show fetch loop.
+
+    ``seconds <= 0`` disables the budget entirely (never exhausted),
+    which is what a caller passes when it wants the legacy
+    run-until-done behaviour.
+    """
+
+    seconds: float
+    _started: float = field(default_factory=time.monotonic)
+
+    @classmethod
+    def from_env(cls, name: str, default: float) -> "FetchBudget":
+        return cls(seconds=_env_float(name, default))
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self._started
+
+    def remaining(self) -> float:
+        if self.seconds <= 0:
+            return float("inf")
+        return self.seconds - self.elapsed()
+
+    def exhausted(self) -> bool:
+        return self.remaining() <= 0
+
+
+__all__ = [
+    "FetchBudget",
+    "clamp_connector_retries",
+    "_env_float",
+    "_env_int",
+]

--- a/pipelines/voices/publish_episode.py
+++ b/pipelines/voices/publish_episode.py
@@ -81,12 +81,24 @@ def main() -> int:
         )
         duration = float(probe.stdout.strip() or 0.0)
 
-        from engine.publisher import update_rss_feed
+        # OP3 analytics prefix. Every other show gets this from its
+        # run_show/pipeline publish path; Age of AI bypasses run_show, so
+        # without it the feed's enclosures are unprefixed and its
+        # downloads never reach api/op3_stats.json (Ep001 shipped that
+        # way — its URL is deliberately left alone, since rewriting a
+        # published enclosure re-downloads the episode for every
+        # subscriber). New episodes are counted from here on.
+        # (Uses apply_op3_prefix's default, which a drift guard pins to
+        # shows/_defaults.yaml's analytics.prefix_url — this pipeline
+        # deliberately doesn't load the show-config stack.)
+        from engine.publisher import apply_op3_prefix, update_rss_feed
+        feed_audio_url = apply_op3_prefix(audio_url)
+
         update_rss_feed(
             ROOT / "age_of_ai_podcast.rss",
             episode_num, title, description, today,
             local_mp3.name, duration, local_mp3,
-            audio_url=audio_url,
+            audio_url=feed_audio_url,
             audio_subdir="digests/age_of_ai",
             channel_title=SHOW_NAME,
             channel_link="https://nerranetwork.com/age-of-ai.html",

--- a/scripts/fetch_apple_stats.py
+++ b/scripts/fetch_apple_stats.py
@@ -40,17 +40,35 @@ import datetime as dt
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from engine.connector_budget import (  # noqa: E402  (after sys.path fix)
+    FetchBudget,
+    _env_float,
+    _env_int,
+    clamp_connector_retries,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger("fetch_apple_stats")
 
 WINDOW_DAYS = 30
+
+# Same bounded-retry contract as the Spotify fetcher — six endpoints per
+# show here, so an unbounded backoff loop would be even more expensive.
+# (appleconnector spells its constant MAX_RETRY_ATTEMPTS, not
+# MAX_REQUEST_ATTEMPTS; the clamp helper only writes what it finds.)
+MAX_RETRY_ATTEMPTS = _env_int("APPLE_MAX_RETRY_ATTEMPTS", 3)
+RETRY_DELAY_BASE = _env_float("APPLE_RETRY_DELAY_BASE", 1.0)
+BUDGET_SECONDS = _env_float("APPLE_FETCH_BUDGET_SECONDS", 900.0)
 
 
 def discover_show_ids() -> dict[str, str]:
@@ -169,14 +187,47 @@ def main(argv=None) -> int:
 
     try:
         import appleconnector  # noqa: F401
+        from appleconnector import connector as _connector_mod
     except ImportError:
         logger.error("appleconnector not installed — add it to "
                      "requirements.txt / pip install appleconnector")
         return 0
 
+    applied = clamp_connector_retries(
+        _connector_mod,
+        attempts_attr="MAX_RETRY_ATTEMPTS",
+        delay_attr="DELAY_BASE",
+        attempts=MAX_RETRY_ATTEMPTS,
+        delay_base=RETRY_DELAY_BASE,
+    )
+    if applied:
+        logger.info("connector retry budget: %s", applied)
+    else:
+        logger.warning(
+            "appleconnector no longer exposes MAX_RETRY_ATTEMPTS / "
+            "DELAY_BASE — retries are UNBOUNDED this run; the wall-clock "
+            "budget is the only guard left")
+
+    out = Path(args.out)
+    previous_shows: dict[str, Any] = {}
+    if out.exists():
+        try:
+            previous_shows = (json.loads(
+                out.read_text(encoding="utf-8")) or {}).get("shows") or {}
+        except Exception:  # noqa: BLE001
+            previous_shows = {}
+
+    budget = FetchBudget(seconds=BUDGET_SECONDS)
     shows: dict[str, Any] = {}
     failures = 0
+    skipped: list[str] = []
     for slug, sid in show_ids.items():
+        if budget.exhausted():
+            skipped.append(slug)
+            prior = previous_shows.get(slug)
+            if isinstance(prior, dict):
+                shows[slug] = {**prior, "not_refreshed_this_run": True}
+            continue
         try:
             shows[slug] = fetch_show(myacinfo, itctx, sid)
             if len(shows[slug].get("errors") or {}) >= 4:
@@ -186,7 +237,15 @@ def main(argv=None) -> int:
             failures += 1
         logger.info("fetched %s (%s)", slug, sid)
 
-    if failures == len(show_ids):
+    if skipped:
+        logger.warning(
+            "::warning::apple fetch budget of %.0fs expired after %d of %d "
+            "shows — %s kept their previous entry.", BUDGET_SECONDS,
+            len(show_ids) - len(skipped), len(show_ids), ", ".join(skipped))
+    logger.info("apple fetch took %.0fs for %d shows",
+                budget.elapsed(), len(show_ids) - len(skipped))
+
+    if show_ids and failures == len(show_ids):
         logger.error(
             "every Apple fetch failed — the myacinfo/itctx cookies have "
             "likely EXPIRED. Re-extract them from a logged-in "
@@ -203,7 +262,6 @@ def main(argv=None) -> int:
     if args.dry_run:
         print(json.dumps(data, indent=2, default=str)[:4000])
         return 0
-    out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(data, indent=2, default=str) + "\n", encoding="utf-8")
     logger.info("wrote %s (%d shows)", out, len(shows))

--- a/scripts/fetch_spotify_stats.py
+++ b/scripts/fetch_spotify_stats.py
@@ -16,6 +16,14 @@ Cookies live for months but do eventually expire. When every show's
 fetch fails, this script logs a loud re-auth hint (and still exits 0 —
 stale cookies must degrade to stale data, never a red nightly).
 
+**Runtime is bounded.** A registered feed with no plays yet answers
+``500`` on ``/metadata`` and ``/aggregate`` every night, and the
+connector's built-in retry loop spends ~124s of exponential backoff on
+each such endpoint. With 18 of 24 feeds in that state (measured
+2026-07-25) the step ran for over an hour. ``engine.connector_budget``
+clamps the retry constants and enforces a wall-clock budget; shows not
+reached before the budget expires keep their previously fetched entry.
+
 Show discovery: any ``shows/<slug>.yaml`` with a top-level or
 ``podcast:``-level ``spotify_show_id:`` key. The operator adds the ID
 after submitting each feed at podcasters.spotify.com (it's the
@@ -34,15 +42,34 @@ import datetime as dt
 import json
 import logging
 import os
+import sys
 from pathlib import Path
 from typing import Any, Dict
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from engine.connector_budget import (  # noqa: E402  (after sys.path fix)
+    FetchBudget,
+    _env_float,
+    _env_int,
+    clamp_connector_retries,
+)
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 logger = logging.getLogger("fetch_spotify_stats")
+
+# Retry budget for the vendored connector's request loop. Three attempts
+# with a 1s base costs ~6s of backoff on a permanently-500 endpoint
+# (vs ~124s at the package defaults) while still riding out a genuine
+# transient. Overridable per-run if Spotify ever gets flakier.
+MAX_REQUEST_ATTEMPTS = _env_int("SPOTIFY_MAX_REQUEST_ATTEMPTS", 3)
+RETRY_DELAY_BASE = _env_float("SPOTIFY_RETRY_DELAY_BASE", 1.0)
+# Hard wall-clock stop for the whole multi-show loop (0 disables).
+BUDGET_SECONDS = _env_float("SPOTIFY_FETCH_BUDGET_SECONDS", 900.0)
 
 BASE_URL = os.getenv("SPOTIFY_CONNECTOR_BASE_URL",
                      "https://generic.wg.spotify.com/podcasters/v0")
@@ -131,14 +158,49 @@ def main() -> int:
 
     try:
         import spotifyconnector  # noqa: F401
+        from spotifyconnector import connector as _connector_mod
     except ImportError:
         logger.error("spotifyconnector not installed — add it to "
                      "requirements.txt / pip install spotifyconnector")
         return 0
 
+    applied = clamp_connector_retries(
+        _connector_mod,
+        attempts_attr="MAX_REQUEST_ATTEMPTS",
+        delay_attr="DELAY_BASE",
+        attempts=MAX_REQUEST_ATTEMPTS,
+        delay_base=RETRY_DELAY_BASE,
+    )
+    if applied:
+        logger.info("connector retry budget: %s", applied)
+    else:
+        logger.warning(
+            "spotifyconnector no longer exposes MAX_REQUEST_ATTEMPTS / "
+            "DELAY_BASE — retries are UNBOUNDED this run; the wall-clock "
+            "budget is the only guard left")
+
+    # Carry forward last-good entries so a budget stop leaves the file
+    # complete rather than silently shrinking the show list.
+    previous_shows: Dict[str, Any] = {}
+    out_path = Path(args.out)
+    if out_path.exists():
+        try:
+            previous_shows = (json.loads(
+                out_path.read_text(encoding="utf-8")) or {}).get("shows") or {}
+        except Exception:  # noqa: BLE001
+            previous_shows = {}
+
+    budget = FetchBudget(seconds=BUDGET_SECONDS)
     shows: Dict[str, Any] = {}
     failures = 0
+    skipped: list[str] = []
     for slug, sid in show_ids.items():
+        if budget.exhausted():
+            skipped.append(slug)
+            prior = previous_shows.get(slug)
+            if isinstance(prior, dict):
+                shows[slug] = {**prior, "not_refreshed_this_run": True}
+            continue
         try:
             shows[slug] = fetch_show(sp_dc, sp_key, sid)
             if shows[slug].get("errors") and len(
@@ -149,7 +211,17 @@ def main() -> int:
             failures += 1
         logger.info("fetched %s (%s)", slug, sid)
 
-    if failures == len(show_ids):
+    if skipped:
+        logger.warning(
+            "::warning::spotify fetch budget of %.0fs expired after %d of "
+            "%d shows — %s kept their previous entry. Raise "
+            "SPOTIFY_FETCH_BUDGET_SECONDS or investigate why the endpoints "
+            "are slow.", BUDGET_SECONDS, len(show_ids) - len(skipped),
+            len(show_ids), ", ".join(skipped))
+    logger.info("spotify fetch took %.0fs for %d shows",
+                budget.elapsed(), len(show_ids) - len(skipped))
+
+    if show_ids and failures == len(show_ids):
         logger.error(
             "every Spotify fetch failed — the sp_dc/sp_key cookies have "
             "likely EXPIRED. Re-extract them from a logged-in "
@@ -166,11 +238,10 @@ def main() -> int:
     if args.dry_run:
         print(json.dumps(data, indent=2, default=str)[:4000])
         return 0
-    out = Path(args.out)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(data, indent=2, default=str) + "\n",
-                   encoding="utf-8")
-    logger.info("wrote %s (%d shows)", out, len(shows))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(data, indent=2, default=str) + "\n",
+                        encoding="utf-8")
+    logger.info("wrote %s (%d shows)", out_path, len(shows))
     return 0
 
 

--- a/tests/test_connector_budget.py
+++ b/tests/test_connector_budget.py
@@ -1,0 +1,190 @@
+"""Drift guards for the analytics-connector runtime bounds (July 2026).
+
+Background: the Spotify and Apple creator dashboards ship no official
+API, so the network reads them through community connector packages.
+Both embed a fixed retry loop with *unbounded* exponential backoff
+(4s, 8s, 16s, 32s, 64s per failing endpoint). That is fine for a
+transient error and pathological for a stable one — and on these
+platforms a registered-but-unplayed feed answers ``500`` on
+``/metadata`` and ``/aggregate`` every single night.
+
+Measured 2026-07-25: 18 of 24 registered Spotify feeds were in that
+state (~32 failing endpoints), so the nightly fetch step spent well
+over an hour asleep before the rest of maintenance could run. Nothing
+surfaced it, because ``api/spotify_stats.json`` records only the final
+error, never the wall-clock cost of reaching it.
+
+These tests pin the two guards that make that unrepeatable:
+the retry clamp and the wall-clock budget.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from engine.connector_budget import (  # noqa: E402
+    FetchBudget,
+    clamp_connector_retries,
+)
+
+SPOTIFY_FETCHER = ROOT / "scripts" / "fetch_spotify_stats.py"
+APPLE_FETCHER = ROOT / "scripts" / "fetch_apple_stats.py"
+
+
+class TestRetryClamp:
+    def test_rewrites_the_module_constants_in_place(self):
+        """Both connectors read module-level constants inside their
+        request loop — there is no per-instance knob, so assignment is
+        the only lever."""
+        mod = types.SimpleNamespace(MAX_REQUEST_ATTEMPTS=6, DELAY_BASE=2.0)
+        applied = clamp_connector_retries(
+            mod, attempts_attr="MAX_REQUEST_ATTEMPTS",
+            delay_attr="DELAY_BASE", attempts=3, delay_base=1.0)
+        assert mod.MAX_REQUEST_ATTEMPTS == 3
+        assert mod.DELAY_BASE == 1.0
+        assert applied == {"MAX_REQUEST_ATTEMPTS": 3, "DELAY_BASE": 1.0}
+
+    def test_missing_attributes_are_a_silent_no_op(self):
+        """A package upgrade that renames or drops the constants must
+        degrade to 'unbounded retries + a loud log line', never crash
+        the nightly fetch."""
+        mod = types.SimpleNamespace()
+        applied = clamp_connector_retries(
+            mod, attempts_attr="MAX_REQUEST_ATTEMPTS",
+            delay_attr="DELAY_BASE", attempts=3, delay_base=1.0)
+        assert applied == {}
+
+    def test_partial_attributes_report_what_was_applied(self):
+        mod = types.SimpleNamespace(DELAY_BASE=2.0)
+        applied = clamp_connector_retries(
+            mod, attempts_attr="MAX_REQUEST_ATTEMPTS",
+            delay_attr="DELAY_BASE", attempts=3, delay_base=1.0)
+        assert applied == {"DELAY_BASE": 1.0}
+        assert mod.DELAY_BASE == 1.0
+
+    def test_the_clamped_backoff_is_bounded_by_construction(self):
+        """The connectors double the delay each attempt and skip the
+        final sleep, so total backoff per dead endpoint is
+        sum(base * 2**k for k in 1..attempts-1). Pin that the shipped
+        settings keep it in single-digit seconds; the package defaults
+        (6 attempts / base 2.0) are ~124s."""
+        def total_backoff(attempts: int, base: float) -> float:
+            delay, total = base, 0.0
+            for _ in range(attempts - 1):
+                delay *= 2
+                total += delay
+            return total
+
+        assert total_backoff(6, 2.0) > 100      # what we were paying
+        assert total_backoff(3, 1.0) <= 10      # what we pay now
+
+
+class TestFetchBudget:
+    def test_a_zero_budget_never_expires(self):
+        budget = FetchBudget(seconds=0)
+        assert budget.remaining() == float("inf")
+        assert not budget.exhausted()
+
+    def test_a_spent_budget_reports_exhausted(self):
+        budget = FetchBudget(seconds=0.001)
+        # Force the clock forward rather than sleeping.
+        budget._started -= 5
+        assert budget.exhausted()
+        assert budget.remaining() < 0
+
+    def test_a_fresh_budget_is_not_exhausted(self):
+        budget = FetchBudget(seconds=900)
+        assert not budget.exhausted()
+        assert 0 < budget.remaining() <= 900
+
+
+class TestFetchersAreBounded:
+    """Both cookie-connector fetchers must clamp AND budget. Losing
+    either one re-opens the hours-long-nightly failure mode."""
+
+    def test_spotify_fetcher_clamps_and_budgets(self):
+        src = SPOTIFY_FETCHER.read_text(encoding="utf-8")
+        assert "clamp_connector_retries" in src
+        assert "FetchBudget" in src
+        assert "budget.exhausted()" in src
+        assert 'attempts_attr="MAX_REQUEST_ATTEMPTS"' in src
+
+    def test_apple_fetcher_clamps_and_budgets(self):
+        src = APPLE_FETCHER.read_text(encoding="utf-8")
+        assert "clamp_connector_retries" in src
+        assert "FetchBudget" in src
+        assert "budget.exhausted()" in src
+        # appleconnector spells it MAX_RETRY_ATTEMPTS — a copy-paste of
+        # the Spotify constant name would silently clamp nothing.
+        assert 'attempts_attr="MAX_RETRY_ATTEMPTS"' in src
+
+    def test_budget_stop_carries_forward_previous_entries(self):
+        """A budget stop must leave the output file complete. Dropping
+        unreached shows would look like 'the feed was deregistered' on
+        the dashboard instead of 'we ran out of time'."""
+        for path in (SPOTIFY_FETCHER, APPLE_FETCHER):
+            src = path.read_text(encoding="utf-8")
+            assert "previous_shows" in src, path.name
+            assert "not_refreshed_this_run" in src, path.name
+
+    def test_all_failed_branch_is_guarded_against_an_empty_show_list(self):
+        """``failures == len(show_ids)`` is 0 == 0 for an empty list —
+        without the guard an unconfigured run would log the alarming
+        'cookies have EXPIRED' error."""
+        for path in (SPOTIFY_FETCHER, APPLE_FETCHER):
+            src = path.read_text(encoding="utf-8")
+            assert "if show_ids and failures == len(show_ids):" in src, path.name
+
+    def test_defaults_are_env_overridable(self):
+        """The operator must be able to loosen the bounds without a
+        code change if a platform genuinely gets slower."""
+        spotify = SPOTIFY_FETCHER.read_text(encoding="utf-8")
+        apple = APPLE_FETCHER.read_text(encoding="utf-8")
+        assert "SPOTIFY_FETCH_BUDGET_SECONDS" in spotify
+        assert "SPOTIFY_MAX_REQUEST_ATTEMPTS" in spotify
+        assert "APPLE_FETCH_BUDGET_SECONDS" in apple
+        assert "APPLE_MAX_RETRY_ATTEMPTS" in apple
+
+
+class TestAgeOfAiFeedIsCountedByOp3:
+    """The Nerra Voices pipeline publishes Age of AI outside run_show, so
+    it never inherited the OP3 enclosure prefix every other show gets.
+    Result: OP3 had no show record for the feed (404 on lookup) and its
+    downloads were invisible network-wide. Caught 2026-07-25."""
+
+    PUBLISHER = ROOT / "pipelines" / "voices" / "publish_episode.py"
+
+    def test_publish_applies_the_op3_prefix_to_new_enclosures(self):
+        src = self.PUBLISHER.read_text(encoding="utf-8")
+        assert "apply_op3_prefix" in src
+        assert "audio_url=feed_audio_url" in src, (
+            "the prefixed URL must be the one handed to update_rss_feed")
+
+    def test_summaries_keep_the_direct_r2_url(self):
+        """Only the RSS enclosure is proxied; the site's own player
+        should hit R2 directly (matching the rest of the network)."""
+        src = self.PUBLISHER.read_text(encoding="utf-8")
+        assert '"audio_url": audio_url' in src
+
+    def test_prefix_default_matches_the_network_default(self):
+        """This pipeline deliberately skips the show-config stack, so
+        the helper's default is the contract — pin it to
+        shows/_defaults.yaml so the two can't drift."""
+        import yaml
+
+        defaults = yaml.safe_load(
+            (ROOT / "shows" / "_defaults.yaml").read_text(encoding="utf-8"))
+        configured = defaults["analytics"]["prefix_url"]
+        publisher = (ROOT / "engine" / "publisher.py").read_text(
+            encoding="utf-8")
+        m = re.search(
+            r'def apply_op3_prefix\([^)]*prefix_url:\s*str\s*=\s*"([^"]+)"',
+            publisher, re.S)
+        assert m, "apply_op3_prefix's default prefix moved"
+        assert m.group(1) == configured


### PR DESCRIPTION
Two problems the committed analytics JSONs had been hiding, both surfaced by a live run of the nightly fetchers.

## 1. The Spotify step runs for over an hour

`spotifyconnector` retries a failing endpoint **6 times with unbounded exponential backoff** (4s → 8s → 16s → 32s → 64s ≈ 124s per endpoint). That is correct for a transient error and pathological for a stable one — and on these platforms a registered feed with **no plays yet answers `500` on `/metadata` and `/aggregate` every single night**.

Current state of `api/spotify_stats.json`: **18 of 24 feeds** are in exactly that state (~32 dead endpoints), so the step was spending **~66 minutes of pure sleep** before the rest of nightly maintenance could start. Nothing surfaced it, because the output file records only the final error — never the wall-clock cost of reaching it.

New `engine/connector_budget.py`, used by both cookie-connector fetchers:

* **`clamp_connector_retries`** rewrites the connector's retry constants in place (3 attempts / 1s base). Measured against a stubbed always-500 endpoint: **6.0s per dead endpoint, down from ~124s** → the whole step lands in ~3 min instead of ~66. Defensive by contract: a package upgrade that renames or drops the constants is a silent no-op plus a loud log line, never a crash.
* **`FetchBudget`** is a wall-clock backstop (900s default, env-tunable) so a future upstream change can't re-create the stall regardless of what the retry constants end up being. Shows not reached keep their previous entry tagged `not_refreshed_this_run`, so a budget stop leaves the file **complete** rather than looking like a deregistered feed.

The Apple fetcher gets the same treatment. Note its constant is `MAX_RETRY_ATTEMPTS`, not `MAX_REQUEST_ATTEMPTS` — a copy-paste would have clamped nothing, so that's pinned by a test.

Also fixed in passing: `failures == len(show_ids)` is `0 == 0` for an empty show list, so an unconfigured run would log the alarming "cookies have EXPIRED" error. Now guarded.

## 2. Age of AI's downloads were never counted

The OP3 prefix is applied by **each publish path** (`run_show.py`, `engine/pipeline.py`, `engine/language_feeds.py`), never by `update_rss_feed`. The Nerra Voices publisher bypasses run_show and was missing the call, so `age_of_ai_podcast.rss` shipped raw R2 enclosures and the show's downloads were invisible network-wide:

```
age_of_ai  https://audio.nerranetwork.com/age_of_ai/Age_of_AI_Ep001…mp3   ← no prefix
dp_pod     https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep001…mp3
```

New episodes are now prefixed. **The published Ep001 URL is deliberately left alone** — rewriting a live enclosure re-downloads the episode for every subscriber (landmine class). A drift guard pins `apply_op3_prefix`'s default against `shows/_defaults.yaml`'s `analytics.prefix_url`, since this pipeline intentionally doesn't load the show-config stack.

## The OP3 404s in the same log are not a bug

`age_of_ai` and `dp_pod` 404 on the OP3 show lookup. Per OP3's own docs, a 404 means *"OP3 doesn't know about the show"* — not that there were no downloads. Both feeds only went LIVE on Apple two days earlier; prefixed downloads attach retroactively once OP3 indexes the feed. Documented in `docs/analytics.md`, along with how to tell that case apart from a genuinely missing prefix (which is what `age_of_ai` also had).

## Verification

* Retry clamp measured end-to-end against a real `spotifyconnector` instance with `requests.Session.send` stubbed to always-500: **6.0s** per dead endpoint (package default ~124s).
* Budget stop driven end-to-end against the real 24-show config with `fetch_show` stubbed to raise: file kept all 24 shows, 23 carried forward with last-good data + `not_refreshed_this_run`.
* `pytest tests/test_connector_budget.py tests/test_op3_stats.py tests/test_age_of_ai_show.py tests/test_dashboard.py` → 85 passed, 1 skipped.
* `ruff check` clean on every touched file (the repo-wide gate is red on `main` independently of this diff — unchanged here).

No audio, prompt, TTS, or enclosure-URL changes for any published episode — outside the landmine #17 A/B gate.

## Operator notes

* Nothing to arm. The Spotify fix takes effect on the next nightly; the Apple guard is dormant until `APPLE_MYACINFO`/`APPLE_ITCTX` are set.
* If a future `::warning::…budget…expired` annotation appears, it means the platform got slower — raise `SPOTIFY_FETCH_BUDGET_SECONDS`, don't assume a feed died.
* Age of AI download data starts accruing from its next published episode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X

---
_Generated by [Claude Code](https://claude.ai/code/session_013vxW6JoP6E894ByEkF6p8X)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches nightly maintenance timing and analytics JSON semantics (partial refresh tags); Age of AI RSS enclosure URLs change for new episodes only—low subscriber impact but affects download measurement correctness.
> 
> **Overview**
> Nightly **Spotify** and **Apple** cookie-connector fetches were stalling maintenance for over an hour on stable `500` responses from registered-but-unplayed feeds. This PR introduces **`engine/connector_budget.py`**: in-place retry clamping (default 3 attempts / 1s base) and a **900s wall-clock budget** per run (`SPOTIFY_/APPLE_FETCH_BUDGET_SECONDS`, overridable). Shows not refreshed before budget expiry **keep their prior JSON row** with `not_refreshed_this_run: true`, plus `::warning::` when the budget trips. Apple uses `MAX_RETRY_ATTEMPTS` (not Spotify’s constant name).
> 
> **Age of AI** publishes outside `run_show` and was shipping **unprefixed** RSS enclosures, so OP3 never counted downloads. **`pipelines/voices/publish_episode.py`** now calls `apply_op3_prefix` before `update_rss_feed` for new episodes; live Ep001 is intentionally unchanged.
> 
> **`docs/analytics.md`** and **`CLAUDE.md`** document OP3 404 indexing lag vs missing prefix, per-path prefix responsibility, and connector bounds. **`tests/test_connector_budget.py`** pins clamp/budget wiring, carry-forward on budget stop, and the Age of AI OP3 fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6e8480de5fb0054ca9db57163c83b6f279f1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->