### PR TITLE
Review of the last two days: unblock CI + repair three shipped regressions

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,16 +1,20 @@
 # actionlint configuration for Nerra Network
-# See: https://github.com/rhysd/actionlint/blob/main/docs/usage.md#configuration-file
+# See: https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# NOTE — shellcheck suppressions do NOT live here. This file previously
+# carried a `shellcheck: {ignore: [SC2086, SC2034, SC2044, SC2035]}` block
+# that suppressed nothing: actionlint's config schema has no such key, and
+# it silently ignores unknown top-level keys (verified against v1.7.12 —
+# an invented `totally-bogus-key` is accepted just as quietly). So all four
+# suppressions had been dead the whole time, and the lint step only stayed
+# green because no workflow happened to trip them.
+#
+# The mechanism that DOES work is `SHELLCHECK_OPTS` on the actionlint step
+# in .github/workflows/test.yml — shellcheck itself reads it. Codes to
+# suppress network-wide are listed there, with the same rationale that used
+# to sit here: SC2086/SC2034/SC2044/SC2035 are noisy-to-false in the Actions
+# environment, where `${{ }}` expansion happens before the shell sees the
+# script. Prefer fixing the script (env vars + arrays) over suppressing.
 
-# We intentionally suppress some common stylistic ShellCheck warnings
-# that are very noisy in GitHub Actions contexts (especially around
-# expression expansion and common scripting patterns).
-shellcheck:
-  # These are mostly stylistic / false-positive in the Actions environment:
-  # - SC2086: Unquoted variables (very common because ${{ }} expansion happens before shell)
-  # - SC2034: Unused variables (often used for documentation or future use)
-  # - SC2044 / SC2035: find + glob patterns (widely used and usually safe here)
-  ignore:
-    - SC2086
-    - SC2034
-    - SC2044
-    - SC2035
+self-hosted-runner:
+  labels: []

--- a/.github/workflows/backfill-dub-playlists.yml
+++ b/.github/workflows/backfill-dub-playlists.yml
@@ -55,12 +55,22 @@ jobs:
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
           YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
           YOUTUBE_REFRESH_TOKEN_FR: ${{ secrets.YOUTUBE_REFRESH_TOKEN_FR }}
+          # Dispatch inputs go through env, never inline `${{ }}` in the
+          # script body: inline interpolation happens BEFORE the shell runs,
+          # so a crafted input is substituted as shell source. Collecting the
+          # flags in an array (rather than a word-split string) is also what
+          # clears the SC2086 actionlint/shellcheck finding honestly —
+          # quoting the old "$ARGS" would have passed every flag as one
+          # argument and broken the script.
+          BACKFILL_LANG: ${{ inputs.lang }}
+          BACKFILL_MAX_INSERTS: ${{ inputs.max_inserts }}
+          BACKFILL_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          ARGS="--max-inserts ${{ inputs.max_inserts }}"
-          if [ "${{ inputs.lang }}" != "all" ] && [ -n "${{ inputs.lang }}" ]; then
-            ARGS="$ARGS --lang ${{ inputs.lang }}"
+          args=(--max-inserts "$BACKFILL_MAX_INSERTS")
+          if [ "$BACKFILL_LANG" != "all" ] && [ -n "$BACKFILL_LANG" ]; then
+            args+=(--lang "$BACKFILL_LANG")
           fi
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            ARGS="$ARGS --dry-run"
+          if [ "$BACKFILL_DRY_RUN" = "true" ]; then
+            args+=(--dry-run)
           fi
-          python scripts/backfill_dub_playlists.py $ARGS
+          python scripts/backfill_dub_playlists.py "${args[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,14 @@ jobs:
         run: ruff check engine/ run_show.py scripts/ --fix --exit-non-zero-on-fix
 
       - name: Validate GitHub Actions workflows (actionlint)
+        env:
+          # The ONLY working place to suppress shellcheck codes for
+          # actionlint — the `shellcheck:` block that used to sit in
+          # .github/actionlint.yaml is not part of actionlint's config
+          # schema and silently did nothing. These four are noisy-to-false
+          # in the Actions environment (`${{ }}` expands before the shell
+          # runs); fix the script rather than extend this list.
+          SHELLCHECK_OPTS: "-e SC2086 -e SC2034 -e SC2044 -e SC2035"
         run: |
           # Install actionlint if not present
           curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- latest

--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -83,7 +83,9 @@ existing track; `--dry-run` to translate + project cost without TTS/upload;
 
 - Re-running skips any `(episode, language)` already recorded unless `--force`.
 - Each run logs a rough character + `$` projection up front (`--dry-run` to see
-  it without spending). Grok TTS is ~$4.20 / 1M chars; a 4-language batch is
+  it without spending). The projection reads Grok TTS's rate from
+  `engine/tracking.py` (`GROK_TTS_COST_PER_1K_CHARS` — $15/M chars as of
+  July 2026; $4.20/M was the promo-era rate). A 4-language batch is
   ~4× the English character volume per episode plus translation tokens.
 
 ## Operator notes (length & quality)

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -354,7 +354,6 @@ def _llm_reasoning_effort(config: Any) -> Optional[str]:
     return effort if effort in ("low", "medium", "high") else None
 
 
-
 def _detect_story_duplication(text: str, show_name: str) -> int:
     """Detect when the same news story is told more than once in a script.
 
@@ -1559,7 +1558,7 @@ def generate_digest(
             temperature=config.llm.digest_temperature,
             max_tokens=bumped_tokens,
             cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+            reasoning_effort=_llm_reasoning_effort(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -1624,7 +1623,7 @@ def generate_digest(
             temperature=config.llm.digest_temperature,
             max_tokens=config.llm.max_tokens,
             cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+            reasoning_effort=_llm_reasoning_effort(config),
         )
         if tracker and "usage" in meta2:
             try:
@@ -1664,7 +1663,7 @@ def generate_digest(
                 temperature=config.llm.podcast_temperature,  # slightly more creative
                 max_tokens=config.llm.max_tokens,
                 cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                reasoning_effort=_llm_reasoning_effort(config),
             )
             if tracker and "usage" in meta3:
                 try:
@@ -1706,7 +1705,7 @@ def generate_digest(
                     temperature=config.llm.podcast_temperature,
                     max_tokens=config.llm.max_tokens,
                     cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                    reasoning_effort=_llm_reasoning_effort(config),
                 )
                 if tracker:
                     try:
@@ -1756,7 +1755,7 @@ def generate_digest(
                 temperature=lower_temp,
                 max_tokens=config.llm.max_tokens,
                 cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                reasoning_effort=_llm_reasoning_effort(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="digest", show_name=config.name,
@@ -1821,7 +1820,7 @@ def generate_digest(
                     temperature=config.llm.digest_temperature,
                     max_tokens=config.llm.max_tokens,
                     cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                    reasoning_effort=_llm_reasoning_effort(config),
                 )
                 # Validate the expanded draft is real content, not a refusal.
                 _validate_llm_output(
@@ -2160,7 +2159,7 @@ def generate_podcast_script(
             temperature=config.llm.podcast_temperature,
             max_tokens=bumped_tokens,
             cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+            reasoning_effort=_llm_reasoning_effort(config),
         )
         if meta.get("finish_reason") == "length":
             logger.warning(
@@ -2218,7 +2217,7 @@ def generate_podcast_script(
             temperature=lower_temp,
             max_tokens=podcast_tokens_for_retry,
             cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+            reasoning_effort=_llm_reasoning_effort(config),
         )
         if tracker and "usage" in meta_r1:
             try:
@@ -2256,7 +2255,7 @@ def generate_podcast_script(
                 temperature=lower_temp,
                 max_tokens=podcast_tokens_for_retry,
                 cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                reasoning_effort=_llm_reasoning_effort(config),
             )
             if tracker:
                 try:
@@ -2334,7 +2333,7 @@ def generate_podcast_script(
             temperature=config.llm.podcast_temperature,
             max_tokens=podcast_tokens,
             cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+            reasoning_effort=_llm_reasoning_effort(config),
         )
 
         if tracker and "usage" in meta2:
@@ -2402,7 +2401,7 @@ def generate_podcast_script(
                 temperature=lower_temp,
                 max_tokens=podcast_tokens,
                 cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                reasoning_effort=_llm_reasoning_effort(config),
             )
             _rep_retry = _validate_llm_output(
                 text_retry, stage="podcast_script", show_name=config.name,
@@ -2478,7 +2477,7 @@ def generate_podcast_script(
                     temperature=config.llm.podcast_temperature,
                     max_tokens=podcast_tokens,
                     cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
+                    reasoning_effort=_llm_reasoning_effort(config),
                 )
                 if tracker and "usage" in meta_rr:
                     try:

--- a/engine/network_promo.py
+++ b/engine/network_promo.py
@@ -203,14 +203,38 @@ NETWORK_SURFACES: list[dict[str, str]] = [
 
 
 def _weighted_surface_pool() -> list[dict[str, str]]:
-    """Expand NETWORK_SURFACES by optional per-entry weight (default 1)."""
-    pool: list[dict[str, str]] = []
+    """Expand NETWORK_SURFACES by optional per-entry weight (default 1).
+
+    The extra copies are INTERLEAVED, not clustered. The rotation walks
+    the pool one step per day, so appending ``[gallery] * 3`` back-to-back
+    would air the identical gallery paragraph three days running on every
+    show — the repeated-boilerplate tic the playbook bans — instead of
+    spreading it across the cycle. Round-robin passes place copy *n* of a
+    weighted surface a full base-cycle apart.
+    """
+    if not NETWORK_SURFACES:
+        return []
+    weights: list[int] = []
     for surface in NETWORK_SURFACES:
         try:
-            weight = max(1, int(surface.get("weight") or 1))
+            weights.append(max(1, int(surface.get("weight") or 1)))
         except (TypeError, ValueError):
-            weight = 1
-        pool.extend([surface] * weight)
+            weights.append(1)
+
+    total = sum(weights)
+    slots: list[Optional[dict[str, str]]] = [None] * total
+    # Heaviest first so it gets the evenly-spaced slots; the rest fill the
+    # gaps in declaration order, preserving their relative rotation.
+    for i in sorted(range(len(NETWORK_SURFACES)), key=lambda n: (-weights[n], n)):
+        weight = weights[i]
+        for copy_index in range(weight):
+            target = (copy_index * total) // weight
+            for step in range(total):
+                pos = (target + step) % total
+                if slots[pos] is None:
+                    slots[pos] = NETWORK_SURFACES[i]
+                    break
+    pool = [s for s in slots if s is not None]
     return pool or list(NETWORK_SURFACES)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
+[tool.ruff]
+# The CI lint gate (`.github/workflows/test.yml`) installs ruff UNPINNED.
+# With no config in the repo, the gate silently tracked whatever rule set
+# the newest ruff happened to default to — a ruff release widened that
+# default and the step went from "2 findings" to 2,360 repo-wide (483 not
+# auto-fixable), so `ruff check ... --exit-non-zero-on-fix` has been red on
+# main and the `pytest` step after it never ran at all.
+#
+# Pin the contract explicitly to ruff's documented default rule set — the
+# one this codebase actually passes — so a dependency bump can never again
+# take the test job down. Widening this is a deliberate, separate cleanup:
+# add codes here and fix the fallout in the same PR.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/run_show.py
+++ b/run_show.py
@@ -2542,10 +2542,41 @@ def run(args: argparse.Namespace) -> None:
             # (July 2026 improvements pack). Keeps blog/SEO free of TTS
             # respellings while *_tts.txt remains the synthesis source.
             try:
+                # Replay the post-snapshot passes that are NOT pronunciation
+                # transforms. The snapshot is taken before
+                # ``_apply_pronunciation`` on purpose (that is the whole
+                # point — no "koo-dah" on the blog), but everything after it
+                # in the spoken path is either a correctness repair or a
+                # formatting strip that the reader needs just as much:
+                #
+                #  * fix_phonetic_garbles repairs garbles the LLM WROTE
+                #    ("An-thropic", "Tesla-rah-tee", "nassa") — those are in
+                #    the pre-pronunciation text too, and shipping them to the
+                #    blog is the exact leak that created the repair layer.
+                #  * russify_english_dates fixes LLM-emitted English dates in
+                #    otherwise-Russian scripts (FP/PR).
+                #  * the speaker-prefix strip removes "Host:"/"Patrick:"
+                #    labels that survived earlier cleaning.
+                from engine.utils import fix_phonetic_garbles as _reader_garbles
+                _reader_body = _reader_garbles(reader_script)
+                if args.show in ("finansy_prosto", "privet_russian"):
+                    from engine.russian_text import russify_english_dates as _ru_dates
+                    _reader_body = _ru_dates(_reader_body)
+                if not config.tts.dialogue_mode:
+                    for _pfx in ("Host:", f"{host}:", "Patrick:", "Ведущая:",
+                                 "Ведущий:", "Narrator:", "Speaker:"):
+                        _esc = _re.escape(_pfx)
+                        _reader_body = _re.sub(
+                            r"^" + _esc + r"\s*", "", _reader_body,
+                            flags=_re.MULTILINE)
+                        _reader_body = _re.sub(
+                            r"(?<=[.!?])\s+" + _esc + r"\s*", " ", _reader_body)
+                _reader_body = _re.sub(r"\n{3,}", "\n\n", _reader_body).strip()
+
                 # Append the same AI disclosure the spoken script carries,
                 # stripped of speech tags, so the on-page transcript matches
                 # the episode ending listeners hear.
-                _reader_body = reader_script.rstrip()
+                _reader_body = _reader_body.rstrip()
                 _reader_disclosure = _strip_tags_for_reader(
                     _AI_DISCLOSURE_RU if args.show in _RUSSIAN_SHOWS
                     else (_AI_DISCLOSURE_DIALOGUE if config.tts.dialogue_mode

--- a/scripts/fetch_ga4_stats.py
+++ b/scripts/fetch_ga4_stats.py
@@ -32,7 +32,6 @@ import datetime as dt
 import json
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import Any, Dict, List
 

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1217,6 +1217,10 @@ def aggregate_costs(root: Path, shows: List[Dict[str, Any]]) -> Dict[str, Any]:
         "per_show": per_show,
         "network_last_7_days": network_7,
         "network_last_30_days": network_30,
+        # Quick-win enhancements (May 2026 codebase review): the cost
+        # rollup also emits forward projections + the YouTube quota
+        # surface. Pinned by tests/test_quick_wins.py — keep this marker
+        # with the block it names.
         "projections": {
             "avg_cost_per_episode_usd": avg_per_episode,
             "projected_weekly_usd": projected_weekly,
@@ -1825,6 +1829,7 @@ def _merge_op3_history(
                     }
             except Exception:  # noqa: BLE001 — corrupt history: rebuild
                 weeks = {}
+        stored_weeks = {wk: dict(row) for wk, row in weeks.items()}
 
         for slug, v in per_show.items():
             series = v.get("weekly_downloads") or []
@@ -1832,13 +1837,19 @@ def _merge_op3_history(
                 week_start = (monday_w0 - _dt.timedelta(weeks=i)).isoformat()
                 weeks.setdefault(week_start, {})[slug] = int(n or 0)
 
-        hist_path.parent.mkdir(parents=True, exist_ok=True)
-        hist_path.write_text(
-            json.dumps(
-                {"updated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
-                 "weeks": weeks},
-                indent=2, ensure_ascii=False, sort_keys=True) + "\n",
-            encoding="utf-8")
+        # Churn suppression: only rewrite when a week actually changed.
+        # An unconditional write bumped ``updated_at`` on every build —
+        # including read-only/offline builds and every test run — which
+        # dirtied the working tree and put a no-content diff into the
+        # nightly commit (same reason language/video feeds suppress churn).
+        if weeks != stored_weeks:
+            hist_path.parent.mkdir(parents=True, exist_ok=True)
+            hist_path.write_text(
+                json.dumps(
+                    {"updated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+                     "weeks": weeks},
+                    indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+                encoding="utf-8")
 
         per_show_totals: Dict[str, int] = {}
         network_series: List[List[Any]] = []

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -36,15 +36,18 @@ from dotenv import load_dotenv  # noqa: E402
 
 load_dotenv(PROJECT_ROOT / ".env")
 
-from engine import multilingual, translate, tts  # noqa: E402
+from engine import multilingual, tracking, translate, tts  # noqa: E402
 from engine.config import load_config  # noqa: E402
 from engine.summaries_io import load_summaries  # noqa: E402
 
 logging.basicConfig(level=logging.INFO, stream=sys.stdout, format="%(levelname)s %(message)s")
 logger = logging.getLogger("generate_translations")
 
-# Grok TTS list price (~$4.20 / 1M chars) for the up-front projection.
-_TTS_USD_PER_MILLION = 4.20
+# Grok TTS list price for the up-front projection. Read from the network's
+# single source of truth so this operator-facing estimate can't drift from
+# what the dashboard actually bills (it was pinned at the promo-era $4.20/M
+# after tracking.py moved to the $15/M list rate — a 3.6× understatement).
+_TTS_USD_PER_MILLION = tracking.GROK_TTS_COST_PER_1K_CHARS * 1000.0
 
 
 def _select_records(records: List[dict], latest: int, episode: Optional[int]) -> List[dict]:

--- a/scripts/restock_topic_queues.py
+++ b/scripts/restock_topic_queues.py
@@ -49,7 +49,7 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-import yaml
+import yaml  # noqa: E402 — must follow the sys.path bootstrap above
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 logger = logging.getLogger(__name__)

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -44,8 +44,11 @@ llm:
   # reasoning_effort: ""
 
 tts:
-  # Network default since May 2026: xAI Grok TTS at $4.20/M chars
-  # (~36× cheaper than ElevenLabs Flash). Voice `kdif6sqjcyiq` is the
+  # Network default since May 2026: xAI Grok TTS. Cost tracking reads the
+  # single source of truth in engine/tracking.py
+  # (GROK_TTS_COST_PER_1K_CHARS — $15/M chars list price as of July 2026;
+  # the $4.20/M figure quoted here through June was the promo-era rate).
+  # Still an order of magnitude under ElevenLabs Flash. Voice `kdif6sqjcyiq` is the
   # operator's current English voice — every English show on the
   # network shares it for a single consistent "host" identity.
   # Russian shows (FP/PR) override voice_id to their custom "Olya"

--- a/tests/test_depth_and_network_discovery_2026_07_09.py
+++ b/tests/test_depth_and_network_discovery_2026_07_09.py
@@ -124,6 +124,29 @@ class TestNetworkDiscoverySurfaces:
                 counts[sid] += 1
         assert counts["gallery"] > counts["blogs"]
 
+    def test_weighted_surface_never_airs_on_consecutive_days(self):
+        """Weight must SPREAD a surface, not cluster it.
+
+        The rotation advances one slot per day, so expanding a weight-3
+        entry into three adjacent pool slots aired the identical gallery
+        paragraph three days running on every show — the repeated-boilerplate
+        tic the playbook bans. Copies are interleaved instead.
+        """
+        from engine.network_promo import (
+            ENGLISH_SHOWS,
+            _weighted_surface_pool,
+            pick_featured_surface,
+        )
+
+        pool_len = len(_weighted_surface_pool())
+        for slug in ENGLISH_SHOWS:
+            ids = [
+                pick_featured_surface(slug, _DAY + dt.timedelta(days=i))["id"]
+                for i in range(pool_len * 2)
+            ]
+            repeats = [a for a, b in zip(ids, ids[1:]) if a == b]
+            assert not repeats, f"{slug} repeats {repeats} on consecutive days"
+
     def test_surface_x_reply_has_utm(self):
         from engine.network_promo import build_surface_x_reply
 

--- a/tests/test_improvements_pack_2026_07_26.py
+++ b/tests/test_improvements_pack_2026_07_26.py
@@ -81,6 +81,32 @@ class TestReaderTranscript:
         assert "_reader.txt" in src
         assert "Prefer *_reader.txt" in src or "prefer" in src.lower()
 
+    def test_reader_replays_the_non_pronunciation_passes(self):
+        """The reader snapshot is taken pre-pronunciation ON PURPOSE, but the
+        passes AFTER it that are not pronunciation transforms must still run.
+
+        ``fix_phonetic_garbles`` repairs garbles the LLM itself wrote
+        ("An-thropic", "Tesla-rah-tee", "nassa") — those are present in the
+        pre-pronunciation text too, so skipping the repair ships them to the
+        blog, which is the exact leak the repair layer exists to stop. Same
+        for the RU date fix and the speaker-prefix strip.
+        """
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        head, _, reader_block = src.partition("Reader/blog transcript")
+        assert reader_block, "reader-transcript block missing"
+        reader_block = reader_block.split("# 9. TTS")[0]
+        assert "fix_phonetic_garbles" in reader_block
+        assert "russify_english_dates" in reader_block
+        assert "_reader_body" in reader_block and "Narrator:" in reader_block
+
+    def test_garbles_the_llm_writes_survive_into_the_snapshot(self):
+        """Pins the premise: these garbles are pre-pronunciation, so the
+        reader transcript needs its own repair pass."""
+        from engine.utils import fix_phonetic_garbles
+        raw = "An-thropic and Tesla-rah-tee covered nassa today."
+        assert fix_phonetic_garbles(raw) != raw
+        assert "Anthropic" in fix_phonetic_garbles(raw)
+
 
 class TestMultiPlatformPilot:
     def test_tesla_and_spacex_enable_multi_platform_assets(self):

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -294,11 +294,26 @@ class TestIpoPositioning:
         block = _build_market_block(161.0, "+19.3%")
         assert "$161.00" in block and "verbatim" in block
 
-    def test_quote_validation_band_and_deviation_guard(self):
+    def test_quote_validation_band_and_deviation_guard(self, monkeypatch):
+        """Band + deviation guard, pinned against a STUBBED cache.
+
+        The in-band assertion used to read the live committed
+        ``api/spcx.json``: once SPCX drifted far enough from the 161.00
+        literal (115.07 by 2026-07-25) the deviation guard rejected it and
+        this guard failed on price movement rather than on a code change.
+        Stub the cache so both halves stay deterministic.
+        """
         from shows.hooks import spacex as hook
+
+        monkeypatch.setattr(hook, "_load_cached_price", lambda: None)
         assert not hook._validate(5.0)       # below band
         assert not hook._validate(5000.0)    # above band
-        assert hook._validate(161.0)         # day-one close passes
+        assert hook._validate(161.0)         # in band, no cache to compare
+
+        # With a cache present the deviation guard is what rejects.
+        monkeypatch.setattr(hook, "_load_cached_price", lambda: 160.0)
+        assert hook._validate(161.0)         # ~0.6% move accepted
+        assert not hook._validate(400.0)     # >35% move rejected
 
     def test_market_watch_chapter_marker(self):
         by_title = {m["title"]: m for m in _spacex_markers()}


### PR DESCRIPTION
Review pass over everything merged 2026-07-24 → 07-26 (PRs #868–#881 plus the direct-to-main analytics commits). Everything below is code/metadata-side — **no prompt or audio changes, so nothing here needs an A/B listen (landmine #17)**.

## The headline: CI has been red for the entire window

Every `Run Tests` run since 2026-07-24 05:31 UTC has failed — including the runs on #874, #876, #877, #878, #879, #880, #881 and their merge commits. The lint step exits non-zero, so **the `pytest` step after it never runs at all**. Nothing merged in the last two days was verified by the drift-guard suite this repo depends on.

Root cause: `test.yml` installs `ruff` **unpinned** and the repo carried no ruff config, so the gate silently tracked whatever rule set the newest ruff happened to default to. A ruff release widened that default and the step went from 2 findings to `Found 2360 errors (1877 fixed, 483 remaining)` across `engine/`, `scripts/`, `run_show.py` — almost all of it pre-existing style (EXE001 shebangs, BLE001, DTZ) with nothing to do with these PRs. (Commit `f31d5ca`, "keeps lint gate at main's baseline", was already working around this rather than fixing it.)

**Fix:** pin the contract in `pyproject.toml` to ruff's documented default rule set (`E4, E7, E9, F`) — the one this codebase actually passes — plus the two genuine findings it was masking. Widening the rule set is now a deliberate, separate cleanup rather than something a dependency bump can impose. This is the one judgment call in the PR and it's a one-line revert if you'd rather keep the broad set and clean up 483 findings instead.

## Two drift guards were genuinely red

Both would have blocked their own PRs had the lint step not short-circuited first.

| Guard | Cause |
|---|---|
| `test_quick_wins::test_dashboard_json_will_contain_projections_after_regen` | The Mission Control rewrite (#881) dropped the comment marker the test pins to the projections / `youtube_quota` block. Restored with the block it names. |
| `test_spacex_show::test_quote_validation_band_and_deviation_guard` | Asserted `_validate(161.0)` against the **live committed** `api/spcx.json`. Once SPCX drifted to 115.07 the >35% deviation guard rejected it — the guard failed on price movement, not on a code change. Stubbed the cache; also added the deviation-rejection case it never covered. |

## Three regressions in the merged work

**1. The reader transcript ships the garbles it exists to remove.** `*_reader.txt` (#880) is snapshotted pre-pronunciation on purpose — that's the whole point, no `koo-dah` on the blog. But it also skips *every* later pass, including `fix_phonetic_garbles`, which repairs garbles **the LLM itself wrote** (`An-thropic`, `Tesla-rah-tee`, `nassa`). Those live in the pre-pronunciation text, and `blog.py` now *prefers* the reader file — so the published transcript would regress to exactly the leak that repair layer was built for (the M&A June-21 / FF `nassa` class). Now replays the non-pronunciation passes: garble repair, RU date russification, speaker-prefix strip, whitespace collapse.

**2. Gallery weighting clusters instead of spreading.** `weight: 3` expanded into three **adjacent** pool slots, and the rotation advances one slot per day — so the identical spoken gallery paragraph aired **three days running** on every English show, then vanished for the rest of the cycle. That's the repeated-boilerplate tic the playbook bans. Copies are now interleaved: gallery keeps 3 of 10 slots, spaced ~3 days apart, zero consecutive repeats on any show.

```
before  tesla: … dp_club, gallery, gallery, gallery, blogs, summaries …
after   tesla: gallery, story_trackers, data_hub, gallery, start_here, age_of_ai, dp_club, gallery …
```

**3. `_merge_op3_history` writes unconditionally.** It rewrote `api/op3_history.json` and bumped `updated_at` on every build — including `offline=True` builds and every test run. That dirtied the working tree (a no-content diff reached two recent commits: `f042fdd`, `e591997`). Now suppresses churn the way the language and video feeds already do.

## Smaller items

- **Grok TTS rate drift.** `tracking.py` moved to $15/M chars, but `scripts/generate_translations.py` kept a hardcoded `4.20`, understating its operator-facing projection 3.6×. Now reads the shared constant; stale $4.20/M comments in `shows/_defaults.yaml` and `docs/multilingual.md` updated to point at the single source of truth.
- **`generator.py` indentation.** The 12 `reasoning_effort=` kwargs landed at the wrong continuation indent (valid Python, just misaligned).

## Verification

- `ruff check engine/ run_show.py scripts/ --fix --exit-non-zero-on-fix` → **All checks passed** (exit 0), the exact CI invocation.
- Full suite: **4176 passed**, working tree clean afterwards. The 9 remaining failures are `feedgen` being unbuildable in this sandbox (`ModuleNotFoundError`), not code — CI installs it from `requirements.txt`.
- New drift guards: reader-transcript pass parity + the premise that those garbles are pre-pronunciation (`test_improvements_pack_2026_07_26.py`), and no-consecutive-repeat for any weighted surface across all English shows (`test_depth_and_network_discovery_2026_07_09.py`).

## For you, not code

- **Verify the Grok TTS list price.** #881 changed it 4.20 → 15.00 per 1M chars, a 3.6× jump that flows into every cost surface (dashboard, multilingual projections). I can't confirm it against docs.x.ai from here. Historical `credit_usage_*.json` files keep their recorded costs; only new episodes bill at the new rate.
- **Same for the `grok-4.5` pricing rows** added in the same commit ($2.00/$6.00/$0.30). Nothing selects 4.5 yet — `reasoning_effort` defaults to `""` and stays commented out in `_defaults.yaml`, so the daily path is byte-identical.
- **The 483 pre-existing ruff findings** are still there, just no longer gating. Worth a dedicated cleanup PR if you want the broader rule set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEKYtq2Bf1otumdXnRqiFU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches published blog/reader transcripts and spoken network promo rotation (listener-facing), plus CI lint contract—low security risk but behavior changes warrant spot-checking promos and a green test run.
> 
> **Overview**
> **Unblocks CI** by pinning ruff to `E4/E7/E9/F` in `pyproject.toml` so unpinned ruff releases can’t fail the lint step and skip pytest. **Fixes actionlint/shellcheck**: documents that `.github/actionlint.yaml`’s `shellcheck:` key was a no-op; moves suppressions to `SHELLCHECK_OPTS` in `test.yml` and hardens `backfill-dub-playlists.yml` (dispatch inputs via env + bash arrays instead of inline `${{ }}`).
> 
> **Shipped regressions:** `*_reader.txt` now replays post-snapshot cleanup (`fix_phonetic_garbles`, RU date russification, speaker-prefix strip) so blog transcripts don’t leak LLM garbles. Network promo **weight** copies are **interleaved** in `_weighted_surface_pool()` so gallery doesn’t air three identical days in a row. `generate_dashboard.py` only rewrites `api/op3_history.json` when week data actually changes.
> 
> **Operator/docs alignment:** multilingual TTS cost projections read `tracking.GROK_TTS_COST_PER_1K_CHARS` (was hardcoded $4.20/M). `generator.py` fixes `reasoning_effort=` indentation on `_call_grok` kwargs. SpaceX quote test stubs cached price; new tests cover reader parity and no consecutive weighted surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b643ade3d8aa8b4b701aa2f1e4b564df476e66da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->