### PR TITLE
Fix EpN speech, SpaceX stage naming, MIT NaN scoreboard, Mission Control

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -1131,7 +1131,24 @@ def replace_timezones(text: str) -> str:
 
 
 def replace_episode_numbers(text: str) -> str:
-    """Convert 'episode 39' to 'episode thirty-nine'."""
+    """Convert episode references to spoken words.
+
+    Handles both ``episode 39`` and the abbreviated forms the narrative-
+    memory block used to seed (``Ep141``, ``Ep 141``, ``EP141``) — those
+    abbreviations were voiced letter-by-letter as "E P one forty-one"
+    (Fascinating Frontiers Ep142, SpaceX Ep44, July 2026). Abbreviations
+    expand to the full word ``episode`` first so TTS never sees bare
+    ``EpN``.
+    """
+    def _ep_abbrev(m: re.Match) -> str:
+        try:
+            return f"episode {number_to_words(int(m.group(1)))}"
+        except ValueError:
+            return m.group(0)
+
+    # Ep141 / Ep 141 / ep.141 — before the bare "episode N" pass.
+    text = re.sub(r"\b[Ee]p\.?\s*(\d+)\b", _ep_abbrev, text)
+
     def _ep(m: re.Match) -> str:
         prefix = m.group(1)
         num = m.group(2)

--- a/digests/modern_investing/investment_tracker.json
+++ b/digests/modern_investing/investment_tracker.json
@@ -1175,14 +1175,14 @@
     }
   ],
   "benchmark": {
-    "current_close": NaN,
-    "inception_to_date_pct": NaN,
-    "ytd_pct": NaN,
+    "current_close": null,
+    "inception_to_date_pct": null,
+    "ytd_pct": null,
     "last_updated": "2026-07-25"
   },
   "alpha": {
-    "inception_to_date_pct": NaN,
-    "ytd_pct": NaN,
+    "inception_to_date_pct": null,
+    "ytd_pct": null,
     "monthly": {}
   },
   "sectors": {

--- a/docs/reviews/listener_feedback_pass_2026_07_25.md
+++ b/docs/reviews/listener_feedback_pass_2026_07_25.md
@@ -1,0 +1,84 @@
+# Listener-feedback quality pass — 2026-07-25
+
+Operator listened to Fascinating Frontiers Ep142, SpaceX Daily Ep44, and
+Modern Investing Ep117. This pass fixes the confirmed defects and several
+dashboard regressions from recent Mission Control work.
+
+## Fixes shipped
+
+### 1. "Ep141" / letter-soup episode refs (FF Ep142, SpaceX Ep44)
+
+**Symptom.** FF Ep142 said "on Ep141" three times (Whisper: "on EP 141").
+SpaceX used the same `EpN` form from narrative memory.
+
+**Root cause.** `build_narrative_status_block` in `engine/show_memory.py`
+and `engine/tesla_memory.py` injected `Ep{N}` and seeded a callback template
+the model echoed per program. `replace_episode_numbers` only matched
+`episode \d+`, not `Ep141`.
+
+**Fix.**
+- Memory blocks: speak-friendly `episode {N}` + date; **CONTINUITY BUDGET ≤1**
+  callback/episode; ban `EpN` abbreviations.
+- Digest/podcast prompts (FF + SpaceX): same budget + ban.
+- TTS defense: `\b[Ee]p\.?\s*\d+\b` → `episode {words}` in
+  `assets/pronunciation.py`.
+
+⚠️ **A/B-listen required** — prompt + TTS path changes.
+
+### 2. SpaceX booster vs Ship landing blur (Ep44)
+
+**Symptom.** Episode treated "the landing" / splashdown / tower-catch as one
+blurred outcome; Super Heavy booster vs Ship upper stage were not kept distinct.
+
+**Fix.** HARD RULE — NAME THE STAGE in `spacex_digest.txt` +
+`spacex_podcast.txt` (validation checklist too).
+
+⚠️ **A/B-listen required**.
+
+### 3. Modern Investing Ep117 — silent scoreboard / NaN benchmark
+
+**Symptom.** Spoken: "Index levels are unavailable… Portfolio… alpha…
+unavailable." Tracker had `benchmark.current_close: NaN` (invalid JSON that
+Python accepts). Matched-window alpha (~+6.6%) was healthy but the early-exit
+in `_build_benchmark_block` hid it.
+
+**Fix.**
+- `_fetch_nasdaq_close` rejects non-finite closes.
+- `_compute_benchmark_state` never persists NaN; clears poisoned alpha/YTD.
+- `_build_benchmark_block` still emits MATCHED-WINDOW scoreboard when the
+  live quote is missing.
+- Scrubbed `investment_tracker.json` NaN → `null`.
+
+⚠️ **A/B-listen** when the quote gap path fires (scoreboard wording changes).
+
+### 4. Mission Control / `management.html`
+
+| Bug | Fix |
+|-----|-----|
+| Show links used `{slug}.html` → 404s (`dp_pod.html`, `modern_investing.html`) | Canonical `_SHOW_PAGE_BY_SLUG` + `network_meta` overlay |
+| Monday-only shows flagged `stale` after 72h | Cadence thresholds (Mon: 8d/10d; Age of AI: never) |
+| Portfolio YTD tile showed `+0.00%` when both sides null/NaN | `sumOrDash` — require finite numbers; show "—" |
+| Matched-window alpha invisible on dashboard | New tile when `matched_window_alpha_pct` present |
+
+No audio impact.
+
+## Suggested follow-ups (not in this PR)
+
+1. **Digest ceiling / length A/B** — still the durable lever for FF/PT/UC
+   chronic under-length (deferred behind the network four-show A/B).
+2. **Transcript source** — publish from pre-pronunciation text so word-guides
+   never leak (June M&A class).
+3. **Age of AI bootstrap** — external (Supabase / Voximplant / Worker / Cal.com);
+   code path is ready; keep topic queue empty.
+4. **MIT live quote resilience** — optional second index source when yfinance
+   returns NaN on a trading day (matched-window path already softens the miss).
+5. **Cover-map DRY** — `management.html` `coverFor` map vs `network_meta`
+   podcast images could share one source.
+6. **safe-commit-push recovery hatch** — landmine #23 still only on run-show /
+   multilingual; extend the composite if large nightly commits keep racing.
+
+## Drift guards
+
+`tests/test_quality_pass_2026_07_25.py` plus updates in
+`test_pronunciation.py`, `test_show_memory.py`, `test_tesla_quality_pass.py`,
+`test_network_quality_pass.py`.

--- a/engine/show_memory.py
+++ b/engine/show_memory.py
@@ -214,9 +214,12 @@ def build_narrative_status_block(tracker: Dict[str, Any], label: str) -> str:
     lines = [
         f"### {label} PROGRAM NARRATIVE MEMORY",
         "Use this to give regular listeners a sense of ongoing stories and real progress (or the lack of it).",
-        "When a story touches one of these programs, MAKE THE CONTINUITY AUDIBLE — open that story with a",
-        "short callback a regular listener recognizes, e.g. 'Remember, the show covered [program] on",
-        "[last covered date] — today's news moves that forward because...'. Then answer naturally:",
+        "CONTINUITY BUDGET — at most ONE audible continuity callback in the whole episode",
+        "(across all programs). Prefer the date ('yesterday' / the covered date). NEVER write",
+        "'Ep141', 'Ep 141', 'ep141', or any 'EpN' abbreviation — those get voiced as letter-soup.",
+        "If a number is truly needed, write 'episode <number in words>' once. Example shape:",
+        "'Remember, we covered [program] yesterday — today's news moves that forward because...'.",
+        "Then answer naturally:",
         "  - Where does today's development fit in the bigger arc for this program?",
         "  - Does it meaningfully move any of the key open questions?",
         "  - What should attentive listeners be watching for next?",
@@ -230,7 +233,11 @@ def build_narrative_status_block(tracker: Dict[str, Any], label: str) -> str:
         status = prog.get("status", "Status not yet tracked.")
         last_ep = prog.get("last_major_update_episode")
         last_date = prog.get("last_major_update_date", "")
-        when = f" (status last reviewed: Ep{last_ep}, {last_date})" if last_ep else ""
+        # Speak-friendly refs only — never "EpN" (July 2026: FF Ep142
+        # echoed "on Ep141" three times from this block's old wording).
+        when = ""
+        if last_ep:
+            when = f" (status last reviewed: {last_date or 'date unknown'}; episode {last_ep})"
         # Auto-tracked freshness (June 2026, ported from the Tesla fix):
         # when the show last actually discussed this program on air —
         # kept current by auto_update_narrative_from_digest, unlike the
@@ -238,7 +245,10 @@ def build_narrative_status_block(tracker: Dict[str, Any], label: str) -> str:
         ment_ep = prog.get("last_mentioned_episode")
         ment_date = prog.get("last_mentioned_date", "")
         if ment_ep and ment_ep != last_ep:
-            when += f" (last covered on air: Ep{ment_ep}, {ment_date})"
+            when += (
+                f" (last covered on air: {ment_date or 'date unknown'}; "
+                f"episode {ment_ep})"
+            )
 
         lines.append(f"\n**{name}**{when}")
         lines.append(f"Current status: {status}")

--- a/engine/tesla_memory.py
+++ b/engine/tesla_memory.py
@@ -265,9 +265,12 @@ def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
     lines = [
         "### TESLA PROGRAM NARRATIVE MEMORY",
         "Use this to give regular listeners a sense of ongoing stories and real progress (or the lack of it).",
-        "When a story touches one of these programs, MAKE THE CONTINUITY AUDIBLE — open that story with a",
-        "short callback a regular listener recognizes, e.g. 'Remember, the show covered [program] on",
-        "[last covered date] — today's news moves that forward because...'. Then answer naturally:",
+        "CONTINUITY BUDGET — at most ONE audible continuity callback in the whole episode",
+        "(across all programs). Prefer the date ('yesterday' / the covered date). NEVER write",
+        "'Ep505', 'Ep 505', 'ep505', or any 'EpN' abbreviation — those get voiced as letter-soup.",
+        "If a number is truly needed, write 'episode <number in words>' once. Example shape:",
+        "'Remember, we covered [program] yesterday — today's news moves that forward because...'.",
+        "Then answer naturally:",
         "  - Where does today's development fit in the bigger arc for this program?",
         "  - Does it meaningfully move any of the key open questions?",
         "  - What should attentive listeners be watching for next?",
@@ -281,7 +284,10 @@ def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
         status = prog.get("status", "Status not yet tracked.")
         last_ep = prog.get("last_major_update_episode")
         last_date = prog.get("last_major_update_date", "")
-        when = f" (status last reviewed: Ep{last_ep}, {last_date})" if last_ep else ""
+        # Speak-friendly refs only — never "EpN" (July 2026 FF/SpaceX tic).
+        when = ""
+        if last_ep:
+            when = f" (status last reviewed: {last_date or 'date unknown'}; episode {last_ep})"
         # Auto-tracked freshness (June 2026): when the show last actually
         # discussed this program on air — kept current automatically by
         # auto_update_narrative_from_digest, unlike the operator-curated
@@ -289,7 +295,10 @@ def build_narrative_status_block(tracker: Dict[str, Any]) -> str:
         ment_ep = prog.get("last_mentioned_episode")
         ment_date = prog.get("last_mentioned_date", "")
         if ment_ep and ment_ep != last_ep:
-            when += f" (last covered on air: Ep{ment_ep}, {ment_date})"
+            when += (
+                f" (last covered on air: {ment_date or 'date unknown'}; "
+                f"episode {ment_ep})"
+            )
 
         lines.append(f"\n**{name}**{when}")
         lines.append(f"Current status: {status}")

--- a/management.html
+++ b/management.html
@@ -1255,9 +1255,19 @@
       if (sub) c.appendChild(h("div", { class: "t-sub", text: sub }));
       return c;
     };
-    strip.appendChild(mcard("NASDAQ ^IXIC", benchmark.current_close == null ? "—" : Number(benchmark.current_close).toLocaleString(), "YTD " + pct(benchmark.ytd_pct)));
-    strip.appendChild(mcard("Portfolio YTD", pct((alpha.ytd_pct ?? 0) + (benchmark.ytd_pct ?? 0)), "ITD " + pct((alpha.inception_to_date_pct ?? 0) + (benchmark.inception_to_date_pct ?? 0))));
+    const finiteNum = (v) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+    const sumOrDash = (a, b) => {
+      const x = finiteNum(a), y = finiteNum(b);
+      return (x != null && y != null) ? pct(x + y) : "—";
+    };
+    const closeNum = finiteNum(benchmark.current_close);
+    strip.appendChild(mcard("NASDAQ ^IXIC", closeNum == null ? "—" : closeNum.toLocaleString(), "YTD " + pct(benchmark.ytd_pct)));
+    strip.appendChild(mcard("Portfolio YTD", sumOrDash(alpha.ytd_pct, benchmark.ytd_pct), "ITD " + sumOrDash(alpha.inception_to_date_pct, benchmark.inception_to_date_pct)));
     strip.appendChild(mcard("Alpha YTD", pct(alpha.ytd_pct), "ITD " + pct(alpha.inception_to_date_pct)));
+    const matchedAlpha = finiteNum(summary.matched_window_alpha_pct);
+    if (matchedAlpha != null) {
+      strip.appendChild(mcard("Matched-window α", pct(matchedAlpha), (summary.matched_window_trades || 0) + " trades · honest scoreboard"));
+    }
     strip.appendChild(mcard("Win rate", (summary.win_rate_pct || 0).toFixed(0) + "%", summary.wins + "W / " + summary.losses + "L / " + summary.breakeven + "BE"));
     strip.appendChild(mcard("Cumulative P&L", money(summary.cumulative_pnl), "avg " + pct(summary.average_return_pct) + " / trade"));
     mitRoot.appendChild(strip);

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -98,6 +98,40 @@ _SANCTIONED_EXTRA_VOICES = {"ara"}
 # Stale CLAUDE.md triple we use to detect documentation drift (item 9).
 _CLAUDE_MD_OLD_VOICE_TRIPLE = "0.65/0.9/0.85"
 
+# Canonical public show-page filenames (must match generate_html.NETWORK_SHOWS
+# + shows/network_meta.yaml). The dashboard used to emit ``{slug}.html``
+# which 404s for almost every show (dp_pod → thedppod.html, modern_investing
+# → modern-investing.html, RU shows under ru/, etc.).
+_SHOW_PAGE_BY_SLUG: Dict[str, str] = {
+    "tesla": "tesla.html",
+    "omni_view": "omni-view.html",
+    "fascinating_frontiers": "fascinating-frontiers.html",
+    "planetterrian": "planetterrian.html",
+    "env_intel": "env-intel.html",
+    "models_agents": "models-agents.html",
+    "models_agents_beginners": "models-agents-beginners.html",
+    "finansy_prosto": "ru/finansy-prosto.html",
+    "privet_russian": "ru/privet-russian.html",
+    "modern_investing": "modern-investing.html",
+    "unintended_consequences": "unintended-consequences.html",
+    "first_principles": "first-principles.html",
+    "spacex": "spacex.html",
+    "dp_pod": "thedppod.html",
+    "age_of_ai": "age-of-ai.html",
+}
+
+# Cadence-aware publish-staleness thresholds (warn_hours, stale_hours).
+# Daily shows keep the historic 48h/72h. Monday-only shows need ~10 days
+# before "stale" is a real miss. Age of AI is interview-driven — never
+# flag as stale from pub age alone.
+_PUB_AGE_THRESHOLDS_H: Dict[str, Optional[tuple]] = {
+    "env_intel": (192, 240),        # Monday
+    "finansy_prosto": (192, 240),   # Monday
+    "privet_russian": (192, 240),   # Monday
+    "age_of_ai": None,              # on-demand interviews
+}
+_PUB_AGE_DEFAULT_H = (48, 72)
+
 
 # ---------------------------------------------------------------------------
 # Data containers
@@ -1335,6 +1369,18 @@ def build_network_rollup(
     # Per-show latest episode from RSS audit
     latest_by_feed = {f["file"]: f.get("latest_pub_date") for f in rss.get("feeds", [])}
 
+    # Overlay network_meta.yaml show_page overrides (dp_pod, age_of_ai, …).
+    show_pages = dict(_SHOW_PAGE_BY_SLUG)
+    meta_path = _ROOT / "shows" / "network_meta.yaml"
+    if meta_path.exists():
+        try:
+            meta = yaml.safe_load(meta_path.read_text(encoding="utf-8")) or {}
+            for mslug, entry in meta.items():
+                if isinstance(entry, dict) and entry.get("show_page"):
+                    show_pages[mslug] = entry["show_page"]
+        except Exception:
+            pass
+
     per_show_summary = []
     for s in shows:
         slug = s["slug"]
@@ -1345,18 +1391,23 @@ def build_network_rollup(
         rss_file = cfg.publishing.rss_file or ""
         latest_pub = latest_by_feed.get(rss_file)
         pub_status = "ok"
-        if latest_pub:
+        thresholds = _PUB_AGE_THRESHOLDS_H.get(slug, _PUB_AGE_DEFAULT_H)
+        if latest_pub and thresholds is not None:
             try:
                 when = _dt.datetime.fromisoformat(latest_pub)
                 age_hours = (
                     _dt.datetime.now(_dt.timezone.utc) - when
                 ).total_seconds() / 3600
-                if age_hours > 72:
+                warn_h, stale_h = thresholds
+                if age_hours > stale_h:
                     pub_status = "stale"
-                elif age_hours > 48:
+                elif age_hours > warn_h:
                     pub_status = "warn"
             except Exception:
                 pub_status = "unknown"
+        elif thresholds is None:
+            # On-demand shows (Age of AI): never paint red from silence.
+            pub_status = "ok"
         cost_7 = costs["per_show"].get(slug, {}).get("last_7_days", {})
         m = metrics.get(slug, {})
         per_show_summary.append({
@@ -1365,7 +1416,8 @@ def build_network_rollup(
             "rss_file": rss_file,
             "rss_title": cfg.publishing.rss_title,
             "rss_image": cfg.publishing.rss_image,
-            "show_page": f"{slug}.html",
+            "show_page": show_pages.get(
+                slug, slug.replace("_", "-") + ".html"),
             "blog_page": f"blog/{slug}/index.html",
             "newsletter_enabled": cfg.newsletter.enabled,
             "x_enabled": cfg.publishing.x_enabled,
@@ -1551,18 +1603,29 @@ def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
 
     # Normalise benchmark/alpha sub-keys so the template can use
     # ``performance_data.benchmark.ytd_pct`` without tripping on
-    # Jinja's Undefined sentinel on older tracker files.
+    # Jinja's Undefined sentinel on older tracker files. Non-finite
+    # floats (yfinance NaN) become None — never 0 (MIT Ep117 / dashboard
+    # Portfolio YTD tile was lying as "+0.00%" when both sides were NaN).
+    import math as _math
+
+    def _finite_or_none(v: Any) -> Any:
+        if isinstance(v, (int, float)) and _math.isfinite(v):
+            return v
+        return None
+
     raw_bench = tracker.get("benchmark") or {}
     benchmark = {
-        "current_close": raw_bench.get("current_close"),
-        "inception_to_date_pct": raw_bench.get("inception_to_date_pct"),
-        "ytd_pct": raw_bench.get("ytd_pct"),
+        "current_close": _finite_or_none(raw_bench.get("current_close")),
+        "inception_to_date_pct": _finite_or_none(
+            raw_bench.get("inception_to_date_pct")),
+        "ytd_pct": _finite_or_none(raw_bench.get("ytd_pct")),
         "last_updated": raw_bench.get("last_updated"),
     }
     raw_alpha = tracker.get("alpha") or {}
     alpha = {
-        "inception_to_date_pct": raw_alpha.get("inception_to_date_pct"),
-        "ytd_pct": raw_alpha.get("ytd_pct"),
+        "inception_to_date_pct": _finite_or_none(
+            raw_alpha.get("inception_to_date_pct")),
+        "ytd_pct": _finite_or_none(raw_alpha.get("ytd_pct")),
         "monthly": raw_alpha.get("monthly") or {},
     }
 

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -1680,7 +1680,10 @@ def _fetch_nasdaq_close(for_date: datetime.date | None = None) -> float | None:
             if for_date is None:
                 hist = ticker.history(period="5d", interval="1d")
                 if not hist.empty:
-                    return float(hist["Close"].iloc[-1])
+                    close = float(hist["Close"].iloc[-1])
+                    # yfinance can return NaN on thin/halted bars; NaN is
+                    # not None and poisons benchmark + alpha (MIT Ep117).
+                    return close if math.isfinite(close) else None
             else:
                 start = for_date - datetime.timedelta(days=5)
                 end = for_date + datetime.timedelta(days=1)
@@ -1689,8 +1692,10 @@ def _fetch_nasdaq_close(for_date: datetime.date | None = None) -> float | None:
                     # Pick the most recent close on or before ``for_date``.
                     mask = hist.index.date <= for_date
                     if mask.any():
-                        return float(hist[mask]["Close"].iloc[-1])
-                    return float(hist["Close"].iloc[-1])
+                        close = float(hist[mask]["Close"].iloc[-1])
+                    else:
+                        close = float(hist["Close"].iloc[-1])
+                    return close if math.isfinite(close) else None
         except Exception as exc:
             logger.warning("NASDAQ fetch attempt %d (%s): %s", attempt + 1, for_date, exc)
         if attempt < 2:
@@ -1764,21 +1769,53 @@ def _compute_benchmark_state(tracker: dict) -> None:
     current_close = _fetch_nasdaq_close()
 
     benchmark = tracker.setdefault("benchmark", {})
-    benchmark["current_close"] = round(current_close, 2) if current_close is not None else benchmark.get("current_close")
+    prev_close = benchmark.get("current_close")
+    if isinstance(prev_close, (int, float)) and not math.isfinite(prev_close):
+        prev_close = None
+    if current_close is not None and math.isfinite(current_close):
+        benchmark["current_close"] = round(current_close, 2)
+    else:
+        # Keep the last finite close; never persist NaN (MIT Ep117).
+        benchmark["current_close"] = prev_close
     benchmark["last_updated"] = today_iso
 
     inception_close = meta.get("nasdaq_inception_close")
     ytd_start = meta.get("nasdaq_ytd_start_close")
+    if isinstance(inception_close, (int, float)) and not math.isfinite(inception_close):
+        inception_close = None
+    if isinstance(ytd_start, (int, float)) and not math.isfinite(ytd_start):
+        ytd_start = None
     ref_close = benchmark["current_close"]
+    if isinstance(ref_close, (int, float)) and not math.isfinite(ref_close):
+        ref_close = None
+        benchmark["current_close"] = None
 
     if ref_close is not None and inception_close:
-        benchmark["inception_to_date_pct"] = round(((ref_close - inception_close) / inception_close) * 100, 2)
+        benchmark["inception_to_date_pct"] = round(
+            ((ref_close - inception_close) / inception_close) * 100, 2)
+    else:
+        prev_itd = benchmark.get("inception_to_date_pct")
+        if not (isinstance(prev_itd, (int, float)) and math.isfinite(prev_itd)):
+            benchmark["inception_to_date_pct"] = None
     if ref_close is not None and ytd_start:
         benchmark["ytd_pct"] = round(((ref_close - ytd_start) / ytd_start) * 100, 2)
+    else:
+        prev_ytd = benchmark.get("ytd_pct")
+        if not (isinstance(prev_ytd, (int, float)) and math.isfinite(prev_ytd)):
+            benchmark["ytd_pct"] = None
 
     alpha = tracker.setdefault("alpha", {"monthly": {}})
-    alpha["inception_to_date_pct"] = round(_portfolio_return_pct(tracker) - benchmark.get("inception_to_date_pct", 0.0), 2)
-    alpha["ytd_pct"] = round(_portfolio_return_ytd_pct(tracker) - benchmark.get("ytd_pct", 0.0), 2)
+    bench_itd = benchmark.get("inception_to_date_pct")
+    bench_ytd = benchmark.get("ytd_pct")
+    if isinstance(bench_itd, (int, float)) and math.isfinite(bench_itd):
+        alpha["inception_to_date_pct"] = round(
+            _portfolio_return_pct(tracker) - bench_itd, 2)
+    else:
+        alpha["inception_to_date_pct"] = None
+    if isinstance(bench_ytd, (int, float)) and math.isfinite(bench_ytd):
+        alpha["ytd_pct"] = round(_portfolio_return_ytd_pct(tracker) - bench_ytd, 2)
+    else:
+        alpha["ytd_pct"] = None
 
 
 def _matched_nasdaq_window(bars, entry_date, exit_date):
@@ -2111,19 +2148,28 @@ def _build_benchmark_block(tracker: dict) -> str:
     portfolio_itd = _portfolio_return_pct(tracker)
     portfolio_ytd = _portfolio_return_ytd_pct(tracker)
     close = benchmark.get("current_close")
+    if isinstance(close, (int, float)) and not math.isfinite(close):
+        close = None
     bench_ytd = benchmark.get("ytd_pct")
     bench_itd = benchmark.get("inception_to_date_pct")
     alpha_ytd = alpha.get("ytd_pct")
     alpha_itd = alpha.get("inception_to_date_pct")
-
-    if close is None:
-        return (
-            "NASDAQ Composite: data temporarily unavailable — acknowledge the gap "
-            "on air rather than inventing numbers."
-        )
+    for _name, _val in (
+        ("bench_ytd", bench_ytd), ("bench_itd", bench_itd),
+        ("alpha_ytd", alpha_ytd), ("alpha_itd", alpha_itd),
+    ):
+        if isinstance(_val, (int, float)) and not math.isfinite(_val):
+            if _name == "bench_ytd":
+                bench_ytd = None
+            elif _name == "bench_itd":
+                bench_itd = None
+            elif _name == "alpha_ytd":
+                alpha_ytd = None
+            else:
+                alpha_itd = None
 
     def _sign(v):
-        if v is None:
+        if v is None or (isinstance(v, float) and not math.isfinite(v)):
             return "n/a"
         return f"{v:+.2f}%"
 
@@ -2132,6 +2178,8 @@ def _build_benchmark_block(tracker: dict) -> str:
     # review). Label them so the script can never conflate the two.
     summary = tracker.get("summary", {}) or {}
     matched_alpha = summary.get("matched_window_alpha_pct")
+    if isinstance(matched_alpha, float) and not math.isfinite(matched_alpha):
+        matched_alpha = None
     matched_n = summary.get("matched_window_trades", 0)
     matched_line = ""
     if matched_n and matched_alpha is not None:
@@ -2195,6 +2243,26 @@ def _build_benchmark_block(tracker: dict) -> str:
                 + ". NASDAQ stays the headline benchmark; mention the sweep "
                   "at most once per episode. "
             )
+    if close is None:
+        # Live index quote failed (NaN/missing) — still speak the matched-
+        # window scoreboard when we have it (MIT Ep117 went silent on alpha
+        # even though matched_window_alpha_pct was healthy).
+        if matched_line:
+            return (
+                "NASDAQ Composite: live index level temporarily unavailable — "
+                "acknowledge the gap on air; do NOT invent a level or a YTD "
+                "benchmark move. Still report the MATCHED-WINDOW SCOREBOARD "
+                "below (it does not need today's quote):\n"
+                f"{matched_line}\n"
+                "Skip the buy-and-hold gap numbers today — they need the "
+                "live NASDAQ level."
+            )
+        return (
+            "NASDAQ Composite: data temporarily unavailable — acknowledge the "
+            "gap on air rather than inventing numbers. Skip portfolio alpha "
+            "versus the NASDAQ today."
+        )
+
     return (
         f"NASDAQ Composite ^IXIC: {close:,.0f} "
         f"(YTD {_sign(bench_ytd)}, since inception {_sign(bench_itd)}).\n"

--- a/shows/prompts/fascinating_frontiers_digest.txt
+++ b/shows/prompts/fascinating_frontiers_digest.txt
@@ -35,7 +35,7 @@ If fewer than 5 quality articles are available today:
 
 ━━━━━━━━━━━━━━━━━━━━
 ### DEPTH OVER BREADTH (news items)
-High-level one-paragraph summaries fail listeners. Prefer fewer stories at FULL depth over 15 thin restatements. Extract every concrete fact the source provides; if a source is title-only, drop it or keep it to 2 sentences — never invent. When a story touches a tracked program in the narrative memory above, add 1–2 continuity sentences. On thin-news days, LENGTHEN the Cosmic Deep Dive first (it is licensed to use your own astrophysics knowledge) rather than padding news items with "this is exciting" sentences.
+High-level one-paragraph summaries fail listeners. Prefer fewer stories at FULL depth over 15 thin restatements. Extract every concrete fact the source provides; if a source is title-only, drop it or keep it to 2 sentences — never invent. CONTINUITY BUDGET: when a story touches a tracked program in the narrative memory above, you may add at most ONE continuity sentence in the whole digest (not one per program). Prefer the date ("yesterday" / the covered date). NEVER write "Ep141", "Ep 141", "ep141", or any "EpN" abbreviation — if a number is needed, write "episode" plus the number in words once. On thin-news days, LENGTHEN the Cosmic Deep Dive first (it is licensed to use your own astrophysics knowledge) rather than padding news items with "this is exciting" sentences.
 
 ### Top 15 Space & Astronomy Stories
 1. **Title (<= 12 words) — Source Name**

--- a/shows/prompts/fascinating_frontiers_podcast.txt
+++ b/shows/prompts/fascinating_frontiers_podcast.txt
@@ -145,4 +145,6 @@ Here is today's complete formatted digest. Use ONLY this content:
 
 {digest}
 
+CONTINUITY BUDGET (from narrative memory): at most ONE audible continuity callback in the whole episode. Prefer the date ("yesterday" / the covered date). NEVER write or say "Ep141", "Ep 141", or any "EpN" abbreviation — if a number is needed, say "episode" plus the number in words once.
+
 {narrative_memory_section}

--- a/shows/prompts/spacex_digest.txt
+++ b/shows/prompts/spacex_digest.txt
@@ -23,7 +23,9 @@ Select only stories that are SPECIFIC, FRESH (last 48 hours), and SUBSTANTIVE. P
 EDITORIAL JUDGMENT BEATS THE COUNT: 8 stories that matter to a SpaceX follower beat 10 where two are filler. Give the saved depth to the biggest 2–3 engineering or mission stories of the day.
 
 ### DEPTH OVER BREADTH (news items)
-High-level summaries fail SpaceX listeners who want engineering substance. Prefer 8 strong Top News items at full depth over 10 thin ones. Extract every concrete fact the source provides; never invent thrust figures, dates, or deal terms. When a story touches a tracked program in the narrative memory above, add 1–2 continuity sentences. On thin-news days, LENGTHEN the Engineering Deep Dive first — it is the licensed-knowledge length lever (target ~280–360 words / three full paragraphs of 4–6 sentences each). Do not pad Top News with significance sentences.
+High-level summaries fail SpaceX listeners who want engineering substance. Prefer 8 strong Top News items at full depth over 10 thin ones. Extract every concrete fact the source provides; never invent thrust figures, dates, or deal terms. CONTINUITY BUDGET: when a story touches a tracked program in the narrative memory above, add at most ONE continuity sentence in the whole digest (not one per program). Prefer the date ("yesterday" / the covered date). NEVER write "Ep43", "Ep 43", or any "EpN" abbreviation — if a number is needed, write "episode" plus the number in words once. On thin-news days, LENGTHEN the Engineering Deep Dive first — it is the licensed-knowledge length lever (target ~280–360 words / three full paragraphs of 4–6 sentences each). Do not pad Top News with significance sentences.
+
+HARD RULE — NAME THE STAGE: For every landing, catch, splashdown, reentry, or failure involving a Starship stack vehicle, name WHICH stage you mean: the Super Heavy booster (first stage) OR the Ship / Starship upper stage. Never say "the landing" or "the catch" without the stage. Booster recovery and Ship recovery are DIFFERENT events with different hardware and status — do not blur them. If only one stage has news today, say so explicitly and do not imply the other stage shared that outcome.
 
 ### RECENTLY COVERED — DO NOT REPEAT:
 {recent_content_summary}
@@ -34,7 +36,7 @@ High-level summaries fail SpaceX listeners who want engineering substance. Prefe
 ### NARRATIVE MEMORY (ground truth for long-term context):
 {narrative_memory_section}
 
-For any story touching a tracked program, include 1–2 sentences of continuity: where this fits in the arc, and whether it moves a key open question.
+For any story touching a tracked program, you may include continuity under the CONTINUITY BUDGET above (at most one callback in the whole digest): where this fits in the arc, and whether it moves a key open question.
 
 {spcx_market_block}
 
@@ -85,6 +87,8 @@ A SHORT, secondary note — 1–2 sentences, no more. This is the quiet business
 - Coverage spans the whole business where there's news (not just Starship + Starlink): engines, pads/infrastructure, Dragon, Starshield, reuse, and the AI/compute thread (xAI/Grok/Cursor) all get a look.
 - AI & Compute section present, covering the SpaceX↔xAI/Grok/X/Cursor thread with source URLs.
 - Engineering Deep Dive uses first-principles reasoning (names a raw-material floor or Idiot Index where it fits) and differs from recent essays.
+- Every landing/catch/splashdown/reentry names Super Heavy booster vs Ship/upper stage (never bare "the landing").
 - Market Watch is at most 2 sentences and follows its quote rule (verbatim quote, or no price at all — never "unavailable").
 - Community Buzz: zero overlap with Top News.
+- No "EpN" abbreviations; at most one continuity callback in the digest.
 - No instruction text or meta-commentary anywhere in the output.

--- a/shows/prompts/spacex_podcast.txt
+++ b/shows/prompts/spacex_podcast.txt
@@ -58,7 +58,9 @@ Patrick: Meanwhile, on the Starlink side...
 ### NARRATIVE MEMORY (HIGH PRIORITY — CONTINUITY FOR REGULAR LISTENERS)
 {narrative_memory_section}
 
-When a story touches a tracked program, give listeners 1–2 natural sentences of "where we are in the bigger story" — like a friend updating a friend. If the show covered the same program yesterday, do NOT re-introduce it: open with a one-line callback and cover ONLY what is new. If a claim is not in the digest or the memory block, treat it as unverified — hedge or omit.
+CONTINUITY BUDGET: at most ONE audible continuity callback in the whole episode. Prefer the date ("yesterday" / the covered date). NEVER say or write "Ep43", "Ep 43", or any "EpN" abbreviation — if a number is needed, say "episode" plus the number in words once. If the show covered the same program yesterday, do NOT re-introduce it: one short callback, then ONLY what is new. If a claim is not in the digest or the memory block, treat it as unverified — hedge or omit.
+
+HARD RULE — NAME THE STAGE: every landing, catch, splashdown, reentry, or failure of a Starship stack vehicle must name WHICH stage — Super Heavy booster (first stage) or Ship / Starship upper stage. Never say "the landing" or "the catch" without the stage. Do not blur booster recovery with Ship recovery.
 
 ATTRIBUTION DISCIPLINE (three tiers):
 (1) official — "SpaceX announced", "the FAA license states"

--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -11,6 +11,7 @@ Covers the ten non-flagship shows (Tesla/MIT had their own passes):
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -109,7 +110,12 @@ class TestShowMemoryFixesPorted:
         tracker = sm.load_narrative_tracker(
             _ROOT / "digests" / "planetterrian", cfg)
         block = sm.build_narrative_status_block(tracker, cfg.label)
-        assert "MAKE THE CONTINUITY AUDIBLE" in block
+        assert "CONTINUITY BUDGET" in block
+        assert "NEVER write" in block
+        # Status lines must not seed "Ep{N}" (ban-list examples may mention it).
+        for line in block.splitlines():
+            if "last covered on air:" in line or "status last reviewed:" in line:
+                assert not re.search(r"\bEp\d+\b", line), line
 
 
 class TestHookLedTeasersNetworkWide:

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -426,6 +426,19 @@ class TestReplaceEpisodeNumbers:
         result = replace_episode_numbers("episode 336")
         assert "three hundred thirty-six" in result
 
+    # July 2026 — FF Ep142 / SpaceX Ep44: narrative memory seeded "Ep141"
+    # and TTS voiced the abbreviation as letter-soup.
+    def test_ep_abbrev_no_space(self):
+        result = replace_episode_numbers("covered on Ep141 — today's news")
+        assert "episode" in result.lower()
+        assert "one hundred forty-one" in result
+        assert "Ep141" not in result
+
+    def test_ep_abbrev_with_space(self):
+        result = replace_episode_numbers("last appeared on Ep 43")
+        assert "episode forty-three" in result
+        assert "Ep 43" not in result
+
 
 class TestReplaceOrdinalNumbers:
     def test_seventh(self):

--- a/tests/test_quality_pass_2026_07_25.py
+++ b/tests/test_quality_pass_2026_07_25.py
@@ -1,0 +1,167 @@
+"""Drift guards for the July 25 2026 listener-feedback quality pass.
+
+Fixes pinned here:
+1. Narrative memory never seeds ``EpN`` abbreviations; continuity budget ≤1.
+2. ``replace_episode_numbers`` expands ``Ep141`` / ``Ep 43`` to spoken words.
+3. SpaceX prompts require naming Super Heavy booster vs Ship on landings.
+4. MIT never persists NaN benchmark closes; scoreboard survives quote gaps.
+5. Dashboard show_page URLs match public filenames; Monday shows aren't
+   falsely stale at 72h; Portfolio YTD doesn't coalesce null→0.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+
+class TestEpisodeAbbrevSpeech:
+    def test_pronunciation_expands_ep_abbrev(self):
+        from assets.pronunciation import replace_episode_numbers
+
+        out = replace_episode_numbers(
+            "Remember, the show covered Starship on Ep141 — today moves forward."
+        )
+        assert "Ep141" not in out
+        assert "episode one hundred forty-one" in out
+
+    def test_show_memory_block_has_budget_not_epn(self):
+        import re
+        from engine import show_memory as sm
+
+        cfg = sm.get_config("fascinating_frontiers")
+        tracker = {
+            "programs": {
+                "starship_mars": {
+                    "display_name": "Starship",
+                    "status": "Flight tests ongoing.",
+                    "key_open_questions": ["Reuse cadence?"],
+                    "last_major_update_episode": 140,
+                    "last_major_update_date": "2026-07-23",
+                    "last_mentioned_episode": 141,
+                    "last_mentioned_date": "2026-07-24",
+                }
+            }
+        }
+        block = sm.build_narrative_status_block(tracker, cfg.label)
+        assert "CONTINUITY BUDGET" in block
+        assert "episode 141" in block
+        assert "last covered on air: 2026-07-24; episode 141" in block
+        for line in block.splitlines():
+            if "last covered on air:" in line or "status last reviewed:" in line:
+                assert not re.search(r"\bEp\d+\b", line), line
+
+
+class TestSpaceXStageNaming:
+    def test_digest_has_name_the_stage_rule(self):
+        text = (_ROOT / "shows/prompts/spacex_digest.txt").read_text(
+            encoding="utf-8")
+        assert "HARD RULE — NAME THE STAGE" in text
+        assert "Super Heavy booster" in text
+        assert "Ship / Starship upper stage" in text
+
+    def test_podcast_has_name_the_stage_rule(self):
+        text = (_ROOT / "shows/prompts/spacex_podcast.txt").read_text(
+            encoding="utf-8")
+        assert "HARD RULE — NAME THE STAGE" in text
+        assert "CONTINUITY BUDGET" in text
+
+
+class TestMITNaNBenchmark:
+    def test_fetch_rejects_nan(self):
+        import types
+        import pandas as pd
+        from shows.hooks import modern_investing as mi
+
+        class _FakeTicker:
+            def history(self, **kwargs):
+                return pd.DataFrame({"Close": [float("nan")]})
+
+        fake_yf = types.ModuleType("yfinance")
+        fake_yf.Ticker = lambda *_a, **_k: _FakeTicker()
+        with patch.dict(sys.modules, {"yfinance": fake_yf}), \
+             patch("time.sleep"):
+            assert mi._fetch_nasdaq_close() is None
+
+    def test_build_block_keeps_matched_window_when_close_nan(self):
+        from shows.hooks import modern_investing as mi
+
+        tracker = {
+            "benchmark": {
+                "current_close": float("nan"),
+                "ytd_pct": float("nan"),
+                "inception_to_date_pct": float("nan"),
+            },
+            "alpha": {"ytd_pct": float("nan"), "inception_to_date_pct": float("nan")},
+            "summary": {
+                "matched_window_alpha_pct": 6.59,
+                "matched_window_trades": 40,
+                "compounded_return_pct": 12.0,
+                "compounded_nasdaq_matched_pct": 5.0,
+                "alpha_t_stat": 1.2,
+                "alpha_statistically_significant": False,
+                "benchmark_scores": {},
+            },
+            "trades": [],
+            "metadata": {"position_size": 1000},
+        }
+        block = mi._build_benchmark_block(tracker)
+        assert "temporarily unavailable" in block.lower() or "unavailable" in block.lower()
+        assert "MATCHED-WINDOW" in block
+        assert "6.59" in block or "+6.59" in block
+        assert "do NOT invent" in block
+
+    def test_compute_benchmark_never_persists_nan(self):
+        from shows.hooks import modern_investing as mi
+
+        tracker = {
+            "metadata": {
+                "nasdaq_inception_close": 15000.0,
+                "nasdaq_ytd_start_close": 18000.0,
+                "nasdaq_ytd_year": 2026,
+                "position_size": 1000,
+            },
+            "benchmark": {"current_close": float("nan")},
+            "alpha": {"monthly": {}},
+            "trades": [],
+        }
+        with patch.object(mi, "_fetch_nasdaq_close", return_value=float("nan")):
+            mi._compute_benchmark_state(tracker)
+        close = tracker["benchmark"]["current_close"]
+        assert close is None or (isinstance(close, float) and math.isfinite(close))
+        assert tracker["benchmark"]["current_close"] is None
+        assert tracker["alpha"]["ytd_pct"] is None
+
+
+class TestDashboardShowPagesAndCadence:
+    def test_show_page_map_covers_network(self):
+        from scripts import generate_dashboard as gd
+
+        assert gd._SHOW_PAGE_BY_SLUG["dp_pod"] == "thedppod.html"
+        assert gd._SHOW_PAGE_BY_SLUG["modern_investing"] == "modern-investing.html"
+        assert gd._SHOW_PAGE_BY_SLUG["fascinating_frontiers"] == (
+            "fascinating-frontiers.html")
+        assert gd._SHOW_PAGE_BY_SLUG["finansy_prosto"].startswith("ru/")
+        assert gd._SHOW_PAGE_BY_SLUG["age_of_ai"] == "age-of-ai.html"
+
+    def test_monday_show_not_stale_at_four_days(self):
+        from scripts import generate_dashboard as gd
+
+        warn_h, stale_h = gd._PUB_AGE_THRESHOLDS_H["env_intel"]
+        assert warn_h > 72
+        assert stale_h > 96
+        assert gd._PUB_AGE_THRESHOLDS_H["age_of_ai"] is None
+
+    def test_management_html_portfolio_ytd_no_null_coalesce(self):
+        html = (_ROOT / "management.html").read_text(encoding="utf-8")
+        assert "sumOrDash" in html
+        assert "alpha.ytd_pct ?? 0" not in html
+        assert "matched_window_alpha_pct" in html

--- a/tests/test_show_memory.py
+++ b/tests/test_show_memory.py
@@ -98,7 +98,10 @@ class TestBlockBuilders:
         block = tm.build_narrative_status_block(tracker)
         assert "Optimus" in block
         assert "Gen 3 hands in testing." in block
-        assert "Ep42" in block
+        # July 2026: never seed "EpN" abbreviations (voiced as letter-soup).
+        assert "Ep42" not in block
+        assert "episode 42" in block
+        assert "CONTINUITY BUDGET" in block
 
     def test_empty_performance_signals_yields_empty(self):
         assert tm.build_performance_signals_block({"recent_signals": {}}) == ""

--- a/tests/test_tesla_quality_pass.py
+++ b/tests/test_tesla_quality_pass.py
@@ -109,8 +109,13 @@ class TestNarrativeAutoFreshness:
             tmp_path, "FSD unsupervised rollout expands.", 505, "2026-06-09")
         tracker = tesla_memory.load_narrative_tracker(tmp_path)
         block = tesla_memory.build_narrative_status_block(tracker)
-        assert "last covered on air: Ep505, 2026-06-09" in block
-        assert "MAKE THE CONTINUITY AUDIBLE" in block
+        assert "last covered on air: 2026-06-09; episode 505" in block
+        assert "CONTINUITY BUDGET" in block
+        # Ban-list examples may mention Ep505; status lines must not seed it.
+        import re
+        for line in block.splitlines():
+            if "last covered on air:" in line or "status last reviewed:" in line:
+                assert not re.search(r"\bEp\d+\b", line), line
 
     def test_run_show_wires_auto_update(self):
         src = (_ROOT / "run_show.py").read_text(encoding="utf-8")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Listener-feedback pass after FF Ep142, SpaceX Ep44, and MIT Ep117, plus Mission Control dashboard bugs from recent merges.

Full writeup: [`docs/reviews/listener_feedback_pass_2026_07_25.md`](docs/reviews/listener_feedback_pass_2026_07_25.md)

### Listener issues fixed

1. **Fascinating Frontiers Ep142 — "Ep141" letter-soup + over-reference**
   - Narrative memory was seeding `Ep{N}` and a per-program callback template (3× "Remember… on Ep141").
   - Continuity budget ≤1/episode; speak-friendly `episode N` + date; TTS expands `\bEp\.?\s*\d+\b`.

2. **SpaceX Daily Ep44 — booster vs Ship landing blur**
   - HARD RULE: every landing/catch/splashdown must name Super Heavy booster vs Ship/upper stage (digest + podcast).

3. **Modern Investing Ep117 — silent scoreboard**
   - `benchmark.current_close: NaN` from yfinance poisoned alpha/YTD and early-exited the scoreboard block.
   - Reject non-finite closes; never persist NaN; still speak matched-window alpha when the live quote is missing; scrubbed tracker.

### Mission Control / `management.html`

- Show-page links were `{slug}.html` → 404s (`dp_pod.html`, `modern_investing.html`, etc.) — now canonical filenames + `network_meta` overlay.
- Monday-only shows no longer paint `stale` after 72h (8d/10d); Age of AI never stale from silence.
- Portfolio YTD tile no longer coalesces null/NaN → `+0.00%`; new matched-window α tile.

### ⚠️ A/B-listen required

Prompt + TTS path changes (memory continuity wording, FF/SpaceX prompts, episode-number expansion, MIT scoreboard gap path). Dashboard/metadata changes are outside landmine #17.

### Suggested follow-ups (not in this PR)

See the review doc: digest-ceiling length A/B, transcript-from-pre-pronunciation, MIT secondary quote source, cover-map DRY, Age of AI external bootstrap.

### Test plan

- [x] `pytest tests/test_quality_pass_2026_07_25.py` (+ related continuity/pronunciation/SpaceX prompt guards)
- [ ] A/B-listen next FF / SpaceX / MIT episodes for continuity + stage naming + scoreboard
- [ ] Spot-check Mission Control show links + Monday-show freshness after nightly dashboard regen

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

