### PR TITLE
Mission Control multi-platform stats + Grok pricing/effort wiring

### DIFF
--- a/api/dashboard.json
+++ b/api/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-25T18:53:46.063810+00:00",
+  "generated_at": "2026-07-26T02:23:21.202221+00:00",
   "network": {
     "landmines_counts": {
       "ok": 10,
@@ -7,9 +7,9 @@
       "fail": 0
     },
     "shows_count": 15,
-    "stale_shows": 4,
-    "total_cost_last_7_days_usd": 6.4745,
-    "total_cost_last_30_days_usd": 25.129,
+    "stale_shows": 0,
+    "total_cost_last_7_days_usd": 5.6128,
+    "total_cost_last_30_days_usd": 24.3593,
     "shows": [
       {
         "slug": "age_of_ai",
@@ -17,12 +17,12 @@
         "rss_file": "age_of_ai_podcast.rss",
         "rss_title": "The Age of AI",
         "rss_image": "https://nerranetwork.com/assets/covers/age-of-ai.jpg",
-        "show_page": "age_of_ai.html",
+        "show_page": "age-of-ai.html",
         "blog_page": "blog/age_of_ai/index.html",
         "newsletter_enabled": false,
         "x_enabled": false,
         "latest_pub_date": "2026-07-20T08:00:00+00:00",
-        "pub_status": "stale",
+        "pub_status": "ok",
         "cost_last_7_days_usd": 0.0,
         "episodes_last_7_days": 0,
         "p50_pipeline_s": 0.0,
@@ -34,14 +34,14 @@
         "rss_file": "dp_pod_podcast.rss",
         "rss_title": "The DP Pod: The Do Positive Podcast",
         "rss_image": "https://nerranetwork.com/assets/covers/dp-pod.jpg",
-        "show_page": "dp_pod.html",
+        "show_page": "thedppod.html",
         "blog_page": "blog/dp_pod/index.html",
         "newsletter_enabled": false,
         "x_enabled": false,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.3565,
-        "episodes_last_7_days": 6,
+        "cost_last_7_days_usd": 0.2951,
+        "episodes_last_7_days": 5,
         "p50_pipeline_s": 49.92,
         "success_rate": 1.0
       },
@@ -51,12 +51,12 @@
         "rss_file": "env_intel_podcast.rss",
         "rss_title": "Environmental Intelligence",
         "rss_image": "https://nerranetwork.com/assets/covers/environmental-intelligence.jpg",
-        "show_page": "env_intel.html",
+        "show_page": "env-intel.html",
         "blog_page": "blog/env_intel/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
         "latest_pub_date": "2026-07-21T08:00:00+00:00",
-        "pub_status": "stale",
+        "pub_status": "ok",
         "cost_last_7_days_usd": 0.1051,
         "episodes_last_7_days": 4,
         "p50_pipeline_s": 55.6,
@@ -68,14 +68,14 @@
         "rss_file": "fascinating_frontiers_podcast.rss",
         "rss_title": "Fascinating Frontiers",
         "rss_image": "https://nerranetwork.com/assets/covers/fascinating-frontiers.jpg",
-        "show_page": "fascinating_frontiers.html",
+        "show_page": "fascinating-frontiers.html",
         "blog_page": "blog/fascinating_frontiers/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6539,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.5824,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 73.75,
         "success_rate": 1.0
       },
@@ -85,14 +85,14 @@
         "rss_file": "finansy_prosto_podcast.rss",
         "rss_title": "Финансы Просто",
         "rss_image": "https://nerranetwork.com/assets/covers/finansy-prosto.jpg",
-        "show_page": "finansy_prosto.html",
+        "show_page": "ru/finansy-prosto.html",
         "blog_page": "blog/finansy_prosto/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
         "latest_pub_date": "2026-07-20T08:00:00+00:00",
-        "pub_status": "stale",
-        "cost_last_7_days_usd": 0.1107,
-        "episodes_last_7_days": 2,
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 0.0553,
+        "episodes_last_7_days": 1,
         "p50_pipeline_s": 64.59,
         "success_rate": 1.0
       },
@@ -102,14 +102,14 @@
         "rss_file": "first_principles_podcast.rss",
         "rss_title": "First Principles Daily",
         "rss_image": "https://nerranetwork.com/assets/covers/first-principles-daily.jpg",
-        "show_page": "first_principles.html",
+        "show_page": "first-principles.html",
         "blog_page": "blog/first_principles/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.4625,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.4076,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 51.98,
         "success_rate": 1.0
       },
@@ -119,14 +119,14 @@
         "rss_file": "models_agents_podcast.rss",
         "rss_title": "Models & Agents",
         "rss_image": "https://nerranetwork.com/assets/covers/models-agents.jpg",
-        "show_page": "models_agents.html",
+        "show_page": "models-agents.html",
         "blog_page": "blog/models_agents/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6397,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.5399,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 79.15,
         "success_rate": 1.0
       },
@@ -136,14 +136,14 @@
         "rss_file": "models_agents_beginners_podcast.rss",
         "rss_title": "Models & Agents for Beginners",
         "rss_image": "https://nerranetwork.com/assets/covers/models-agents-beginners.jpg",
-        "show_page": "models_agents_beginners.html",
+        "show_page": "models-agents-beginners.html",
         "blog_page": "blog/models_agents_beginners/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.3901,
-        "episodes_last_7_days": 8,
+        "cost_last_7_days_usd": 0.3432,
+        "episodes_last_7_days": 7,
         "p50_pipeline_s": 45.96,
         "success_rate": 1.0
       },
@@ -153,14 +153,14 @@
         "rss_file": "modern_investing_podcast.rss",
         "rss_title": "Modern Investing Techniques",
         "rss_image": "https://nerranetwork.com/assets/covers/modern-investing.jpg",
-        "show_page": "modern_investing.html",
+        "show_page": "modern-investing.html",
         "blog_page": "blog/modern_investing/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6099,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.5406,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 94.42,
         "success_rate": 1.0
       },
@@ -170,14 +170,14 @@
         "rss_file": "omni_view_podcast.rss",
         "rss_title": "Omni View - Balanced News Perspectives",
         "rss_image": "https://nerranetwork.com/assets/covers/omni-view.jpg",
-        "show_page": "omni_view.html",
+        "show_page": "omni-view.html",
         "blog_page": "blog/omni_view/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.5973,
-        "episodes_last_7_days": 8,
+        "cost_last_7_days_usd": 0.5205,
+        "episodes_last_7_days": 7,
         "p50_pipeline_s": 138.85,
         "success_rate": 1.0
       },
@@ -193,8 +193,8 @@
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.5779,
-        "episodes_last_7_days": 8,
+        "cost_last_7_days_usd": 0.5132,
+        "episodes_last_7_days": 7,
         "p50_pipeline_s": 55.1,
         "success_rate": 1.0
       },
@@ -204,14 +204,14 @@
         "rss_file": "privet_russian_podcast.rss",
         "rss_title": "Привет, Русский!",
         "rss_image": "https://nerranetwork.com/assets/covers/privet-russian.jpg",
-        "show_page": "privet_russian.html",
+        "show_page": "ru/privet-russian.html",
         "blog_page": "blog/privet_russian/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
         "latest_pub_date": "2026-07-20T08:00:00+00:00",
-        "pub_status": "stale",
-        "cost_last_7_days_usd": 0.1128,
-        "episodes_last_7_days": 2,
+        "pub_status": "ok",
+        "cost_last_7_days_usd": 0.0563,
+        "episodes_last_7_days": 1,
         "p50_pipeline_s": 56.66,
         "success_rate": 1.0
       },
@@ -227,8 +227,8 @@
         "x_enabled": false,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6613,
-        "episodes_last_7_days": 18,
+        "cost_last_7_days_usd": 0.5983,
+        "episodes_last_7_days": 16,
         "p50_pipeline_s": 99.67,
         "success_rate": 1.0
       },
@@ -244,8 +244,8 @@
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.8537,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.7483,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 139.43,
         "success_rate": 1.0
       },
@@ -255,14 +255,14 @@
         "rss_file": "unintended_consequences_podcast.rss",
         "rss_title": "Unintended Consequences",
         "rss_image": "https://nerranetwork.com/assets/covers/unintended-consequences.jpg",
-        "show_page": "unintended_consequences.html",
+        "show_page": "unintended-consequences.html",
         "blog_page": "blog/unintended_consequences/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
         "latest_pub_date": "2026-07-25T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.3431,
-        "episodes_last_7_days": 8,
+        "cost_last_7_days_usd": 0.3069,
+        "episodes_last_7_days": 7,
         "p50_pipeline_s": 20.3,
         "success_rate": 1.0
       }
@@ -444,7 +444,7 @@
           "op3.dev"
         ],
         "unreachable": [],
-        "offline": false
+        "offline": true
       }
     },
     {
@@ -456,8 +456,8 @@
         "total": 95,
         "by_extension": {
           ".txt": 45,
-          ".json": 47,
-          ".py": 3
+          ".py": 3,
+          ".json": 47
         },
         "previous_total": 95
       }
@@ -781,10 +781,10 @@
       },
       "dp_pod": {
         "last_7_days": {
-          "grok": 0.1602,
-          "tts": 0.1964,
-          "total": 0.3565,
-          "episodes": 6
+          "grok": 0.1371,
+          "tts": 0.158,
+          "total": 0.2951,
+          "episodes": 5
         },
         "last_30_days": {
           "grok": 0.4626,
@@ -879,10 +879,10 @@
           "episodes": 4
         },
         "last_30_days": {
-          "grok": 0.3159,
-          "tts": 0.3003,
-          "total": 0.6162,
-          "episodes": 24
+          "grok": 0.2938,
+          "tts": 0.2807,
+          "total": 0.5745,
+          "episodes": 22
         },
         "daily_series": [
           [
@@ -1009,16 +1009,16 @@
       },
       "fascinating_frontiers": {
         "last_7_days": {
-          "grok": 0.3243,
-          "tts": 0.3297,
-          "total": 0.6539,
-          "episodes": 16
+          "grok": 0.2924,
+          "tts": 0.2899,
+          "total": 0.5824,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.0578,
-          "tts": 1.351,
-          "total": 2.4087,
-          "episodes": 62
+          "grok": 1.0255,
+          "tts": 1.3123,
+          "total": 2.3377,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -1145,10 +1145,10 @@
       },
       "finansy_prosto": {
         "last_7_days": {
-          "grok": 0.0633,
-          "tts": 0.0474,
-          "total": 0.1107,
-          "episodes": 2
+          "grok": 0.0318,
+          "tts": 0.0234,
+          "total": 0.0553,
+          "episodes": 1
         },
         "last_30_days": {
           "grok": 0.4663,
@@ -1281,16 +1281,16 @@
       },
       "first_principles": {
         "last_7_days": {
-          "grok": 0.1499,
-          "tts": 0.3127,
-          "total": 0.4625,
-          "episodes": 16
+          "grok": 0.132,
+          "tts": 0.2756,
+          "total": 0.4076,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 0.572,
-          "tts": 1.2378,
-          "total": 1.8098,
-          "episodes": 62
+          "grok": 0.5539,
+          "tts": 1.1974,
+          "total": 1.7514,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -1417,16 +1417,16 @@
       },
       "models_agents": {
         "last_7_days": {
-          "grok": 0.3169,
-          "tts": 0.3227,
-          "total": 0.6397,
-          "episodes": 16
+          "grok": 0.2591,
+          "tts": 0.2808,
+          "total": 0.5399,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.1881,
-          "tts": 1.2131,
-          "total": 2.4011,
-          "episodes": 62
+          "grok": 1.148,
+          "tts": 1.1692,
+          "total": 2.3172,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -1553,16 +1553,16 @@
       },
       "models_agents_beginners": {
         "last_7_days": {
-          "grok": 0.2006,
-          "tts": 0.1895,
-          "total": 0.3901,
-          "episodes": 8
+          "grok": 0.178,
+          "tts": 0.1653,
+          "total": 0.3432,
+          "episodes": 7
         },
         "last_30_days": {
-          "grok": 0.7406,
-          "tts": 0.7975,
-          "total": 1.5381,
-          "episodes": 31
+          "grok": 0.7138,
+          "tts": 0.7734,
+          "total": 1.4873,
+          "episodes": 30
         },
         "daily_series": [
           [
@@ -1689,16 +1689,16 @@
       },
       "modern_investing": {
         "last_7_days": {
-          "grok": 0.3013,
-          "tts": 0.3085,
-          "total": 0.6099,
-          "episodes": 16
+          "grok": 0.2661,
+          "tts": 0.2745,
+          "total": 0.5406,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.3103,
-          "tts": 1.247,
-          "total": 2.5573,
-          "episodes": 60
+          "grok": 1.2513,
+          "tts": 1.2074,
+          "total": 2.4587,
+          "episodes": 59
         },
         "daily_series": [
           [
@@ -1825,16 +1825,16 @@
       },
       "omni_view": {
         "last_7_days": {
-          "grok": 0.276,
-          "tts": 0.3213,
-          "total": 0.5973,
-          "episodes": 8
+          "grok": 0.2454,
+          "tts": 0.2752,
+          "total": 0.5205,
+          "episodes": 7
         },
         "last_30_days": {
-          "grok": 0.9731,
-          "tts": 1.357,
-          "total": 2.3301,
-          "episodes": 31
+          "grok": 0.942,
+          "tts": 1.3093,
+          "total": 2.2513,
+          "episodes": 30
         },
         "daily_series": [
           [
@@ -1961,16 +1961,16 @@
       },
       "planetterrian": {
         "last_7_days": {
-          "grok": 0.2349,
-          "tts": 0.343,
-          "total": 0.5779,
-          "episodes": 8
+          "grok": 0.2082,
+          "tts": 0.305,
+          "total": 0.5132,
+          "episodes": 7
         },
         "last_30_days": {
-          "grok": 0.8966,
-          "tts": 1.3107,
-          "total": 2.2072,
-          "episodes": 31
+          "grok": 0.867,
+          "tts": 1.2652,
+          "total": 2.1322,
+          "episodes": 30
         },
         "daily_series": [
           [
@@ -2097,10 +2097,10 @@
       },
       "privet_russian": {
         "last_7_days": {
-          "grok": 0.0812,
-          "tts": 0.0316,
-          "total": 0.1128,
-          "episodes": 2
+          "grok": 0.0405,
+          "tts": 0.0158,
+          "total": 0.0563,
+          "episodes": 1
         },
         "last_30_days": {
           "grok": 0.5288,
@@ -2233,16 +2233,16 @@
       },
       "spacex": {
         "last_7_days": {
-          "grok": 0.3387,
-          "tts": 0.3226,
-          "total": 0.6613,
-          "episodes": 18
+          "grok": 0.3047,
+          "tts": 0.2936,
+          "total": 0.5983,
+          "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.0936,
-          "tts": 1.0871,
-          "total": 2.1807,
-          "episodes": 62
+          "grok": 1.0582,
+          "tts": 1.055,
+          "total": 2.1132,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -2369,16 +2369,16 @@
       },
       "tesla": {
         "last_7_days": {
-          "grok": 0.485,
-          "tts": 0.3688,
-          "total": 0.8537,
-          "episodes": 16
+          "grok": 0.4344,
+          "tts": 0.314,
+          "total": 0.7483,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.7682,
-          "tts": 1.3113,
-          "total": 3.0795,
-          "episodes": 62
+          "grok": 1.7202,
+          "tts": 1.2654,
+          "total": 2.9856,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -2505,16 +2505,16 @@
       },
       "unintended_consequences": {
         "last_7_days": {
-          "grok": 0.0962,
-          "tts": 0.247,
-          "total": 0.3431,
-          "episodes": 8
+          "grok": 0.0848,
+          "tts": 0.2221,
+          "total": 0.3069,
+          "episodes": 7
         },
         "last_30_days": {
-          "grok": 0.3612,
-          "tts": 0.9571,
-          "total": 1.3184,
-          "episodes": 30
+          "grok": 0.35,
+          "tts": 0.9182,
+          "total": 1.2682,
+          "episodes": 29
         },
         "daily_series": [
           [
@@ -2641,21 +2641,23 @@
       }
     },
     "network_last_7_days": {
-      "grok": 3.0843,
-      "tts": 3.3902,
-      "total": 6.4745,
-      "episodes": 144
+      "grok": 2.6703,
+      "tts": 2.9425,
+      "total": 5.6128,
+      "episodes": 125
     },
     "network_last_30_days": {
-      "grok": 11.735,
-      "tts": 13.394,
-      "total": 25.129,
-      "episodes": 565
+      "grok": 11.3816,
+      "tts": 12.9778,
+      "total": 24.3593,
+      "episodes": 548
     },
     "projections": {
-      "avg_cost_per_episode_usd": 0.045,
-      "projected_weekly_usd": 2.92,
-      "note": "Projection uses last-7d average × 65 (network volume). Tune per operator knowledge."
+      "avg_cost_per_episode_usd": 0.0449,
+      "projected_weekly_usd": 5.61,
+      "projected_monthly_usd": 24.36,
+      "episodes_7d": 125,
+      "note": "Weekly projection = actual last-7d Grok+TTS spend (125 credit_usage files). Monthly = last-30d total. Not a calendar forecast — a trailing burn rate."
     },
     "youtube_quota": {
       "enabled_shows_count": 13,
@@ -2704,7 +2706,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.0599
+        "cost_7d_usd": 0.9306
       },
       "first_principles": {
         "languages": [
@@ -2720,7 +2722,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.4186
+        "cost_7d_usd": 0.3667
       },
       "models_agents": {
         "languages": [
@@ -2736,7 +2738,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.4823
+        "cost_7d_usd": 0.4199
       },
       "modern_investing": {
         "languages": [
@@ -2753,7 +2755,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.8718
+        "cost_7d_usd": 0.818
       },
       "spacex": {
         "languages": [
@@ -2771,7 +2773,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.0436
+        "cost_7d_usd": 0.9441
       },
       "tesla": {
         "languages": [
@@ -2789,10 +2791,10 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.8675
+        "cost_7d_usd": 0.7686
       }
     },
-    "network_cost_7d_usd": 4.8232
+    "network_cost_7d_usd": 4.3274
   },
   "pipeline_health": {
     "age_of_ai": {
@@ -4408,8 +4410,8 @@
             "url": "https://audio.nerranetwork.com/age_of_ai/Age_of_AI_Ep001_Patrick_Novak.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-07-20T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4432,22 +4434,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep019_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep018_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep017_20260721.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-21T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4462,22 +4464,22 @@
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep047_20260619.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-19T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep046_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4492,22 +4494,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep060_20260721.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-21T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep059_20260720.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-20T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep058_20260717.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4522,22 +4524,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep060_20260721.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-21T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep059_20260720.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-20T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/env_intel/Env_Intel_Ep058_20260717.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4552,22 +4554,22 @@
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep047_20260619.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-19T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep046_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4582,22 +4584,22 @@
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep047_20260619.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-19T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep046_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/env_intel/Env_Intel_Ep045_20260615.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4612,22 +4614,22 @@
             "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep105_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep104_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep103_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4642,22 +4644,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep142_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep141_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep140_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4672,22 +4674,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep142_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep141_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep140_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4702,22 +4704,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep142_20260725.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep141_20260724.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep140_20260723.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4732,22 +4734,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep142_20260725.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep141_20260724.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep140_20260723.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4762,22 +4764,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep075_20260720.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-20T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep074_20260718.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/finansy_prosto/FP_Ep073_20260716.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4792,22 +4794,22 @@
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep013_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep012_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4822,22 +4824,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep050_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep049_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep048_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4852,22 +4854,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep050_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep049_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep048_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4882,22 +4884,22 @@
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep013_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep012_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4912,22 +4914,22 @@
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep013_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep012_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/first_principles/First_Principles_Ep011_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4942,22 +4944,22 @@
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep075_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep074_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -4972,22 +4974,22 @@
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep075_20260618.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep074_20260617.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5002,22 +5004,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep113_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep112_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep111_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5032,22 +5034,22 @@
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep075_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep074_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5062,22 +5064,22 @@
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep075_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep074_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents_beginners/MAB_Ep073_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5092,22 +5094,22 @@
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep084_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep083_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5122,22 +5124,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep122_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep121_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep120_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5152,22 +5154,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep122_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep121_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep120_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5182,22 +5184,22 @@
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep084_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep083_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5212,22 +5214,22 @@
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep084_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep083_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/models_agents/Models_Agents_Ep082_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5242,22 +5244,22 @@
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep080_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep079_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5272,22 +5274,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep116_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep115_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5302,22 +5304,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep116_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep115_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5332,22 +5334,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep116_20260724.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep115_20260723.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5362,22 +5364,22 @@
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep080_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep079_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/modern_investing/Modern_Investing_Ep078_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5392,22 +5394,22 @@
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep084_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep082_20260615.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5422,22 +5424,22 @@
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep085_20260618.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep084_20260617.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5452,22 +5454,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep123_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep122_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep121_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5482,22 +5484,22 @@
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep085_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep084_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5512,22 +5514,22 @@
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep084_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep083_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/omni_view/Omni_View_Ep082_20260615.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5542,22 +5544,22 @@
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep093_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep092_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5572,22 +5574,22 @@
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep093_20260618.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep092_20260617.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5602,22 +5604,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep131_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep130_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep129_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5632,22 +5634,22 @@
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep093_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep092_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5662,22 +5664,22 @@
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep093_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep092_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep091_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5692,22 +5694,22 @@
             "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep513_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep512_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep511_20260615.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-15T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5722,22 +5724,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep552_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep551_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep550_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5752,22 +5754,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep552_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep551_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep550_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5782,22 +5784,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep552_20260725.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep551_20260724.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep550_20260723.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5812,22 +5814,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep552_20260725.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep551_20260724.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep550_20260723.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5842,22 +5844,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep062_20260720.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-20T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep061_20260718.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/privet_russian/PR_Ep060_20260716.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5872,22 +5874,22 @@
             "url": "https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep007_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep006_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/spacex/SpaceX_Daily_Ep005_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5902,22 +5904,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep044_20260725.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep043_20260724.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep042_20260723.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5932,22 +5934,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep044_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep043_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep042_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5962,22 +5964,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep044_20260725.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep043_20260724.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep042_20260723.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -5992,22 +5994,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep044_20260725.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep043_20260724.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep042_20260723.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6022,22 +6024,22 @@
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep033_20260618.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep032_20260617.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.es.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6052,22 +6054,22 @@
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep033_20260618.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep032_20260617.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.fr.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6082,22 +6084,22 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep069_20260725.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-25T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep068_20260724.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-24T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep067_20260723.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-23T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6112,22 +6114,22 @@
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep033_20260618.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep032_20260617.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.ru.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6142,22 +6144,22 @@
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep033_20260618.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-18T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep032_20260617.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-17T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           },
           {
             "url": "https://audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep031_20260616.zh.mp3",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-06-16T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
+            "http_status": null,
+            "reachable": false
           }
         ],
         "malformed": false,
@@ -6168,7 +6170,7 @@
     "non_r2_hosts": [
       "op3.dev"
     ],
-    "offline": false
+    "offline": true
   },
   "mit_performance": {
     "available": true,
@@ -7480,159 +7482,159 @@
         "count": 57,
         "last_episode": 117,
         "last_date": "2026-07-25",
-        "days_since": 0,
-        "cools_in_days": 21
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "valuation_discipline",
         "count": 41,
         "last_episode": 117,
         "last_date": "2026-07-25",
-        "days_since": 0,
-        "cools_in_days": 21
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "dividend_compounding",
         "count": 3,
         "last_episode": 117,
         "last_date": "2026-07-25",
-        "days_since": 0,
-        "cools_in_days": 21
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "geopolitical_premium",
         "count": 18,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 29
+        "days_since": 2,
+        "cools_in_days": 28
       },
       {
         "tag": "tax_loss_harvesting",
         "count": 9,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "position_sizing",
         "count": 37,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "momentum_entry",
         "count": 40,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "earnings_surprise",
         "count": 22,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "covered_call",
         "count": 25,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "macro_rotation",
         "count": 19,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "catalyst_confirmation",
         "count": 41,
         "last_episode": 115,
         "last_date": "2026-07-23",
-        "days_since": 2,
-        "cools_in_days": 19
+        "days_since": 3,
+        "cools_in_days": 18
       },
       {
         "tag": "bid_ask_spread",
         "count": 26,
         "last_episode": 114,
         "last_date": "2026-07-22",
-        "days_since": 3,
-        "cools_in_days": 42
+        "days_since": 4,
+        "cools_in_days": 41
       },
       {
         "tag": "risk_management",
         "count": 25,
         "last_episode": 114,
         "last_date": "2026-07-22",
-        "days_since": 3,
-        "cools_in_days": 18
+        "days_since": 4,
+        "cools_in_days": 17
       },
       {
         "tag": "technical_breakout",
         "count": 9,
         "last_episode": 113,
         "last_date": "2026-07-21",
-        "days_since": 4,
-        "cools_in_days": 17
+        "days_since": 5,
+        "cools_in_days": 16
       },
       {
         "tag": "dollar_cost_averaging",
         "count": 4,
         "last_episode": 113,
         "last_date": "2026-07-21",
-        "days_since": 4,
-        "cools_in_days": 17
+        "days_since": 5,
+        "cools_in_days": 16
       },
       {
         "tag": "technical_support",
         "count": 9,
         "last_episode": 111,
         "last_date": "2026-07-19",
-        "days_since": 6,
-        "cools_in_days": 15
+        "days_since": 7,
+        "cools_in_days": 14
       },
       {
         "tag": "sector_concentration",
         "count": 16,
         "last_episode": 104,
         "last_date": "2026-07-12",
-        "days_since": 13,
-        "cools_in_days": 8
+        "days_since": 14,
+        "cools_in_days": 7
       },
       {
         "tag": "analyst_upgrade",
         "count": 18,
         "last_episode": 101,
         "last_date": "2026-07-09",
-        "days_since": 16,
-        "cools_in_days": 5
+        "days_since": 17,
+        "cools_in_days": 4
       },
       {
         "tag": "mean_reversion",
         "count": 11,
         "last_episode": 99,
         "last_date": "2026-07-07",
-        "days_since": 18,
-        "cools_in_days": 3
+        "days_since": 19,
+        "cools_in_days": 2
       }
     ],
     "sector_concentration_warning": "tech: 30% of recent trades (cumulative P&L $+18.84)",
     "execution_health": {
       "signal": {
         "generated_at": "2026-07-25",
-        "age_days": 0,
+        "age_days": 1,
         "action": "new_trade",
         "symbol": "EPD",
         "stale": false
@@ -7659,6 +7661,7 @@
       "network_downloads_7d": 1067,
       "network_downloads_all_time": 3270,
       "all_time_since": "2026-06-29",
+      "all_time_incomplete": true,
       "network_weekly_downloads": [
         660,
         624,
@@ -7884,6 +7887,7 @@
     "youtube": {
       "configured": true,
       "generated": "2026-07-25T18:52:30.974826+00:00",
+      "window_days": 90,
       "channels": {
         "en": {
           "subscribers": 217,
@@ -7939,7 +7943,127 @@
           "subscribers_gained": 2,
           "views": 447
         }
-      ]
+      ],
+      "per_show": {
+        "env_intel": {
+          "views": 118,
+          "subscribers_gained": 0,
+          "subscribers_lost": 0,
+          "video_count": 15,
+          "long_views": 75,
+          "short_views": 43,
+          "avg_view_percentage": 30.1
+        },
+        "fascinating_frontiers": {
+          "views": 7065,
+          "subscribers_gained": 13,
+          "subscribers_lost": 0,
+          "video_count": 97,
+          "long_views": 771,
+          "short_views": 6294,
+          "avg_view_percentage": 36.1
+        },
+        "finansy_prosto": {
+          "views": 248,
+          "subscribers_gained": 1,
+          "subscribers_lost": 0,
+          "video_count": 24,
+          "long_views": 39,
+          "short_views": 209,
+          "avg_view_percentage": 29.4
+        },
+        "first_principles": {
+          "views": 478,
+          "subscribers_gained": 0,
+          "subscribers_lost": 0,
+          "video_count": 38,
+          "long_views": 58,
+          "short_views": 420,
+          "avg_view_percentage": 36.5
+        },
+        "models_agents": {
+          "views": 869,
+          "subscribers_gained": 10,
+          "subscribers_lost": 1,
+          "video_count": 46,
+          "long_views": 653,
+          "short_views": 216,
+          "avg_view_percentage": 28.2
+        },
+        "models_agents_beginners": {
+          "views": 515,
+          "subscribers_gained": 4,
+          "subscribers_lost": 0,
+          "video_count": 46,
+          "long_views": 408,
+          "short_views": 107,
+          "avg_view_percentage": 20.8
+        },
+        "modern_investing": {
+          "views": 1377,
+          "subscribers_gained": 0,
+          "subscribers_lost": 0,
+          "video_count": 67,
+          "long_views": 89,
+          "short_views": 1288,
+          "avg_view_percentage": 21.6
+        },
+        "omni_view": {
+          "views": 565,
+          "subscribers_gained": 2,
+          "subscribers_lost": 0,
+          "video_count": 42,
+          "long_views": 162,
+          "short_views": 403,
+          "avg_view_percentage": 26.9
+        },
+        "planetterrian": {
+          "views": 261,
+          "subscribers_gained": 3,
+          "subscribers_lost": 0,
+          "video_count": 36,
+          "long_views": 147,
+          "short_views": 114,
+          "avg_view_percentage": 27.0
+        },
+        "privet_russian": {
+          "views": 446,
+          "subscribers_gained": 7,
+          "subscribers_lost": 0,
+          "video_count": 25,
+          "long_views": 208,
+          "short_views": 238,
+          "avg_view_percentage": 17.0
+        },
+        "spacex": {
+          "views": 10526,
+          "subscribers_gained": 16,
+          "subscribers_lost": 0,
+          "video_count": 103,
+          "long_views": 862,
+          "short_views": 9664,
+          "avg_view_percentage": 38.0
+        },
+        "tesla": {
+          "views": 6492,
+          "subscribers_gained": 9,
+          "subscribers_lost": 0,
+          "video_count": 98,
+          "long_views": 1082,
+          "short_views": 5410,
+          "avg_view_percentage": 40.6
+        },
+        "unintended_consequences": {
+          "views": 250,
+          "subscribers_gained": 1,
+          "subscribers_lost": 0,
+          "video_count": 32,
+          "long_views": 64,
+          "short_views": 186,
+          "avg_view_percentage": 20.6
+        }
+      },
+      "network_views": 29210
     },
     "site": {
       "configured": true,
@@ -8733,6 +8857,188 @@
       ]
     }
   },
+  "efficiency": {
+    "cost_7d_usd": 5.6128,
+    "episodes_7d": 125,
+    "op3_downloads_7d": 1067,
+    "op3_downloads_30d": 3463,
+    "usd_per_op3_download_7d": 0.0053,
+    "youtube_views_window": 29210,
+    "youtube_window_days": 90,
+    "usd_per_yt_view": 0.0002,
+    "spotify_streams_30d": 240,
+    "spotify_listeners_30d": 109,
+    "apple_feeds_reporting": 0,
+    "apple_plays_30d": null,
+    "note": "Platform metrics are side-by-side and never summed into one reach number. $/OP3-download uses 7d cost ÷ 7d RSS downloads; $/YT-view uses 7d cost ÷ Analytics window views (usually 90d) — directional only across mismatched windows.",
+    "per_show": {
+      "age_of_ai": {
+        "cost_7d_usd": 0.0,
+        "op3_downloads_7d": 0,
+        "op3_downloads_30d": 0,
+        "usd_per_op3_download": null,
+        "youtube_views": 0,
+        "youtube_avg_view_pct": null,
+        "youtube_subs_gained": 0,
+        "usd_per_yt_view": null,
+        "spotify_streams_30d": null
+      },
+      "dp_pod": {
+        "cost_7d_usd": 0.2951,
+        "op3_downloads_7d": 0,
+        "op3_downloads_30d": 0,
+        "usd_per_op3_download": null,
+        "youtube_views": 0,
+        "youtube_avg_view_pct": null,
+        "youtube_subs_gained": 0,
+        "usd_per_yt_view": null,
+        "spotify_streams_30d": null
+      },
+      "env_intel": {
+        "cost_7d_usd": 0.1051,
+        "op3_downloads_7d": 22,
+        "op3_downloads_30d": 75,
+        "usd_per_op3_download": 0.0048,
+        "youtube_views": 118,
+        "youtube_avg_view_pct": 30.1,
+        "youtube_subs_gained": 0,
+        "usd_per_yt_view": 0.0009,
+        "spotify_streams_30d": null
+      },
+      "fascinating_frontiers": {
+        "cost_7d_usd": 0.5824,
+        "op3_downloads_7d": 59,
+        "op3_downloads_30d": 210,
+        "usd_per_op3_download": 0.0099,
+        "youtube_views": 7065,
+        "youtube_avg_view_pct": 36.1,
+        "youtube_subs_gained": 13,
+        "usd_per_yt_view": 0.0001,
+        "spotify_streams_30d": 1
+      },
+      "finansy_prosto": {
+        "cost_7d_usd": 0.0553,
+        "op3_downloads_7d": 8,
+        "op3_downloads_30d": 50,
+        "usd_per_op3_download": 0.0069,
+        "youtube_views": 248,
+        "youtube_avg_view_pct": 29.4,
+        "youtube_subs_gained": 1,
+        "usd_per_yt_view": 0.0002,
+        "spotify_streams_30d": null
+      },
+      "first_principles": {
+        "cost_7d_usd": 0.4076,
+        "op3_downloads_7d": 26,
+        "op3_downloads_30d": 85,
+        "usd_per_op3_download": 0.0157,
+        "youtube_views": 478,
+        "youtube_avg_view_pct": 36.5,
+        "youtube_subs_gained": 0,
+        "usd_per_yt_view": 0.0009,
+        "spotify_streams_30d": null
+      },
+      "models_agents": {
+        "cost_7d_usd": 0.5399,
+        "op3_downloads_7d": 207,
+        "op3_downloads_30d": 627,
+        "usd_per_op3_download": 0.0026,
+        "youtube_views": 869,
+        "youtube_avg_view_pct": 28.2,
+        "youtube_subs_gained": 10,
+        "usd_per_yt_view": 0.0006,
+        "spotify_streams_30d": 95
+      },
+      "models_agents_beginners": {
+        "cost_7d_usd": 0.3432,
+        "op3_downloads_7d": 46,
+        "op3_downloads_30d": 235,
+        "usd_per_op3_download": 0.0075,
+        "youtube_views": 515,
+        "youtube_avg_view_pct": 20.8,
+        "youtube_subs_gained": 4,
+        "usd_per_yt_view": 0.0007,
+        "spotify_streams_30d": 9
+      },
+      "modern_investing": {
+        "cost_7d_usd": 0.5406,
+        "op3_downloads_7d": 59,
+        "op3_downloads_30d": 228,
+        "usd_per_op3_download": 0.0092,
+        "youtube_views": 1377,
+        "youtube_avg_view_pct": 21.6,
+        "youtube_subs_gained": 0,
+        "usd_per_yt_view": 0.0004,
+        "spotify_streams_30d": null
+      },
+      "omni_view": {
+        "cost_7d_usd": 0.5205,
+        "op3_downloads_7d": 56,
+        "op3_downloads_30d": 195,
+        "usd_per_op3_download": 0.0093,
+        "youtube_views": 565,
+        "youtube_avg_view_pct": 26.9,
+        "youtube_subs_gained": 2,
+        "usd_per_yt_view": 0.0009,
+        "spotify_streams_30d": null
+      },
+      "planetterrian": {
+        "cost_7d_usd": 0.5132,
+        "op3_downloads_7d": 72,
+        "op3_downloads_30d": 212,
+        "usd_per_op3_download": 0.0071,
+        "youtube_views": 261,
+        "youtube_avg_view_pct": 27.0,
+        "youtube_subs_gained": 3,
+        "usd_per_yt_view": 0.002,
+        "spotify_streams_30d": 28
+      },
+      "privet_russian": {
+        "cost_7d_usd": 0.0563,
+        "op3_downloads_7d": 15,
+        "op3_downloads_30d": 28,
+        "usd_per_op3_download": 0.0038,
+        "youtube_views": 446,
+        "youtube_avg_view_pct": 17.0,
+        "youtube_subs_gained": 7,
+        "usd_per_yt_view": 0.0001,
+        "spotify_streams_30d": 2
+      },
+      "spacex": {
+        "cost_7d_usd": 0.5983,
+        "op3_downloads_7d": 241,
+        "op3_downloads_30d": 564,
+        "usd_per_op3_download": 0.0025,
+        "youtube_views": 10526,
+        "youtube_avg_view_pct": 38.0,
+        "youtube_subs_gained": 16,
+        "usd_per_yt_view": 0.0001,
+        "spotify_streams_30d": 46
+      },
+      "tesla": {
+        "cost_7d_usd": 0.7483,
+        "op3_downloads_7d": 214,
+        "op3_downloads_30d": 782,
+        "usd_per_op3_download": 0.0035,
+        "youtube_views": 6492,
+        "youtube_avg_view_pct": 40.6,
+        "youtube_subs_gained": 9,
+        "usd_per_yt_view": 0.0001,
+        "spotify_streams_30d": 17
+      },
+      "unintended_consequences": {
+        "cost_7d_usd": 0.3069,
+        "op3_downloads_7d": 42,
+        "op3_downloads_30d": 172,
+        "usd_per_op3_download": 0.0073,
+        "youtube_views": 250,
+        "youtube_avg_view_pct": 20.6,
+        "youtube_subs_gained": 1,
+        "usd_per_yt_view": 0.0012,
+        "spotify_streams_30d": 42
+      }
+    }
+  },
   "catalog": {
     "shows_count": 15,
     "network_episodes_to_date": 1680,
@@ -9076,118 +9382,26 @@
     },
     "retention": {
       "available": true,
-      "generated": "2026-07-24T19:22:25.582644+00:00",
+      "generated": "2026-07-25T19:00:24.671597+00:00",
       "shows_analyzed": 13,
       "images_with_retention": 2035
     }
   },
   "content_lake": {
     "stats": {
-      "total_episodes": 1215,
-      "shows": [
-        "age_of_ai",
-        "dp_pod",
-        "env_intel",
-        "fascinating_frontiers",
-        "finansy_prosto",
-        "first_principles",
-        "models_agents",
-        "models_agents_beginners",
-        "modern_investing",
-        "omni_view",
-        "planetterrian",
-        "privet_russian",
-        "spacex",
-        "tesla",
-        "unintended_consequences"
-      ],
+      "total_episodes": 0,
+      "shows": [],
       "date_range": {
-        "earliest": "2026-02-26",
-        "latest": "2026-07-25"
+        "earliest": null,
+        "latest": null
       },
-      "per_show": {
-        "age_of_ai": {
-          "count": 1,
-          "earliest": "2026-07-20",
-          "latest": "2026-07-20"
-        },
-        "dp_pod": {
-          "count": 19,
-          "earliest": "2026-07-04",
-          "latest": "2026-07-25"
-        },
-        "env_intel": {
-          "count": 58,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-21"
-        },
-        "fascinating_frontiers": {
-          "count": 111,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-25"
-        },
-        "finansy_prosto": {
-          "count": 69,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-20"
-        },
-        "first_principles": {
-          "count": 50,
-          "earliest": "2026-06-07",
-          "latest": "2026-07-25"
-        },
-        "models_agents": {
-          "count": 122,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-25"
-        },
-        "models_agents_beginners": {
-          "count": 107,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-25"
-        },
-        "modern_investing": {
-          "count": 117,
-          "earliest": "2026-03-20",
-          "latest": "2026-07-25"
-        },
-        "omni_view": {
-          "count": 121,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-25"
-        },
-        "planetterrian": {
-          "count": 108,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-25"
-        },
-        "privet_russian": {
-          "count": 62,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-20"
-        },
-        "spacex": {
-          "count": 44,
-          "earliest": "2026-06-13",
-          "latest": "2026-07-25"
-        },
-        "tesla": {
-          "count": 157,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-25"
-        },
-        "unintended_consequences": {
-          "count": 69,
-          "earliest": "2026-05-04",
-          "latest": "2026-07-25"
-        }
-      },
-      "total_words": 1517747
+      "per_show": {},
+      "total_words": 0
     },
     "db_path": "data/content_lake.db",
     "db_exists": true,
-    "db_size_bytes": 46714880,
-    "healthy": true,
+    "db_size_bytes": 45056,
+    "healthy": false,
     "compaction_note": "Run scripts/compact_lake.py or engine.content_lake.compact_lake() to prune old full text."
   },
   "distribution": {

--- a/engine/config.py
+++ b/engine/config.py
@@ -98,6 +98,11 @@ class LLMConfig:
     reviewer_model: str = "grok-4-1-fast-non-reasoning"
     reviewer_max_tokens: int = 1500
     reviewer_temperature: float = 0.3
+    # Optional xAI reasoning depth for models that support it (grok-4.5:
+    # low|medium|high). Empty string = omit the parameter (byte-identical
+    # to pre-wiring requests on grok-4.3). Do NOT set on digest/podcast
+    # paths without an A/B listen when the model change alters prose.
+    reasoning_effort: str = ""
 
 
 @dataclass

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -171,6 +171,7 @@ def _call_grok(
     max_tokens: int = 3500,
     timeout: float = 300.0,
     cache_key: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> tuple[str, Dict[str, Any]]:
     """Call xAI Grok via the OpenAI-compatible endpoint.
 
@@ -181,6 +182,11 @@ def _call_grok(
     the same server, maximizing automatic prompt-cache hits (see
     https://docs.x.ai/developers/advanced-api-usage/prompt-caching). When
     omitted the call is unchanged from the pre-caching path.
+
+    *reasoning_effort* (optional: ``low`` / ``medium`` / ``high``) is sent
+    only when set — required for meaningful grok-4.5 cost control (default
+    high is expensive). Empty/None keeps requests byte-identical for
+    models that ignore the field (grok-4.3 daily path).
     """
     from openai import OpenAI
 
@@ -206,6 +212,12 @@ def _call_grok(
     # system-prompt prefix can hit cache; different shows stay isolated.
     if cache_key:
         create_kwargs["extra_headers"] = {"x-grok-conv-id": str(cache_key)}
+    effort = (reasoning_effort or "").strip().lower()
+    if effort in ("low", "medium", "high"):
+        create_kwargs["extra_body"] = {
+            **(create_kwargs.get("extra_body") or {}),
+            "reasoning_effort": effort,
+        }
 
     resp = client.chat.completions.create(**create_kwargs)
 
@@ -332,6 +344,15 @@ _STOPWORDS = frozenset(
     "think know see like make take come go say says said new first last "
     "today according".split()
 )
+
+
+def _llm_reasoning_effort(config: Any) -> Optional[str]:
+    """Return a validated reasoning_effort from config, or None to omit."""
+    effort = (
+        getattr(getattr(config, "llm", None), "reasoning_effort", "") or ""
+    ).strip().lower()
+    return effort if effort in ("low", "medium", "high") else None
+
 
 
 def _detect_story_duplication(text: str, show_name: str) -> int:
@@ -1521,6 +1542,7 @@ def generate_digest(
         temperature=config.llm.digest_temperature,
         max_tokens=config.llm.max_tokens,
         cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
     )
 
     # Retry once with 50% more tokens if the response was truncated
@@ -1537,6 +1559,7 @@ def generate_digest(
             temperature=config.llm.digest_temperature,
             max_tokens=bumped_tokens,
             cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -1601,6 +1624,7 @@ def generate_digest(
             temperature=config.llm.digest_temperature,
             max_tokens=config.llm.max_tokens,
             cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
         )
         if tracker and "usage" in meta2:
             try:
@@ -1640,6 +1664,7 @@ def generate_digest(
                 temperature=config.llm.podcast_temperature,  # slightly more creative
                 max_tokens=config.llm.max_tokens,
                 cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
             )
             if tracker and "usage" in meta3:
                 try:
@@ -1681,6 +1706,7 @@ def generate_digest(
                     temperature=config.llm.podcast_temperature,
                     max_tokens=config.llm.max_tokens,
                     cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
                 )
                 if tracker:
                     try:
@@ -1730,6 +1756,7 @@ def generate_digest(
                 temperature=lower_temp,
                 max_tokens=config.llm.max_tokens,
                 cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="digest", show_name=config.name,
@@ -1794,6 +1821,7 @@ def generate_digest(
                     temperature=config.llm.digest_temperature,
                     max_tokens=config.llm.max_tokens,
                     cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
                 )
                 # Validate the expanded draft is real content, not a refusal.
                 _validate_llm_output(
@@ -2002,6 +2030,7 @@ def _generate_podcast_outline(
         temperature=config.llm.digest_temperature,  # Lower temp for planning
         max_tokens=2500,
         cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
     )
 
     # A truncated outline is worse than none: stage 2 is told to "follow
@@ -2114,6 +2143,7 @@ def generate_podcast_script(
         temperature=config.llm.podcast_temperature,
         max_tokens=podcast_tokens,
         cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
     )
 
     # Retry once with 50% more tokens if the response was truncated
@@ -2130,6 +2160,7 @@ def generate_podcast_script(
             temperature=config.llm.podcast_temperature,
             max_tokens=bumped_tokens,
             cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -2187,6 +2218,7 @@ def generate_podcast_script(
             temperature=lower_temp,
             max_tokens=podcast_tokens_for_retry,
             cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
         )
         if tracker and "usage" in meta_r1:
             try:
@@ -2224,6 +2256,7 @@ def generate_podcast_script(
                 temperature=lower_temp,
                 max_tokens=podcast_tokens_for_retry,
                 cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
             )
             if tracker:
                 try:
@@ -2301,6 +2334,7 @@ def generate_podcast_script(
             temperature=config.llm.podcast_temperature,
             max_tokens=podcast_tokens,
             cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
         )
 
         if tracker and "usage" in meta2:
@@ -2368,6 +2402,7 @@ def generate_podcast_script(
                 temperature=lower_temp,
                 max_tokens=podcast_tokens,
                 cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="podcast_script", show_name=config.name,
@@ -2443,6 +2478,7 @@ def generate_podcast_script(
                     temperature=config.llm.podcast_temperature,
                     max_tokens=podcast_tokens,
                     cache_key=_show_cache_key(config),
+        reasoning_effort=_llm_reasoning_effort(config),
                 )
                 if tracker and "usage" in meta_rr:
                     try:

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -17,26 +17,44 @@ logger = logging.getLogger(__name__)
 
 # TTS pricing per 1000 characters, by provider.
 # - ElevenLabs Flash v2.5: $0.15/1K chars  (0.5 credits/char × $0.30/1K credits)
-# - Grok TTS (xAI /v1/tts): $0.0042/1K chars ($4.20 per 1M chars, ~36× cheaper
-#   than ElevenLabs Flash; introduced April 2026, used for the Russian shows
-#   since May 2026).
+# - Grok TTS (xAI /v1/tts): public list price as of July 2026 is
+#   $15.00 per 1M chars ($0.015/1K) — see docs.x.ai Voice pricing.
+#   Earlier network tracking used $4.20/M (April–June 2026 promo-era
+#   figure); dashboard costs for NEW episodes use the list rate so
+#   Mission Control isn't systematically understating TTS spend.
+#   Still ~10× cheaper than ElevenLabs Flash ($150/M).
 ELEVENLABS_COST_PER_1K_CHARS = 0.15
-GROK_TTS_COST_PER_1K_CHARS = 0.0042
+GROK_TTS_COST_PER_1K_CHARS = 0.015
 
 TTS_PROVIDER_PRICING = {
     "elevenlabs": ELEVENLABS_COST_PER_1K_CHARS,
     "grok": GROK_TTS_COST_PER_1K_CHARS,
 }
 
-# xAI Grok pricing per 1M tokens (input/output).
+# xAI Grok pricing per 1M tokens (input/output/cached_input).
 # Only models actually reachable by the current code are listed — historical
 # ids (grok-2, grok-3, grok-3-mini, grok-4.20-0309-*) were pruned April 2026
 # once the audit confirmed no live call site resolves to them.
+# Cached-input rates (July 2026 docs) apply when usage reports
+# prompt_tokens_details.cached_tokens — see _estimate_grok_cost.
 GROK_PRICING = {
     # Grok 4.3 — current network default (released 2026-04-30). Always-on
-    # reasoning, 1M context, ~37% cheaper input and ~58% cheaper output
-    # than grok-4.20 at the same or better intelligence tier.
-    "grok-4.3": {"input_per_1m": 1.25, "output_per_1m": 2.50},
+    # reasoning, 1M context. Prefer over 4.5 for daily digests (cheaper +
+    # larger context); 4.5 is opt-in for hard agentic paths.
+    "grok-4.3": {
+        "input_per_1m": 1.25,
+        "output_per_1m": 2.50,
+        "cached_input_per_1m": 0.20,
+    },
+    # Grok 4.5 (July 16 2026) — frontier coding/agentic. Higher unit cost,
+    # 500k context, reasoning_effort low|medium|high (default high).
+    # Wired for selective use; do NOT flip network digest default without
+    # a measured A/B (landmine #17 for any prompt-quality change).
+    "grok-4.5": {
+        "input_per_1m": 2.00,
+        "output_per_1m": 6.00,
+        "cached_input_per_1m": 0.30,
+    },
     # Grok 4 (legacy refusal fallback — retained because older
     # credit_usage JSONs still report it, and _estimate_grok_cost may be
     # re-run against them).
@@ -117,13 +135,28 @@ def record_refusal_fallback(tracker: dict, stage: str, model: str) -> None:
 
 
 def _estimate_grok_cost(
-    model: str, prompt_tokens: int, completion_tokens: int
+    model: str,
+    prompt_tokens: int,
+    completion_tokens: int,
+    cached_tokens: int = 0,
 ) -> float:
-    """Estimate cost for a Grok API call based on model pricing."""
+    """Estimate cost for a Grok API call based on model pricing.
+
+    When *cached_tokens* > 0 and the model row has ``cached_input_per_1m``,
+    those tokens are billed at the cached rate and the remainder of
+    *prompt_tokens* at the full input rate (xAI prompt-cache accounting).
+    """
     pricing = GROK_PRICING.get(model)
     if not pricing:
         return 0.0
-    input_cost = (prompt_tokens / 1_000_000) * pricing["input_per_1m"]
+    cached = max(0, min(int(cached_tokens or 0), int(prompt_tokens or 0)))
+    uncached = max(0, int(prompt_tokens or 0) - cached)
+    cached_rate = pricing.get("cached_input_per_1m")
+    if cached and cached_rate is not None:
+        input_cost = (uncached / 1_000_000) * pricing["input_per_1m"]
+        input_cost += (cached / 1_000_000) * float(cached_rate)
+    else:
+        input_cost = (prompt_tokens / 1_000_000) * pricing["input_per_1m"]
     output_cost = (completion_tokens / 1_000_000) * pricing["output_per_1m"]
     return input_cost + output_cost
 
@@ -143,12 +176,8 @@ def record_llm_usage(
     ``"podcast_script_generation"``.
 
     If *estimated_cost_usd* is 0 and *model* is provided, cost is
-    estimated from the Grok pricing table.
-
-    *cached_tokens* (optional) is the prompt-cache hit count from xAI
-    ``usage.prompt_tokens_details.cached_tokens``. Tracked for telemetry;
-    cost estimation still uses full prompt_tokens until cached pricing
-    is wired into ``GROK_PRICING``.
+    estimated from the Grok pricing table (including cached-input rates
+    when *cached_tokens* is reported).
     """
     grok = tracker["services"]["grok_api"]
     if model:
@@ -176,7 +205,7 @@ def record_llm_usage(
         grok[step]["estimated_cost_usd"] += estimated_cost_usd
     elif model:
         grok[step]["estimated_cost_usd"] += _estimate_grok_cost(
-            model, prompt_tokens, completion_tokens
+            model, prompt_tokens, completion_tokens, cached_tokens=cached_tokens
         )
 
 

--- a/management.html
+++ b/management.html
@@ -8,6 +8,9 @@
 <meta name="robots" content="noindex,follow">
 <link rel="canonical" href="https://nerranetwork.com/management.html">
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><circle cx='50' cy='50' r='6' fill='%236B47FF'/><circle cx='20' cy='30' r='4' fill='%2300D4FF'/><circle cx='80' cy='30' r='4' fill='%2300D4FF'/><circle cx='25' cy='75' r='4' fill='%2300D4FF'/><circle cx='75' cy='75' r='4' fill='%2300D4FF'/></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles/main.css">
 <style>
   /* ---- design tokens (dark; validated against surface #161a24) ---- */
@@ -30,13 +33,18 @@
     --accent: #6B47FF;
   }
   .mc-root { max-width: 1280px; margin: 0 auto; padding: 28px 24px 72px;
-    font-family: system-ui, -apple-system, "Segoe UI", sans-serif; }
+    font-family: "IBM Plex Sans", "Source Sans 3", system-ui, -apple-system, "Segoe UI", sans-serif;
+    background:
+      radial-gradient(1200px 420px at 8% -10%, rgba(107, 71, 255, 0.14), transparent 55%),
+      radial-gradient(900px 360px at 92% 0%, rgba(0, 212, 255, 0.08), transparent 50%),
+      transparent; }
 
   /* ---- header ---- */
   .mc-header { display: flex; align-items: flex-end; justify-content: space-between;
     gap: 16px; flex-wrap: wrap; margin-bottom: 6px; }
-  .mc-header h1 { margin: 0; font-size: 26px; letter-spacing: -0.01em; color: var(--ink-1); }
-  .mc-header .subtitle { color: var(--ink-3); font-size: 13px; margin-top: 4px; }
+  .mc-header h1 { margin: 0; font-size: 26px; letter-spacing: -0.02em; color: var(--ink-1);
+    font-weight: 650; }
+  .mc-header .subtitle { color: var(--ink-3); font-size: 13px; margin-top: 4px; max-width: 52ch; }
   .health-pills { display: inline-flex; gap: 8px; align-items: center; flex-wrap: wrap; }
   .pill { display: inline-flex; gap: 6px; align-items: center; padding: 4px 11px;
     border-radius: 999px; font-size: 12.5px; font-weight: 600; border: 1px solid transparent; }
@@ -60,12 +68,15 @@
   /* ---- hero stat tiles ---- */
   .tile-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 12px; margin-bottom: 28px; }
-  .tile { background: var(--surface-1); border: 1px solid var(--hairline);
-    border-radius: 14px; padding: 14px 16px 12px; min-width: 0; }
+  .tile { background: linear-gradient(180deg, rgba(255,255,255,0.02), transparent 40%),
+    var(--surface-1); border: 1px solid var(--hairline);
+    border-radius: 14px; padding: 14px 16px 12px; min-width: 0;
+    transition: border-color 160ms ease, transform 160ms ease; }
+  .tile:hover { border-color: #2f3748; transform: translateY(-1px); }
   .tile .t-label { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em;
     color: var(--ink-3); }
   .tile .t-value { font-size: 27px; font-weight: 600; color: var(--ink-1); margin-top: 5px;
-    line-height: 1.1; }
+    line-height: 1.1; font-variant-numeric: tabular-nums; }
   .tile .t-sub { font-size: 12px; color: var(--ink-3); margin-top: 5px; }
   .tile .t-delta { font-size: 12px; font-weight: 600; margin-left: 6px; }
   .tile .t-delta.up { color: var(--status-ok); }
@@ -147,10 +158,24 @@
     flex-shrink: 0; }
   .show-card h3 { margin: 0; font-size: 15px; }
   .show-card .slug { font-size: 10.5px; color: var(--ink-4); font-family: ui-monospace, monospace; }
-  .show-card .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
+  .show-card .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px;
     margin: 10px 0 6px; font-size: 11.5px; color: var(--ink-3); }
-  .show-card .stats div { background: var(--surface-2); padding: 7px 10px; border-radius: 8px; }
-  .show-card .stats strong { display: block; font-size: 14px; color: var(--ink-1); }
+  @media (min-width: 720px) {
+    .show-card .stats { grid-template-columns: repeat(6, 1fr); }
+  }
+  .show-card .stats div { background: var(--surface-2); padding: 7px 8px; border-radius: 8px; }
+  .show-card .stats strong { display: block; font-size: 13px; color: var(--ink-1);
+    font-variant-numeric: tabular-nums; }
+  .show-card .stats span.stat-label { font-size: 10px; color: var(--ink-4);
+    text-transform: uppercase; letter-spacing: 0.04em; }
+  .eff-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px;
+    margin: 8px 0 12px; }
+  .eff-cell { background: var(--surface-2); border-radius: 10px; padding: 10px 12px; }
+  .eff-cell .eff-n { font-size: 18px; font-weight: 600; color: var(--ink-1);
+    font-variant-numeric: tabular-nums; }
+  .eff-cell .eff-l { font-size: 11px; color: var(--ink-4); margin-top: 2px;
+    text-transform: uppercase; letter-spacing: 0.04em; }
+  .platform-note { font-size: 12px; color: var(--ink-4); margin: 0 0 8px; line-height: 1.4; }
   .show-card .links { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 8px; font-size: 12px; }
   .show-card .links a { color: #818cf8; text-decoration: none; }
   .show-card .links a:hover { text-decoration: underline; }
@@ -184,6 +209,7 @@
   <div>
     <h1>Nerra Network — Mission Control</h1>
     <div class="subtitle" id="generated-at">Loading dashboard data…</div>
+    <div class="subtitle" style="margin-top:2px;">RSS downloads · Spotify · Apple · YouTube · site · spend — side by side, never one fake “reach” number.</div>
   </div>
   <div class="health-pills" id="status-summary" hidden>
     <span class="pill ok"><span id="count-ok">0</span>&nbsp;OK</span>
@@ -463,6 +489,7 @@
   const sp = audience.spotify || {};
   const bd = audience.newsletter || {};
   const cost = data.cost_rollup || {};
+  const eff = data.efficiency || {};
   const catalog = data.catalog || {};
   const gallery = data.gallery || {};
   const lake = data.content_lake || {};
@@ -493,19 +520,25 @@
   const siteSpark = (site.day_series || []).map((r) => Number(r.activeUsers || 0));
 
   const weeklyHist = (op3.network_weekly_history || []).map((r) => Number(r[1] || 0));
+  const allTimeSub = op3.all_time_incomplete
+    ? "incomplete history (below 30d) · since " + (op3.all_time_since || "?")
+    : ((op3.all_time_since ? "tracked since " + op3.all_time_since + " · " : "") + "via OP3");
   tiles.appendChild(statTile("RSS downloads · all-time", compact(op3.network_downloads_all_time),
-    { sub: (op3.all_time_since ? "tracked since " + op3.all_time_since + " · " : "") + "via OP3",
+    { sub: allTimeSub,
       spark: weeklyHist,
       sparkTitle: "Weekly downloads since " + (op3.all_time_since || "tracking began") }));
   tiles.appendChild(statTile("RSS downloads · 30d", compact(op3.network_downloads_30d),
     { sub: fmt(op3.network_downloads_7d) + " in the last 7d · via OP3" }));
-  tiles.appendChild(statTile("Shows", fmt(catalog.shows_count || (data.network || {}).shows_count),
-    { sub: fmt(catalog.network_episodes_to_date) + " episodes to date · " +
-           fmt(catalog.network_news_sources) + " news sources" }));
+  tiles.appendChild(statTile("Spotify streams · 30d",
+    sp.configured ? compact((sp.totals || {}).streams) : "—",
+    { sub: sp.configured
+        ? fmt((sp.totals || {}).listeners) + " listeners · " +
+          fmt(sp.feeds_reporting || 0) + "/" + fmt(sp.feeds_registered || 0) + " feeds"
+        : "not configured" }));
   tiles.appendChild(statTile("YouTube subscribers", compact(chSum("subscribers")),
     { delta: chSum("subscribers_delta_7d"), deltaSuffix: " · 7d",
-      sub: compact(chSum("total_views")) + " total views · " +
-           Object.keys(yt.channels || {}).length + " channels" }));
+      sub: compact(yt.network_views != null ? yt.network_views : chSum("total_views")) +
+           " video views · " + Object.keys(yt.channels || {}).length + " channels" }));
   tiles.appendChild(statTile("Site active users · 28d",
     site.configured && site.totals ? compact(site.totals.active_users) : "—",
     { sub: site.configured && site.totals
@@ -514,10 +547,13 @@
       spark: siteSpark,
       sparkTitle: "Daily active users, last " + siteSpark.length + " days" }));
   tiles.appendChild(statTile("Spend · 7d", money(data.network.total_cost_last_7_days_usd),
-    { sub: money(data.network.total_cost_last_30_days_usd) + " · 30d · projected " +
-           money((cost.projections || {}).projected_weekly_usd) + "/wk" }));
+    { sub: money(data.network.total_cost_last_30_days_usd) + " · 30d · " +
+           (eff.usd_per_op3_download_7d != null
+             ? ("$" + Number(eff.usd_per_op3_download_7d).toFixed(3) + "/RSS dl")
+             : (money((cost.projections || {}).projected_weekly_usd) + "/wk burn")) }));
   tiles.appendChild(statTile("Episodes · 7d", fmt((cost.network_last_7_days || {}).episodes),
-    { sub: money((cost.projections || {}).avg_cost_per_episode_usd) + " avg / episode" }));
+    { sub: money((cost.projections || {}).avg_cost_per_episode_usd) + " avg / episode · " +
+           fmt(catalog.shows_count || (data.network || {}).shows_count) + " shows" }));
   tiles.appendChild(statTile("Newsletter", bd.configured ? fmt(bd.subscriber_count) : "—",
     { sub: bd.configured ? "subscribers · Buttondown" : "not configured" }));
   tiles.appendChild(statTile("Image library", gallery.configured ? compact(gallery.image_count) : "—",
@@ -544,6 +580,11 @@
         html: fmt(op3.network_downloads_all_time) + "<small>all-time</small>" +
               "&nbsp;&nbsp;" + fmt(op3.network_downloads_30d) + "<small>30d</small>" +
               "&nbsp;&nbsp;" + fmt(op3.network_downloads_7d) + "<small>7d</small>" }));
+      if (op3.all_time_incomplete) {
+        card.appendChild(h("p", { class: "platform-note", text:
+          "All-time is still accumulating (tracked since " + (op3.all_time_since || "?") +
+          ") and can read below the rolling 30d window until history catches up." }));
+      }
       if (weeklyHist.length > 1) {
         const sparkWrap = h("div", { style: "margin:6px 0 2px;" });
         const sv = sparkline(weeklyHist, { w: 560, h: 40, title: "Weekly downloads, all tracked weeks" });
@@ -598,6 +639,23 @@
           (delta != null ? " (" + (delta >= 0 ? "+" : "") + delta + " · 7d)" : ""),
           { title: chName(ch) + ": " + fmt(c.total_views || 0) + " total views · " + fmt(c.video_count || 0) + " videos" }));
       });
+      const ytPer = yt.per_show || {};
+      const ytSlugs = Object.keys(ytPer)
+        .sort((a, b) => (ytPer[b].views || 0) - (ytPer[a].views || 0));
+      if (ytSlugs.length) {
+        card.appendChild(h("div", { style: "margin-top:12px;font-size:11px;color:var(--ink-4);text-transform:uppercase;letter-spacing:0.05em;",
+          text: "Views by show · " + (yt.window_days || 90) + "d Analytics window" }));
+        const maxV = Math.max.apply(null, ytSlugs.map((s) => ytPer[s].views || 0).concat([1]));
+        ytSlugs.slice(0, 10).forEach((slug) => {
+          const v = ytPer[slug] || {};
+          card.appendChild(barRow(slug, v.views || 0, maxV,
+            fmt(v.views || 0) + " views · " +
+            (v.avg_view_percentage != null ? v.avg_view_percentage + "% ret" : "—"),
+            { color: "var(--series-2)",
+              title: slug + ": long " + fmt(v.long_views || 0) + " · shorts " +
+                     fmt(v.short_views || 0) + " · +" + fmt(v.subscribers_gained || 0) + " subs" }));
+        });
+      }
       const ul = h("ul", { class: "fine-list" });
       (yt.top_subscriber_videos || []).slice(0, 5).forEach((v) => {
         ul.appendChild(h("li", { html:
@@ -667,6 +725,15 @@
               "plays and completion — the only finish-rate signal the network gets." }));
     } else if (ap.error) {
       card.appendChild(h("p", { class: "fine-list", text: "Apple error: " + ap.error }));
+    } else if (!(ap.feeds_reporting > 0)) {
+      card.appendChild(h("div", { class: "headline",
+        html: "—<small>not reporting</small>" }));
+      card.appendChild(h("p", { class: "platform-note", text:
+        "0 of " + fmt(ap.feeds_registered || 0) + " registered shows returned engagement. " +
+        "This is a connector/cookie problem — not zero listener interest. " +
+        "Apple downloads still flow through OP3 above." }));
+      if (ap.fetched_at) card.appendChild(h("p", { class: "fine-list",
+        text: "fetched " + ageText(ap.fetched_at) + staleNote(ap.fetched_at) }));
     } else {
       const t = ap.totals || {};
       card.appendChild(h("div", { class: "headline",
@@ -692,6 +759,65 @@
       }
       if (ap.fetched_at) card.appendChild(h("p", { class: "fine-list",
         text: "fetched " + ageText(ap.fetched_at) + staleNote(ap.fetched_at) }));
+    }
+    audGrid.appendChild(card);
+  }
+
+  // Unit economics — cost vs each platform (never summed)
+  {
+    const card = sectionCard("Unit economics", "Grok+TTS vs listening · not one reach number");
+    if (!eff || eff.cost_7d_usd == null) {
+      card.appendChild(h("p", { class: "fine-list", text: "Efficiency rollup not in this dashboard.json yet — regenerate." }));
+    } else {
+      const grid = h("div", { class: "eff-grid" });
+      const cells = [
+        [money(eff.cost_7d_usd), "spend · 7d"],
+        [eff.usd_per_op3_download_7d != null
+          ? ("$" + Number(eff.usd_per_op3_download_7d).toFixed(3)) : "—",
+          "$ / RSS download · 7d"],
+        [fmt(eff.op3_downloads_7d), "RSS downloads · 7d"],
+        [fmt(eff.spotify_streams_30d), "Spotify streams · 30d"],
+        [fmt(eff.youtube_views_window), "YouTube views · " + (eff.youtube_window_days || 90) + "d"],
+        [eff.usd_per_yt_view != null
+          ? ("$" + Number(eff.usd_per_yt_view).toFixed(3)) : "—",
+          "$ / YT view (directional)"],
+      ];
+      cells.forEach(([n, l]) => {
+        const cell = h("div", { class: "eff-cell" });
+        cell.appendChild(h("div", { class: "eff-n", text: String(n) }));
+        cell.appendChild(h("div", { class: "eff-l", text: l }));
+        grid.appendChild(cell);
+      });
+      card.appendChild(grid);
+      card.appendChild(h("p", { class: "platform-note", text: eff.note ||
+        "Platform metrics stay separate — never sum OP3 + Spotify + YouTube." }));
+      const per = eff.per_show || {};
+      const ranked = Object.keys(per)
+        .filter((s) => (per[s].op3_downloads_7d || 0) > 0 || (per[s].cost_7d_usd || 0) > 0)
+        .sort((a, b) => {
+          const ua = per[a].usd_per_op3_download;
+          const ub = per[b].usd_per_op3_download;
+          if (ua == null && ub == null) return 0;
+          if (ua == null) return 1;
+          if (ub == null) return -1;
+          return ua - ub;
+        });
+      if (ranked.length) {
+        card.appendChild(h("div", { style: "margin-top:8px;font-size:11px;color:var(--ink-4);text-transform:uppercase;letter-spacing:0.05em;",
+          text: "Best $/RSS-download · 7d (lower is better)" }));
+        const maxCost = Math.max.apply(null,
+          ranked.map((s) => per[s].usd_per_op3_download || 0).concat([0.001]));
+        ranked.slice(0, 8).forEach((slug) => {
+          const v = per[slug];
+          const rate = v.usd_per_op3_download;
+          card.appendChild(barRow(slug, rate == null ? 0 : rate, maxCost,
+            (rate == null ? "—" : ("$" + Number(rate).toFixed(3))) +
+            " · " + fmt(v.op3_downloads_7d) + " dl · " + money(v.cost_7d_usd),
+            { color: "var(--series-3)",
+              title: slug + ": YT " + fmt(v.youtube_views || 0) + " views · Spotify " +
+                     fmt(v.spotify_streams_30d || 0) + " streams" }));
+        });
+      }
     }
     audGrid.appendChild(card);
   }
@@ -1023,9 +1149,21 @@
     }
     const proj = cost.projections || {};
     card.appendChild(h("p", { class: "fine-list", html:
-      "<span class='k'>" + fmt(n7.episodes) + "</span> episodes · 7d — avg <span class='k'>" +
-      money(proj.avg_cost_per_episode_usd) + "</span>/episode, projected <span class='k'>" +
-      money(proj.projected_weekly_usd) + "</span>/week" }));
+      "<span class='k'>" + fmt(n7.episodes) + "</span> credit files · 7d — avg <span class='k'>" +
+      money(proj.avg_cost_per_episode_usd) + "</span>/file · trailing burn <span class='k'>" +
+      money(proj.projected_weekly_usd) + "</span>/week" +
+      (proj.projected_monthly_usd != null
+        ? (" · <span class='k'>" + money(proj.projected_monthly_usd) + "</span>/30d")
+        : "") }));
+    if (eff.usd_per_op3_download_7d != null) {
+      card.appendChild(h("p", { class: "fine-list", html:
+        "Unit cost: <span class='k'>$" + Number(eff.usd_per_op3_download_7d).toFixed(3) +
+        "</span> per RSS download · 7d" +
+        (eff.usd_per_yt_view != null
+          ? (" · <span class='k'>$" + Number(eff.usd_per_yt_view).toFixed(3) +
+             "</span> per YT view (mismatched windows — directional)")
+          : "") }));
+    }
     const quota = cost.youtube_quota || {};
     if (quota.note) {
       card.appendChild(h("p", { class: "fine-list", html:
@@ -1152,6 +1290,9 @@
   const showGrid = $("#shows-grid");
   const shows = (data.network && data.network.shows) || [];
   const op3PerShow = op3.per_show || {};
+  const effPerShow = eff.per_show || {};
+  const ytPerShow = yt.per_show || {};
+  const spPerShow = sp.per_show || {};
   // Prefer rss_image from api/dashboard.json (single source of truth with
   // network_meta / show YAML). Hardcoded cover map kept only as fallback
   // for older dashboard.json blobs missing the field.
@@ -1188,17 +1329,33 @@
     card.appendChild(head);
 
     const dl = op3PerShow[s.slug] || {};
+    const eRow = effPerShow[s.slug] || {};
+    const yRow = ytPerShow[s.slug] || {};
+    const sRow = spPerShow[s.slug] || {};
     const cat = (catalog.per_show || {})[s.slug] || {};
     const stats = h("div", { class: "stats" });
-    stats.appendChild(h("div", { html:
-      "<strong>" + fmt(cat.episodes_to_date || 0) + "</strong>episodes" }));
-    stats.appendChild(h("div", { html:
-      "<strong>" + (s.episodes_last_7_days || 0) + "</strong>ep · 7d" }));
-    stats.appendChild(h("div", { html:
-      "<strong>" + money(s.cost_last_7_days_usd) + "</strong>cost · 7d" }));
-    stats.appendChild(h("div", { html:
-      "<strong>" + fmt(dl.downloads_7d || 0) + "</strong>dl · 7d" }));
+    const addStat = (value, label) => {
+      stats.appendChild(h("div", { html:
+        "<strong>" + value + "</strong><span class='stat-label'>" + label + "</span>" }));
+    };
+    addStat(fmt(cat.episodes_to_date || 0), "episodes");
+    addStat(String(s.episodes_last_7_days || 0), "ep · 7d");
+    addStat(money(s.cost_last_7_days_usd), "cost · 7d");
+    addStat(fmt(dl.downloads_7d || 0), "RSS · 7d");
+    addStat(fmt(yRow.views || eRow.youtube_views || 0), "YT views");
+    addStat(
+      (sRow.streams != null ? fmt(sRow.streams) :
+        (eRow.spotify_streams_30d != null ? fmt(eRow.spotify_streams_30d) : "—")),
+      "Spotify");
     card.appendChild(stats);
+    if (eRow.usd_per_op3_download != null) {
+      card.appendChild(h("div", { class: "meta-line", html:
+        "$/RSS dl · 7d: <strong>$" + Number(eRow.usd_per_op3_download).toFixed(3) +
+        "</strong>" +
+        (yRow.avg_view_percentage != null
+          ? (" · YT retention <strong>" + yRow.avg_view_percentage + "%</strong>")
+          : "") }));
+    }
 
     const pubStatus = s.pub_status || "unknown";
     const pubColor = pubStatus === "ok" ? "var(--status-ok)" :

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1203,13 +1203,15 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
         for k in ("grok", "tts", "total"):
             bucket[k] = round(bucket[k], 4)
 
-    # Quick-win enhancements (May 2026 codebase review):
-    # - Simple projection so operators see "at current burn rate, what does a week cost?"
-    # - Surface for future live YT quota remaining (engine.youtube_quota already exists).
-    episodes_7 = max(network_7.get("episodes", 0), 1)
-    avg_per_episode = round(network_7["total"] / episodes_7, 4)
-    # Conservative: network ships ~70-80 episodes/week across 12 shows
-    projected_weekly = round(avg_per_episode * 65, 2)
+    # Projection = actual last-7d burn (honest "current weekly rate").
+    # Previously multiplied avg × 65, which understated spend when the
+    # network ships ~100–150 credit_usage files/week (July 2026).
+    episodes_7 = int(network_7.get("episodes", 0) or 0)
+    avg_per_episode = (
+        round(network_7["total"] / episodes_7, 4) if episodes_7 else 0.0
+    )
+    projected_weekly = round(network_7["total"], 2)
+    projected_monthly = round(network_30["total"], 2)
 
     return {
         "per_show": per_show,
@@ -1218,7 +1220,13 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
         "projections": {
             "avg_cost_per_episode_usd": avg_per_episode,
             "projected_weekly_usd": projected_weekly,
-            "note": "Projection uses last-7d average × 65 (network volume). Tune per operator knowledge.",
+            "projected_monthly_usd": projected_monthly,
+            "episodes_7d": episodes_7,
+            "note": (
+                "Weekly projection = actual last-7d Grok+TTS spend "
+                f"({episodes_7} credit_usage files). Monthly = last-30d total. "
+                "Not a calendar forecast — a trailing burn rate."
+            ),
         },
         "youtube_quota": {
             "enabled_shows_count": sum(
@@ -1747,6 +1755,9 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
 
     alerts = extract_critical_alerts(landmines, costs)
 
+    audience = build_audience_section(root)
+    efficiency = build_efficiency_section(costs, audience)
+
     return {
         "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "network": network,
@@ -1759,7 +1770,8 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "pipeline_health": metrics,
         "rss_audit": rss,
         "mit_performance": aggregate_mit_performance(root),
-        "audience": build_audience_section(root),
+        "audience": audience,
+        "efficiency": efficiency,
         "catalog": build_catalog_section(root, shows, rss),
         "gallery": build_gallery_section(root),
         "content_lake": build_content_lake_section(root),
@@ -1910,15 +1922,20 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
                 key=lambda e: e["downloads_7d"],
                 reverse=True,
             )[:5]
+            d30 = sum(v["downloads_30d"] for v in per_show.values())
+            d7 = sum(v["downloads_7d"] for v in per_show.values())
+            all_time = int(history["network_total"] or 0)
             section["op3"] = {
                 "configured": True,
                 "fetched_at": data.get("fetched_at"),
-                "network_downloads_30d": sum(
-                    v["downloads_30d"] for v in per_show.values()),
-                "network_downloads_7d": sum(
-                    v["downloads_7d"] for v in per_show.values()),
-                "network_downloads_all_time": history["network_total"],
+                "network_downloads_30d": d30,
+                "network_downloads_7d": d7,
+                "network_downloads_all_time": all_time,
                 "all_time_since": history["since"],
+                # History tracking began mid-2026 — all-time can read BELOW
+                # the rolling 30d window until enough weeks accumulate.
+                "all_time_incomplete": bool(
+                    all_time and d30 and all_time < d30),
                 "network_weekly_downloads": network_weekly,
                 "network_weekly_history": history["network_series"],
                 "per_show": per_show,
@@ -2004,12 +2021,59 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
                 key=lambda r: r["subscribers_gained"],
                 reverse=True,
             )[:5]
-            if per_channel or top_converters:
+            # Per-show rollup (90d Analytics window). Videos already carry
+            # show_slug; fall back to digest-dir → YAML slug (tesla_shorts_time
+            # → tesla) so Mission Control can show YT next to OP3/Spotify.
+            dir_to_slug = {v: k for k, v in _SHOW_DIR_OVERRIDES.items()}
+            yt_per_show: Dict[str, Dict[str, Any]] = {}
+            for dir_name, s in (data.get("shows") or {}).items():
+                for v in s.get("videos") or []:
+                    if not isinstance(v, dict):
+                        continue
+                    slug = str(v.get("show_slug") or "").strip() or str(dir_name)
+                    if slug in dir_to_slug:
+                        slug = dir_to_slug[slug]
+                    if slug == "tesla_shorts_time":
+                        slug = "tesla"
+                    bucket = yt_per_show.setdefault(slug, {
+                        "views": 0,
+                        "subscribers_gained": 0,
+                        "subscribers_lost": 0,
+                        "video_count": 0,
+                        "long_views": 0,
+                        "short_views": 0,
+                        "_ret": [],
+                    })
+                    views = int(v.get("views") or 0)
+                    bucket["views"] += views
+                    bucket["subscribers_gained"] += int(
+                        v.get("subscribers_gained") or 0)
+                    bucket["subscribers_lost"] += int(
+                        v.get("subscribers_lost") or 0)
+                    bucket["video_count"] += 1
+                    kind = str(v.get("kind") or "").lower()
+                    if kind == "long":
+                        bucket["long_views"] += views
+                    elif "short" in kind:
+                        bucket["short_views"] += views
+                    avp = v.get("average_view_percentage")
+                    if isinstance(avp, (int, float)):
+                        bucket["_ret"].append(float(avp))
+            for slug, bucket in yt_per_show.items():
+                rets = bucket.pop("_ret", [])
+                bucket["avg_view_percentage"] = (
+                    round(sum(rets) / len(rets), 1) if rets else None
+                )
+            if per_channel or top_converters or yt_per_show:
                 section["youtube"] = {
                     "configured": True,
                     "generated": data.get("generated"),
+                    "window_days": data.get("window_days") or 90,
                     "channels": per_channel,
                     "top_subscriber_videos": top_converters,
+                    "per_show": yt_per_show,
+                    "network_views": sum(
+                        v["views"] for v in yt_per_show.values()),
                 }
         except Exception as exc:  # noqa: BLE001
             section["youtube"] = {"configured": True, "error": str(exc)}
@@ -2157,6 +2221,104 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
             section["spotify"] = {"configured": True, "error": str(exc)}
 
     return section
+
+
+def build_efficiency_section(
+    costs: Dict[str, Any],
+    audience: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Unit economics across OP3 / YouTube / Spotify — never summed as reach.
+
+    Mission Control historically over-weighted YouTube subscriber tiles and
+    understated podcast downloads + cost-per-listen. This section puts
+    trailing spend next to each platform's own metric so operators can see
+    which shows earn their Grok+TTS bill without inventing a fake "total
+    reach" number (forbidden by docs/analytics.md).
+    """
+    op3 = audience.get("op3") or {}
+    yt = audience.get("youtube") or {}
+    sp = audience.get("spotify") or {}
+    ap = audience.get("apple") or {}
+    n7 = costs.get("network_last_7_days") or {}
+    cost7 = float(n7.get("total") or 0.0)
+    eps7 = int(n7.get("episodes") or 0)
+    dl7 = int(op3.get("network_downloads_7d") or 0)
+    dl30 = int(op3.get("network_downloads_30d") or 0)
+    yt_views = int(yt.get("network_views") or 0)
+    if not yt_views and isinstance(yt.get("per_show"), dict):
+        yt_views = sum(int(v.get("views") or 0) for v in yt["per_show"].values())
+    sp_totals = sp.get("totals") or {}
+    sp_streams = int(sp_totals.get("streams") or 0)
+    sp_listeners = int(sp_totals.get("listeners") or 0)
+    ap_totals = ap.get("totals") or {}
+    ap_reporting = int(ap.get("feeds_reporting") or 0)
+
+    slugs = set()
+    for block in (
+        (op3.get("per_show") or {}),
+        (costs.get("per_show") or {}),
+        (yt.get("per_show") or {}),
+        (sp.get("per_show") or {}),
+    ):
+        slugs.update(block.keys())
+
+    per_show: Dict[str, Dict[str, Any]] = {}
+    for slug in sorted(slugs):
+        # Skip Spotify language variants in the show-card join (fascinating_frontiers_ru)
+        if "_" in slug and slug.rsplit("_", 1)[-1] in ("ru", "fr", "es", "zh"):
+            base = slug.rsplit("_", 1)[0]
+            if base in slugs or base in (op3.get("per_show") or {}):
+                continue
+        c7 = ((costs.get("per_show") or {}).get(slug) or {}).get("last_7_days") or {}
+        o = (op3.get("per_show") or {}).get(slug) or {}
+        y = (yt.get("per_show") or {}).get(slug) or {}
+        s = (sp.get("per_show") or {}).get(slug) or {}
+        cost_s = float(c7.get("total") or 0.0)
+        dl = int(o.get("downloads_7d") or 0)
+        views = int(y.get("views") or 0)
+        streams = s.get("streams")
+        streams_n = int(streams) if isinstance(streams, (int, float)) else 0
+        per_show[slug] = {
+            "cost_7d_usd": round(cost_s, 4),
+            "op3_downloads_7d": dl,
+            "op3_downloads_30d": int(o.get("downloads_30d") or 0),
+            "usd_per_op3_download": (
+                round(cost_s / dl, 4) if dl > 0 else None
+            ),
+            "youtube_views": views,
+            "youtube_avg_view_pct": y.get("avg_view_percentage"),
+            "youtube_subs_gained": int(y.get("subscribers_gained") or 0),
+            "usd_per_yt_view": (
+                round(cost_s / views, 4) if views > 0 else None
+            ),
+            "spotify_streams_30d": streams_n or None,
+        }
+
+    return {
+        "cost_7d_usd": round(cost7, 4),
+        "episodes_7d": eps7,
+        "op3_downloads_7d": dl7,
+        "op3_downloads_30d": dl30,
+        "usd_per_op3_download_7d": (
+            round(cost7 / dl7, 4) if dl7 > 0 else None
+        ),
+        "youtube_views_window": yt_views,
+        "youtube_window_days": yt.get("window_days") or 90,
+        "usd_per_yt_view": (
+            round(cost7 / yt_views, 4) if yt_views > 0 else None
+        ),
+        "spotify_streams_30d": sp_streams,
+        "spotify_listeners_30d": sp_listeners,
+        "apple_feeds_reporting": ap_reporting,
+        "apple_plays_30d": int(ap_totals.get("plays") or 0) if ap_reporting else None,
+        "note": (
+            "Platform metrics are side-by-side and never summed into one "
+            "reach number. $/OP3-download uses 7d cost ÷ 7d RSS downloads; "
+            "$/YT-view uses 7d cost ÷ Analytics window views (usually 90d) "
+            "— directional only across mismatched windows."
+        ),
+        "per_show": per_show,
+    }
 
 
 def build_youtube_policy_section(root: Path) -> Dict[str, Any]:

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -36,6 +36,12 @@ llm:
   reviewer_model: grok-4-1-fast-non-reasoning
   reviewer_max_tokens: 1500
   reviewer_temperature: 0.3
+  # Optional (July 2026): set to low|medium|high only when using a model
+  # that honors reasoning_effort (e.g. grok-4.5). Empty = omit param —
+  # daily shows stay on grok-4.3 without the extra dial. Keep unset for
+  # digest/podcast until a measured trial; safe first targets are
+  # reviewer / synth / tool-heavy fetch.
+  # reasoning_effort: ""
 
 tts:
   # Network default since May 2026: xAI Grok TTS at $4.20/M chars

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -643,3 +643,163 @@ class TestAppleAnalytics:
         assert "api/apple_stats.json" in wf.split("add-paths")[1]
         # And must run BEFORE the dashboard build that consumes it.
         assert wf.find("fetch_apple_stats.py") < wf.find("generate_dashboard.py")
+
+
+# ---------------------------------------------------------------------------
+# July 26 2026 — multi-platform efficiency + cost projection honesty
+# ---------------------------------------------------------------------------
+
+
+class TestEfficiencyAndProjection:
+    def test_projected_weekly_equals_trailing_7d_spend(self, tmp_path):
+        """Projection must NOT multiply by a hard-coded 65 episode volume."""
+        shows_dir = tmp_path / "shows"
+        shows_dir.mkdir()
+        (shows_dir / "_defaults.yaml").write_text(
+            "llm: {model: grok-4.3}\ntts: {provider: grok, voice_id: x}\n"
+            "publishing: {}\nnewsletter: {enabled: false}\nyoutube: {enabled: false}\n",
+            encoding="utf-8",
+        )
+        (shows_dir / "demo.yaml").write_text(
+            "slug: demo\nname: Demo\n"
+            "episode:\n  output_dir: digests/demo\n  prefix: Demo\n"
+            "publishing:\n  rss_file: demo.rss\n  summaries_json: digests/demo/summaries.json\n",
+            encoding="utf-8",
+        )
+        ddir = tmp_path / "digests" / "demo"
+        ddir.mkdir(parents=True)
+        # Two usage files in the last 7 days → total $2.00
+        import datetime as _dt
+        today = _dt.date.today().isoformat()
+        for i, total in enumerate((1.25, 0.75), start=1):
+            (ddir / f"credit_usage_{today}_ep{i:03d}.json").write_text(
+                json.dumps({
+                    "date": today,
+                    "episode_number": i,
+                    "total_estimated_cost_usd": total,
+                    "services": {
+                        "grok_api": {"total_cost_usd": total * 0.8},
+                        "tts_api": {"estimated_cost_usd": total * 0.2},
+                    },
+                }),
+                encoding="utf-8",
+            )
+        shows = gd.load_shows_from_yaml(shows_dir, tmp_path)
+        costs = gd.aggregate_costs(tmp_path, shows)
+        assert costs["network_last_7_days"]["total"] == pytest.approx(2.0)
+        assert costs["projections"]["projected_weekly_usd"] == pytest.approx(2.0)
+        assert costs["projections"]["episodes_7d"] == 2
+        # Guard against the old ×65 understatement returning.
+        assert costs["projections"]["projected_weekly_usd"] != pytest.approx(
+            costs["projections"]["avg_cost_per_episode_usd"] * 65
+        )
+
+    def test_youtube_per_show_joins_digest_dir_to_slug(self, tmp_path):
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "youtube_stats.json").write_text(json.dumps({
+            "schema_version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "window_days": 90,
+            "channels": {"en": {"subscribers": 10, "total_views": 100,
+                                "video_count": 2}},
+            "shows": {
+                "tesla_shorts_time": {
+                    "videos": [
+                        {"show_slug": "tesla", "kind": "long", "views": 40,
+                         "subscribers_gained": 2, "subscribers_lost": 0,
+                         "average_view_percentage": 50.0, "title": "A"},
+                        {"show_slug": "tesla", "kind": "short", "views": 60,
+                         "subscribers_gained": 1, "subscribers_lost": 0,
+                         "average_view_percentage": 30.0, "title": "B"},
+                    ],
+                },
+            },
+        }), encoding="utf-8")
+        yt = gd.build_audience_section(tmp_path)["youtube"]
+        assert yt["configured"] is True
+        assert "tesla" in yt["per_show"]
+        assert "tesla_shorts_time" not in yt["per_show"]
+        row = yt["per_show"]["tesla"]
+        assert row["views"] == 100
+        assert row["long_views"] == 40
+        assert row["short_views"] == 60
+        assert row["avg_view_percentage"] == 40.0
+        assert yt["network_views"] == 100
+
+    def test_efficiency_uses_op3_and_youtube_side_by_side(self):
+        costs = {
+            "network_last_7_days": {"total": 10.0, "episodes": 5,
+                                    "grok": 8.0, "tts": 2.0},
+            "per_show": {
+                "tesla": {"last_7_days": {"total": 4.0, "episodes": 2}},
+                "spacex": {"last_7_days": {"total": 6.0, "episodes": 3}},
+            },
+        }
+        audience = {
+            "op3": {
+                "network_downloads_7d": 1000,
+                "network_downloads_30d": 4000,
+                "per_show": {
+                    "tesla": {"downloads_7d": 400, "downloads_30d": 1600},
+                    "spacex": {"downloads_7d": 600, "downloads_30d": 2400},
+                },
+            },
+            "youtube": {
+                "window_days": 90,
+                "network_views": 5000,
+                "per_show": {
+                    "tesla": {"views": 2000, "avg_view_percentage": 40,
+                              "subscribers_gained": 5},
+                    "spacex": {"views": 3000, "avg_view_percentage": 35,
+                               "subscribers_gained": 8},
+                },
+            },
+            "spotify": {
+                "totals": {"streams": 240, "listeners": 100},
+                "per_show": {"tesla": {"streams": 17}},
+            },
+            "apple": {"feeds_reporting": 0, "totals": {"plays": 0}},
+        }
+        eff = gd.build_efficiency_section(costs, audience)
+        assert eff["usd_per_op3_download_7d"] == pytest.approx(0.01)
+        assert eff["youtube_views_window"] == 5000
+        assert eff["spotify_streams_30d"] == 240
+        assert eff["per_show"]["tesla"]["usd_per_op3_download"] == pytest.approx(0.01)
+        assert "never summed" in eff["note"].lower() or "side-by-side" in eff["note"]
+
+    def test_op3_all_time_incomplete_flag(self, tmp_path):
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "op3_stats.json").write_text(json.dumps({
+            "fetched_at": "2026-07-26T00:00:00+00:00",
+            "shows": {
+                "tesla": {
+                    "downloads_7d": 100, "downloads_30d": 500, "weekly_avg": 100,
+                    # One short week only — after merge, all-time stays < 30d.
+                    "weekly_downloads": [80],
+                    "episodes": [],
+                },
+            },
+        }), encoding="utf-8")
+        op3 = gd.build_audience_section(tmp_path)["op3"]
+        assert op3["network_downloads_30d"] == 500
+        assert op3["network_downloads_all_time"] < op3["network_downloads_30d"]
+        assert op3["all_time_incomplete"] is True
+
+    def test_management_html_renders_efficiency_and_multiplatform(self):
+        html = (ROOT / "management.html").read_text(encoding="utf-8")
+        assert "data.efficiency" in html
+        assert "Unit economics" in html
+        assert "not reporting" in html
+        assert "Spotify streams" in html
+        assert "Views by show" in html
+        assert "stat-label" in html
+
+    def test_dashboard_payload_includes_efficiency(self):
+        data = gd.build_dashboard(ROOT, offline=True)
+        assert "efficiency" in data
+        assert "per_show" in data["efficiency"]
+        yt = data["audience"]["youtube"]
+        if yt.get("configured") and not yt.get("error"):
+            assert "per_show" in yt
+            # Tesla digest dir must resolve to the YAML slug.
+            assert "tesla" in yt["per_show"] or "spacex" in yt["per_show"]

--- a/tests/test_prompt_grok_review_2026_07_09.py
+++ b/tests/test_prompt_grok_review_2026_07_09.py
@@ -117,6 +117,30 @@ class TestPromptCacheRouting:
         _call_grok("hello", model="grok-4.3")
         assert "extra_headers" not in recorder
 
+    def test_call_grok_sends_reasoning_effort_when_set(self, fake_openai_cache):
+        from engine.generator import _call_grok
+
+        recorder, _ = fake_openai_cache
+        _call_grok("hello", model="grok-4.5", reasoning_effort="low")
+        assert (recorder.get("extra_body") or {}).get("reasoning_effort") == "low"
+
+    def test_call_grok_omits_reasoning_effort_when_unset(self, fake_openai_cache):
+        from engine.generator import _call_grok
+
+        recorder, _ = fake_openai_cache
+        _call_grok("hello", model="grok-4.3")
+        assert "reasoning_effort" not in (recorder.get("extra_body") or {})
+
+    def test_llm_reasoning_effort_helper(self):
+        from engine.generator import _llm_reasoning_effort
+
+        assert _llm_reasoning_effort(SimpleNamespace(
+            llm=SimpleNamespace(reasoning_effort="medium"))) == "medium"
+        assert _llm_reasoning_effort(SimpleNamespace(
+            llm=SimpleNamespace(reasoning_effort=""))) is None
+        assert _llm_reasoning_effort(SimpleNamespace(
+            llm=SimpleNamespace(reasoning_effort="nope"))) is None
+
     def test_record_llm_usage_tracks_cached_tokens(self):
         from engine.tracking import create_tracker, record_llm_usage
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -157,6 +157,28 @@ class TestRecordLlmUsage:
         step = tracker["services"]["grok_api"]["x_thread_generation"]
         assert step["estimated_cost_usd"] == 0.0
 
+    def test_cached_tokens_use_cached_input_rate(self):
+        from engine.tracking import _estimate_grok_cost, GROK_PRICING
+        pricing = GROK_PRICING["grok-4.3"]
+        # 1M prompt, 400k cached, 100k completion
+        cost = _estimate_grok_cost(
+            "grok-4.3", 1_000_000, 100_000, cached_tokens=400_000,
+        )
+        expected = (
+            (600_000 / 1e6) * pricing["input_per_1m"]
+            + (400_000 / 1e6) * pricing["cached_input_per_1m"]
+            + (100_000 / 1e6) * pricing["output_per_1m"]
+        )
+        assert cost == pytest.approx(expected)
+        # Cheaper than billing the full prompt at the uncached rate.
+        full = _estimate_grok_cost("grok-4.3", 1_000_000, 100_000, cached_tokens=0)
+        assert cost < full
+
+    def test_grok_45_pricing_row_exists(self):
+        assert "grok-4.5" in GROK_PRICING
+        assert GROK_PRICING["grok-4.5"]["input_per_1m"] == 2.0
+        assert GROK_PRICING["grok-4.5"]["cached_input_per_1m"] == 0.30
+
 
 # ===================================================================
 # TEST: record_tts_usage

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -271,10 +271,14 @@ def test_grok_tts_pricing_is_per_provider_map():
 
 
 def test_grok_tts_is_substantially_cheaper_than_elevenlabs():
-    """Whole point of the migration — Grok must be at least 10× cheaper."""
+    """Whole point of the migration — Grok must be at least 10× cheaper.
+
+    July 2026 list price is $15/M chars ($0.015/1K) vs ElevenLabs $150/M —
+    exactly 10×; keep the floor inclusive so a list-price sync doesn't fail CI.
+    """
     el = TTS_PROVIDER_PRICING["elevenlabs"]
     grok = TTS_PROVIDER_PRICING["grok"]
-    assert grok < el / 10, (
+    assert grok <= el / 10, (
         f"Grok TTS at ${grok}/1K vs ElevenLabs at ${el}/1K — "
         "expected at least 10× savings; got "
         f"{el / grok:.1f}× ratio."
@@ -293,7 +297,7 @@ def test_save_usage_uses_grok_rate_when_provider_grok(tmp_path: Path):
     assert tts_block["estimated_cost_usd"] == pytest.approx(expected)
     # Sanity: this is much less than what ElevenLabs would have charged.
     elevenlabs_equiv = (10_000 / 1000) * TTS_PROVIDER_PRICING["elevenlabs"]
-    assert tts_block["estimated_cost_usd"] < elevenlabs_equiv / 10
+    assert tts_block["estimated_cost_usd"] <= elevenlabs_equiv / 10
 
 
 def test_save_usage_uses_elevenlabs_rate_when_provider_elevenlabs(tmp_path: Path):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the safe, high-leverage items from the Grok/xAI July updates review, plus a Mission Control pass so operators see **podcast + Spotify + Apple + YouTube + spend together** (never one fake “reach” number).

### Mission Control / dashboard
- **YouTube per-show rollup** in `audience.youtube.per_show` (digest dir `tesla_shorts_time` → slug `tesla`; views / long vs Shorts / retention / subs)
- **Unit economics** section: 7d spend, `$/RSS download`, Spotify streams, YT views, ranked best `$/OP3-dl` per show
- **Cost projection fix**: weekly burn = actual last-7d total (was avg × 65 → systematically low; live: $5.61/wk at 125 files)
- OP3 **all-time incomplete** flag when history &lt; rolling 30d
- Apple card: **“not reporting”** honesty when `feeds_reporting == 0` (not “zero plays”)
- Show cards: RSS · YT views · Spotify + `$/RSS dl`
- Visual polish: IBM Plex Sans, soft header atmosphere, denser stats grid, efficiency cells

Regenerated `api/dashboard.json` offline so the page lights up immediately after merge.

### Grok infra (opt-in / accounting only — no shipped-audio flip)
- `reasoning_effort` optional on `_call_grok` + `LLMConfig` (empty default = byte-identical on grok-4.3)
- `GROK_PRICING` adds **grok-4.5** + **cached_input** rates; cost estimate uses cache hits
- Grok TTS tracker rate synced to public **$15/M chars** (was $4.20/M — understated TTS on Mission Control)

**Not done (needs you):** voice re-clone, drop `<fast>`, flip digest model to 4.5, Imagine Video 1.5 — all landmine #17 / portal work.

### Tests
`TestEfficiencyAndProjection`, tracking cached-cost + 4.5 pricing, `_call_grok` reasoning_effort guards, TTS ratio floor inclusive of 10× list price.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f4434-cb50-7434-9f72-5a6120a951f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

