### PR TITLE
Improvement plan Phase 2 (P1-1, P1-3, P1-4) + ruff fix for #895

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # Runtime state — never commit. See engine/newsletter.py:_record_send.
 digests/*/_newsletter_lastsend.txt
 digests/*/.published_*.json
+# Remembered "this account cannot send yet" state. Same convention as the
+# guardrail above: runtime state, never committed. See
+# engine/newsletter.py:sending_block_reason.
+digests/_newsletter_sending_blocked.json
 
 # OAuth client secrets (Google Cloud Console download)
 client_secret*.json

--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -247,18 +247,41 @@ def _headers_for_url(url: str) -> dict:
     return DEFAULT_HEADERS
 
 
+class ThrottledError(Exception):
+    """A feed answered 429/503 — retryable, unlike other HTTP errors."""
+
+
+# Statuses that mean "ask again shortly", as opposed to "this feed is
+# broken". Retrying a 404 or 403 is pointless; retrying a 429 usually
+# works, and until July 28 2026 we did not try at all.
+_RETRYABLE_STATUSES = (429, 503)
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=2, max=10),
     retry=retry_if_exception_type((
         requests.exceptions.ConnectionError,
         requests.exceptions.Timeout,
+        ThrottledError,
     )),
     reraise=True,
 )
 def _fetch_url_with_retry(url: str) -> requests.Response:
-    """GET a URL with automatic retry on transient network errors."""
+    """GET a URL with automatic retry on transient network errors.
+
+    429 is treated as transient. Reddit throttles per-request from cloud
+    egress rather than blocking outright — a live probe on 2026-07-28 got
+    200 on r/LocalLLaMA and r/SpaceXLounge and 429 on r/space in the same
+    second — but the retry predicate only covered connection errors and
+    timeouts, so a throttled feed was dropped on the first refusal with no
+    second attempt. Backing off and asking again recovers most of them.
+    """
     response = requests.get(url, headers=_headers_for_url(url), timeout=HTTP_TIMEOUT_SECONDS)
+    if response.status_code in _RETRYABLE_STATUSES:
+        raise ThrottledError(
+            f"HTTP {response.status_code} (throttled) for {url}"
+        )
     response.raise_for_status()
     return response
 

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -272,6 +272,25 @@ def _download_entry(
         # CDN rejects us (403/401/etc.) — don't keep paying the round-trip.
         status = getattr(getattr(exc, "response", None), "status_code", None)
         if status in (401, 403) or "403" in str(exc) or "401" in str(exc):
+            # Announce the FIRST flip loudly. Before July 28 2026 this
+            # degradation was only visible as an INFO line per image
+            # ("R2 fallback OK"), so a CDN that had been rejecting every
+            # public GET for weeks looked like a healthy pipeline —
+            # renders just silently paid the slower authenticated path up
+            # to 16 times each. A public bucket that stops being public
+            # is a config regression and should be seen the same day.
+            if not _prefer_r2_download:
+                print(
+                    "::warning::gallery CDN rejected a public read "
+                    f"(HTTP {status or 'error'}) — falling back to "
+                    "authenticated R2 for the rest of this run. Check the "
+                    "bucket's public-access / custom-domain configuration.",
+                    flush=True,
+                )
+                logger.warning(
+                    "gallery_library: public CDN unavailable (%s) — every "
+                    "library image this run pays the R2 fallback", public_err,
+                )
             _prefer_r2_download = True
         if _download_via_r2(entry, dest):
             logger.info(

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -1481,6 +1481,37 @@ def _build_educational_fallback_prompt(
         )
 
 
+def _record_discarded_call(tracker, step: str, meta: dict, config) -> None:
+    """Account for a generation call whose output is about to be thrown away.
+
+    The truncation retries below replace ``text``/``meta`` wholesale, so
+    the first call's tokens used to vanish — billed by xAI, absent from
+    the episode's credit file. That made the waste unmeasurable: the
+    July 2026 improvement plan had to infer it from run logs, and named
+    the wrong show (SpaceX, which has never truncated in 45 recorded
+    runs; the real offenders are Omni View at 17% and Fascinating
+    Frontiers at 6%).
+
+    Recorded under its own step key so it shows up as a distinct line in
+    the credit summary rather than inflating the successful call.
+    """
+    if not tracker or "usage" not in (meta or {}):
+        return
+    try:
+        from engine.tracking import record_llm_usage
+        usage = meta["usage"]
+        record_llm_usage(
+            tracker,
+            step,
+            usage.get("prompt_tokens", 0),
+            usage.get("completion_tokens", 0),
+            model=config.llm.model,
+            cached_tokens=usage.get("cached_tokens", 0),
+        )
+    except Exception as exc:  # accounting must never break generation
+        logger.warning("Failed to record discarded-call usage: %s", exc)
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=15),
@@ -1551,6 +1582,13 @@ def generate_digest(
             "Digest truncated at %d tokens — retrying with %d tokens",
             config.llm.max_tokens, bumped_tokens,
         )
+        # Record the DISCARDED call before `meta` is overwritten. Until
+        # July 2026 only the retry's usage was tracked, so the thrown-away
+        # call was invisible in cost data — which is precisely why the
+        # improvement plan could not tell which shows were paying for it
+        # (it named SpaceX, which turns out never to truncate). Cost that
+        # is not recorded cannot be optimised.
+        _record_discarded_call(tracker, "x_thread_generation_truncated", meta, config)
         text, meta = _call_grok(
             prompt,
             model=config.llm.model,
@@ -2151,6 +2189,11 @@ def generate_podcast_script(
         logger.warning(
             "Podcast script truncated at %d tokens — retrying with %d tokens",
             podcast_tokens, bumped_tokens,
+        )
+        # See the digest path: the discarded call is recorded so wasted
+        # spend is measurable instead of inferred.
+        _record_discarded_call(
+            tracker, "podcast_script_generation_truncated", meta, config
         )
         text, meta = _call_grok(
             prompt,

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -7,9 +7,12 @@ so subscribers only receive emails for shows they opted into.
 
 from __future__ import annotations
 
+import datetime
+import json
 import logging
 import os
 import re
+from pathlib import Path
 from typing import Dict, List, Optional
 
 import requests
@@ -120,6 +123,87 @@ def _md_inline(text: str) -> str:
 # ---------------------------------------------------------------------------
 # API key validation
 # ---------------------------------------------------------------------------
+
+
+# Where a known sending block is remembered. Buttondown exposes no
+# documented endpoint for "can this account send yet", so rather than
+# guess at an undocumented schema we record what the send endpoint
+# actually told us and let the preflight read it back.
+#
+# SCOPE, precisely: this file is gitignored runtime state, matching the
+# double-send guardrail above, so on GitHub Actions (a fresh clone per
+# run) it suppresses within a run but not across runs. The part that
+# always works is the message — one actionable warning naming the
+# operator fix, instead of a generic `logger.error` at the end of every
+# pipeline. The durable fix is configuring the sending domain (or
+# turning the newsletter off); this only stops the noise from training
+# people to ignore real errors in the meantime.
+_SENDING_BLOCKED_MARKER = Path(__file__).resolve().parent.parent / "digests" / "_newsletter_sending_blocked.json"
+
+# The account cannot send until a custom sending domain is verified in
+# Buttondown. This is a standing configuration state, not a transient
+# fault, so it must not be logged as a fresh error on every run.
+_SENDING_DOMAIN_HINTS = ("sending domain", "email_invalid")
+
+# How long a remembered block is trusted. Short enough that the pipeline
+# picks the newsletter back up on its own once the operator configures
+# the domain, without needing anyone to clear a file.
+_SENDING_BLOCK_TTL_DAYS = 7
+
+
+def _is_sending_domain_error(detail: str) -> bool:
+    """True when Buttondown refused because the account cannot send yet."""
+    lowered = (detail or "").lower()
+    return all(hint in lowered for hint in _SENDING_DOMAIN_HINTS) or (
+        "custom sending domain" in lowered
+    )
+
+
+def _remember_sending_block(detail: str) -> None:
+    """Persist the sending block so the next run can skip early."""
+    try:
+        _SENDING_BLOCKED_MARKER.parent.mkdir(parents=True, exist_ok=True)
+        _SENDING_BLOCKED_MARKER.write_text(
+            json.dumps({
+                "blocked_at": datetime.datetime.now(
+                    datetime.timezone.utc
+                ).isoformat(),
+                "detail": (detail or "")[:500],
+            }, indent=2),
+            encoding="utf-8",
+        )
+    except Exception as exc:  # never let bookkeeping break the pipeline
+        logger.debug("Could not record newsletter sending block: %s", exc)
+
+
+def clear_sending_block() -> None:
+    """Forget a remembered block. Called after any successful send."""
+    try:
+        _SENDING_BLOCKED_MARKER.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("Could not clear newsletter sending block: %s", exc)
+
+
+def sending_block_reason() -> Optional[str]:
+    """Return a short reason when sending is known to be blocked, else None.
+
+    Expires after ``_SENDING_BLOCK_TTL_DAYS`` so a fixed configuration is
+    picked up automatically rather than staying suppressed forever.
+    """
+    try:
+        if not _SENDING_BLOCKED_MARKER.exists():
+            return None
+        data = json.loads(_SENDING_BLOCKED_MARKER.read_text(encoding="utf-8"))
+        blocked_at = datetime.datetime.fromisoformat(data["blocked_at"])
+        age = datetime.datetime.now(datetime.timezone.utc) - blocked_at
+        if age > datetime.timedelta(days=_SENDING_BLOCK_TTL_DAYS):
+            return None
+        return (
+            "Buttondown account has no verified custom sending domain "
+            "(configure it in Buttondown → Settings → Sending)"
+        )
+    except Exception:
+        return None
 
 
 def validate_api_key(api_key: str) -> bool:
@@ -371,6 +455,10 @@ def send_newsletter(
                 email_id, tags,
             )
             return None
+        # A send that actually landed proves the account can send, so any
+        # remembered block is stale — drop it immediately rather than
+        # waiting out the TTL.
+        clear_sending_block()
         return email_id
     else:
         error_detail = resp.text[:500]
@@ -379,6 +467,20 @@ def send_newsletter(
                 "Newsletter send failed with tag filter error (likely invalid Buttondown tag identifier in YAML 'newsletter.tag'). "
                 "Current tag value(s): %s. Check your Buttondown Tags page for the exact slug/ID to use. Error: %s",
                 tags, error_detail,
+            )
+        elif _is_sending_domain_error(error_detail):
+            # A standing configuration state, not a fault in this run.
+            # Logging it as a fresh error every single pipeline (which is
+            # what happened until July 28 2026) is how people learn to
+            # ignore errors. One clear, actionable warning instead, and
+            # remember it so the next run skips before doing the work.
+            _remember_sending_block(error_detail)
+            logger.warning(
+                "Newsletter not sent: the Buttondown account has no verified "
+                "custom sending domain. Configure it in Buttondown → Settings "
+                "→ Sending, or disable the newsletter for this show. "
+                "Suppressing this stage for %d days.",
+                _SENDING_BLOCK_TTL_DAYS,
             )
         else:
             logger.error(
@@ -439,6 +541,15 @@ def send_show_newsletter(
     api_key = os.getenv(newsletter.api_key_env, "").strip()
     if not api_key:
         logger.info("Newsletter API key not set (%s). Skipping.", newsletter.api_key_env)
+        return None
+
+    # Skip before doing the work. Composing, scrubbing, contrast-checking
+    # and rendering a newsletter only to have Buttondown reject it for a
+    # standing account-configuration reason is wasted pipeline time and a
+    # guaranteed error at the end of every run (July 28 2026).
+    blocked = sending_block_reason()
+    if blocked:
+        logger.info("Newsletter skipped — %s", blocked)
         return None
 
     slug = getattr(config, "slug", "") or ""

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -31,6 +31,11 @@ GROK_TTS_COST_PER_1K_CHARS = 0.015
 # use them); only the display label is corrected here.
 _STEP_LABELS = {
     "x_thread_generation": "Digest",
+    # Output that was generated, billed, and thrown away because it hit
+    # max_tokens. A persistently non-zero line here means the show's
+    # llm.max_tokens is set below what its prompt actually needs.
+    "x_thread_generation_truncated": "Digest (truncated, discarded)",
+    "podcast_script_generation_truncated": "Podcast script (truncated, discarded)",
     "x_thread_generation_expansion": "Digest expansion retry",
     "x_thread_generation_retry": "Digest retry",
     "x_thread_generation_retry_edu": "Digest retry (edu)",

--- a/engine/url_utils.py
+++ b/engine/url_utils.py
@@ -24,6 +24,7 @@ malformed URL.
 from __future__ import annotations
 
 import logging
+import re
 import unicodedata
 from typing import Optional
 from urllib.parse import urlparse
@@ -212,7 +213,7 @@ def relabel_aggregator_links(text: str, articles) -> tuple[str, int]:
 
     count = 0
 
-    def _replace(match: "re.Match") -> str:
+    def _replace(match: re.Match) -> str:
         nonlocal count
         label, url = match.group(1), match.group(2)
         publisher = by_url.get(url.strip())
@@ -223,7 +224,5 @@ def relabel_aggregator_links(text: str, articles) -> tuple[str, int]:
             return f"[{publisher}]({url})"
         return match.group(0)
 
-    import re as _re
-
-    text = _re.sub(r"\[([^\]]+)\]\((https?://news\.google\.[^)]+)\)", _replace, text)
+    text = re.sub(r"\[([^\]]+)\]\((https?://news\.google\.[^)]+)\)", _replace, text)
     return text, count

--- a/run_show.py
+++ b/run_show.py
@@ -483,8 +483,19 @@ def _preflight_checks(config, *, dry_run: bool = False) -> None:
             )
         else:
             try:
-                from engine.newsletter import validate_api_key
-                if not validate_api_key(nl_key):
+                from engine.newsletter import sending_block_reason, validate_api_key
+                # A valid key is not the same as a sendable account. The
+                # preflight used to print "validated successfully" and the
+                # send then failed at the very end of every pipeline, which
+                # is a permanent false-green. If a previous run already
+                # learned the account cannot send, say so once, here, and
+                # skip the stage cleanly (July 28 2026).
+                blocked = sending_block_reason()
+                if blocked:
+                    logger.warning(
+                        "Newsletter skipped for '%s': %s", config.name, blocked
+                    )
+                elif not validate_api_key(nl_key):
                     logger.error(
                         "Newsletter API key validation FAILED for '%s' — "
                         "emails will not be sent this run",

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -186,7 +186,12 @@ llm:
   podcast_prompt_file: shows/prompts/fascinating_frontiers_podcast.txt
   digest_temperature: 0.5
   podcast_temperature: 0.75
-  max_tokens: 5000
+  # Raised 5000 -> 7500 (July 28 2026). 7 of 107 recorded runs (6%) hit
+  # the truncation retry; largest kept digest was 7,287 tokens, which the
+  # old ceiling could never have produced in one call. Matches the retry
+  # ceiling (5000 x 1.5), so a run that used to need two calls now needs
+  # one. Free on the 94% of runs that finish well under it.
+  max_tokens: 7500
   podcast_max_tokens: 10000
   min_podcast_words: 1700
   podcast_expand_below_target: true

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -184,7 +184,13 @@ llm:
   podcast_prompt_file: shows/prompts/omni_view_podcast.txt
   digest_temperature: 0.5
   podcast_temperature: 0.7
-  max_tokens: 10000
+  # Raised 10000 -> 13000 (July 28 2026). 21 of 117 recorded runs (17%)
+  # hit the truncation retry, each one paying for a full 10k-token digest
+  # that was then discarded and regenerated at 15k. Largest digest
+  # actually kept: 12,000 tokens. Output tokens bill on what is produced,
+  # not on the ceiling, so headroom is free on the 83% of runs that never
+  # reach it — this removes a wasted call without adding any cost.
+  max_tokens: 13000
   podcast_max_tokens: 8000
   min_podcast_words: 1400
   podcast_expand_below_target: true

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -515,8 +515,12 @@ class TestLoadConfigRealFiles:
         assert cfg.llm.model == "grok-4.3"
         assert cfg.llm.digest_temperature == 0.5
         # Raised 4000 -> 10000 so the multi-perspective digest completes
-        # without truncation. See shows/omni_view.yaml.
-        assert cfg.llm.max_tokens == 10000
+        # without truncation, then 10000 -> 13000 (July 28 2026) because it
+        # still didn't: 21 of 117 recorded runs hit the truncation retry,
+        # each paying for a full 10k digest that was discarded and
+        # regenerated. Largest digest actually kept was 12,000 tokens.
+        # See shows/omni_view.yaml and tests/test_truncation_waste.py.
+        assert cfg.llm.max_tokens == 13000
         assert cfg.tts.stability == 0.5
         assert cfg.tts.style == 0.0
         # OV got its own dedicated theme in May 2026 (replaced LubechangeOilers.mp3).

--- a/tests/test_feed_and_cdn_resilience.py
+++ b/tests/test_feed_and_cdn_resilience.py
@@ -1,0 +1,228 @@
+"""Drift guards for P1-3 (feeds/CDN that fail every run) and P1-4 (false-green).
+
+Three degradations that had become background noise:
+
+  * Reddit feeds 429 from cloud egress. The descriptive-UA fix (July 21)
+    helped, but the retry predicate never covered 429 — a throttled feed
+    was dropped on the first refusal. A live probe on 2026-07-28 returned
+    200 / 200 / 429 for r/LocalLLaMA / r/SpaceXLounge / r/space in the
+    same second, so these are throttles to back off from, not blocks.
+  * The gallery CDN 403s and every render silently pays the authenticated
+    R2 fallback — visible only as INFO lines, so a bucket that stopped
+    being public looked like a healthy pipeline.
+  * The newsletter preflight printed "validated successfully" and the
+    send then failed at the end of every single run, because a valid API
+    key is not the same as an account that is allowed to send.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import engine.fetcher as fetcher  # noqa: E402
+import engine.gallery_library as gallery_library  # noqa: E402
+import engine.newsletter as newsletter  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestThrottleRetry:
+    def _response(self, status):
+        resp = Mock()
+        resp.status_code = status
+        resp.content = b"<rss/>"
+        resp.raise_for_status = Mock()
+        return resp
+
+    def test_429_is_retried_and_can_succeed(self):
+        calls = []
+
+        def _get(url, **kwargs):
+            calls.append(url)
+            return self._response(429 if len(calls) < 3 else 200)
+
+        with patch.object(fetcher.requests, "get", side_effect=_get):
+            resp = fetcher._fetch_url_with_retry("https://www.reddit.com/r/space/.rss")
+
+        assert resp.status_code == 200
+        assert len(calls) == 3, "throttled feed must be retried, not dropped"
+
+    def test_503_is_retried(self):
+        calls = []
+
+        def _get(url, **kwargs):
+            calls.append(url)
+            return self._response(503 if len(calls) < 2 else 200)
+
+        with patch.object(fetcher.requests, "get", side_effect=_get):
+            resp = fetcher._fetch_url_with_retry("https://example.com/feed.rss")
+        assert resp.status_code == 200
+        assert len(calls) == 2
+
+    def test_persistent_throttle_finally_raises(self):
+        with patch.object(fetcher.requests, "get",
+                          side_effect=lambda url, **kw: self._response(429)):
+            with pytest.raises(fetcher.ThrottledError):
+                fetcher._fetch_url_with_retry("https://www.reddit.com/r/space/.rss")
+
+    def test_404_is_not_retried(self):
+        """Retrying a dead feed is the waste this is meant to remove."""
+        calls = []
+
+        def _get(url, **kwargs):
+            calls.append(url)
+            resp = Mock()
+            resp.status_code = 404
+            resp.raise_for_status = Mock(
+                side_effect=fetcher.requests.exceptions.HTTPError("404")
+            )
+            return resp
+
+        with patch.object(fetcher.requests, "get", side_effect=_get):
+            with pytest.raises(fetcher.requests.exceptions.HTTPError):
+                fetcher._fetch_url_with_retry("https://example.com/gone.rss")
+        assert len(calls) == 1
+
+    def test_success_is_a_single_call(self):
+        calls = []
+
+        def _get(url, **kwargs):
+            calls.append(url)
+            return self._response(200)
+
+        with patch.object(fetcher.requests, "get", side_effect=_get):
+            fetcher._fetch_url_with_retry("https://example.com/feed.rss")
+        assert len(calls) == 1
+
+    def test_reddit_keeps_its_descriptive_user_agent(self):
+        """Reddit's guidelines require it; a browser UA draws the 429s."""
+        headers = fetcher._headers_for_url("https://www.reddit.com/r/space/.rss")
+        assert "nerranetwork-rss" in headers["User-Agent"]
+        other = fetcher._headers_for_url("https://www.nasaspaceflight.com/feed/")
+        assert "nerranetwork-rss" not in other["User-Agent"]
+
+
+class TestGalleryCdnVisibility:
+    @pytest.fixture(autouse=True)
+    def _reset_breaker(self):
+        gallery_library._prefer_r2_download = False
+        yield
+        gallery_library._prefer_r2_download = False
+
+    def _forbidden(self, *args, **kwargs):
+        err = gallery_library.requests.exceptions.HTTPError("403 Forbidden")
+        err.response = Mock(status_code=403)
+        raise err
+
+    def _entry(self, name="b"):
+        return {
+            "original_url": f"https://gallery.nerranetwork.com/a/{name}.jpeg",
+            "image_id": name,
+            "original_key": f"a/{name}.jpeg",
+        }
+
+    def test_first_403_emits_a_loud_annotation(self, tmp_path, capsys):
+        with patch.object(gallery_library.requests, "get", side_effect=self._forbidden), \
+             patch.object(gallery_library, "_download_via_r2", return_value=False):
+            result = gallery_library._download_entry(self._entry(), tmp_path)
+
+        assert result is None
+        out = capsys.readouterr().out
+        assert "::warning::gallery CDN rejected a public read" in out
+        assert "403" in out
+        # And the breaker flipped, so the rest of the run skips the CDN.
+        assert gallery_library._prefer_r2_download is True
+
+    def test_annotation_fires_once_not_per_image(self, tmp_path, capsys):
+        """Up to 16 library fetches per render — one warning, not sixteen."""
+        with patch.object(gallery_library.requests, "get", side_effect=self._forbidden), \
+             patch.object(gallery_library, "_download_via_r2", return_value=False):
+            for i in range(5):
+                gallery_library._download_entry(self._entry(f"img{i}"), tmp_path)
+
+        out = capsys.readouterr().out
+        assert out.count("::warning::gallery CDN rejected a public read") == 1
+
+    def test_healthy_cdn_stays_silent(self, tmp_path, capsys):
+        ok = Mock(content=b"jpegbytes", raise_for_status=Mock())
+        with patch.object(gallery_library.requests, "get", return_value=ok):
+            result = gallery_library._download_entry(self._entry(), tmp_path)
+
+        assert result is not None
+        assert "::warning::" not in capsys.readouterr().out
+        assert gallery_library._prefer_r2_download is False
+
+
+class TestNewsletterSendingBlock:
+    @pytest.fixture(autouse=True)
+    def _isolate_marker(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            newsletter, "_SENDING_BLOCKED_MARKER", tmp_path / "blocked.json"
+        )
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            '{"code":"email_invalid","detail":"configure a custom sending domain"}',
+            "EMAIL_INVALID: you must configure a custom sending domain first",
+        ],
+    )
+    def test_sending_domain_error_is_recognised(self, detail):
+        assert newsletter._is_sending_domain_error(detail) is True
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            '{"code":"tag_invalid","detail":"unknown tag"}',
+            "500 Internal Server Error",
+            "",
+        ],
+    )
+    def test_other_errors_are_not_swallowed(self, detail):
+        assert newsletter._is_sending_domain_error(detail) is False
+
+    def test_block_is_remembered_then_reported(self):
+        assert newsletter.sending_block_reason() is None
+        newsletter._remember_sending_block("email_invalid: sending domain")
+        reason = newsletter.sending_block_reason()
+        assert reason and "sending domain" in reason
+
+    def test_block_expires_so_a_fix_is_picked_up_automatically(self):
+        import datetime
+        newsletter._remember_sending_block("email_invalid: sending domain")
+        stale = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            days=newsletter._SENDING_BLOCK_TTL_DAYS + 1
+        )
+        newsletter._SENDING_BLOCKED_MARKER.write_text(
+            json.dumps({"blocked_at": stale.isoformat(), "detail": "x"}),
+            encoding="utf-8",
+        )
+        assert newsletter.sending_block_reason() is None
+
+    def test_successful_send_clears_the_block(self):
+        newsletter._remember_sending_block("email_invalid: sending domain")
+        assert newsletter.sending_block_reason() is not None
+        newsletter.clear_sending_block()
+        assert newsletter.sending_block_reason() is None
+
+    def test_corrupt_marker_is_not_fatal(self):
+        newsletter._SENDING_BLOCKED_MARKER.write_text("{not json", encoding="utf-8")
+        assert newsletter.sending_block_reason() is None
+
+    def test_send_skips_early_when_blocked(self):
+        """Skip before composing, not after — the point is to stop the waste."""
+        source = (REPO_ROOT / "engine" / "newsletter.py").read_text(encoding="utf-8")
+        body = source.split("def send_show_newsletter(")[1]
+        assert "sending_block_reason()" in body.split("_can_send_now(")[0], \
+            "the block check must run before the send guards and composition"
+
+    def test_preflight_consults_the_block(self):
+        source = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "sending_block_reason" in source

--- a/tests/test_truncation_waste.py
+++ b/tests/test_truncation_waste.py
@@ -1,0 +1,162 @@
+"""Drift guards for wasted truncation retries (July 28 2026, P1-1).
+
+When a generation call hits ``max_tokens`` the code retries at 1.5x and
+replaces ``text``/``meta`` wholesale. The first call's tokens were
+therefore billed by xAI and recorded nowhere — the waste was invisible
+in every credit file.
+
+That mattered more than the accounting: the improvement plan had to
+infer the problem from run logs and named the wrong show. Measured
+across the committed credit files, SpaceX has hit the digest truncation
+retry in **0 of 45** recorded runs (largest completion 3,870 against a
+4,000 cap). The real offenders are Omni View (21/117, 17%) and
+Fascinating Frontiers (7/107, 6%), whose caps are raised here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from engine.config import load_config  # noqa: E402
+from engine.tracking import (  # noqa: E402
+    _STEP_LABELS,
+    create_tracker,
+    save_usage,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestDiscardedCallIsRecorded:
+    def test_helper_records_under_its_own_step(self):
+        from engine.generator import _record_discarded_call
+
+        class _Cfg:
+            class llm:
+                model = "grok-4.3"
+
+        tracker = create_tracker("Show", 1)
+        meta = {"usage": {"prompt_tokens": 8000, "completion_tokens": 10000,
+                          "cached_tokens": 0}}
+        _record_discarded_call(tracker, "x_thread_generation_truncated", meta, _Cfg)
+
+        bucket = tracker["services"]["grok_api"]["x_thread_generation_truncated"]
+        assert bucket["completion_tokens"] == 10000
+        # Must not be folded into the successful call's bucket, or the
+        # waste becomes indistinguishable from useful output.
+        assert "x_thread_generation" in tracker["services"]["grok_api"]
+        assert (
+            tracker["services"]["grok_api"]["x_thread_generation"]["completion_tokens"]
+            == 0
+        )
+
+    def test_discarded_cost_reaches_the_episode_total(self, tmp_path):
+        """P0-3 sums every bucket, so the waste now shows up in dollars."""
+        from engine.generator import _record_discarded_call
+
+        class _Cfg:
+            class llm:
+                model = "grok-4.3"
+
+        tracker = create_tracker("Show", 1)
+        _record_discarded_call(
+            tracker, "x_thread_generation_truncated",
+            {"usage": {"prompt_tokens": 8000, "completion_tokens": 10000}}, _Cfg,
+        )
+        import json
+        data = json.loads(
+            Path(save_usage(tracker, tmp_path)).read_text(encoding="utf-8")
+        )
+        assert data["total_estimated_cost_usd"] > 0
+
+    def test_missing_usage_is_a_noop(self):
+        from engine.generator import _record_discarded_call
+
+        class _Cfg:
+            class llm:
+                model = "grok-4.3"
+
+        tracker = create_tracker("Show", 1)
+        _record_discarded_call(tracker, "x_thread_generation_truncated", {}, _Cfg)
+        assert "x_thread_generation_truncated" not in tracker["services"]["grok_api"]
+
+    def test_no_tracker_is_a_noop(self):
+        from engine.generator import _record_discarded_call
+
+        class _Cfg:
+            class llm:
+                model = "grok-4.3"
+
+        # Must not raise — generation runs without a tracker in --test mode.
+        _record_discarded_call(None, "step", {"usage": {}}, _Cfg)
+
+    @pytest.mark.parametrize(
+        "step",
+        ["x_thread_generation_truncated", "podcast_script_generation_truncated"],
+    )
+    def test_discarded_steps_are_labelled(self, step):
+        assert step in _STEP_LABELS
+        assert "discarded" in _STEP_LABELS[step].lower()
+
+
+class TestBothRetryPathsRecord:
+    """Digest and podcast both throw away a call; both must account for it."""
+
+    def test_wired_into_both_truncation_retries(self):
+        source = (REPO_ROOT / "engine" / "generator.py").read_text(encoding="utf-8")
+        assert source.count("_record_discarded_call(") >= 3  # def + 2 call sites
+        assert "x_thread_generation_truncated" in source
+        assert "podcast_script_generation_truncated" in source
+
+    def test_recorded_before_meta_is_overwritten(self):
+        """Order matters: after the retry, the first call's usage is gone."""
+        source = (REPO_ROOT / "engine" / "generator.py").read_text(encoding="utf-8")
+        block = source.split('"x_thread_generation_truncated", meta, config)')[1]
+        # The very next _call_grok is the retry that replaces meta.
+        assert block.lstrip().startswith("text, meta = _call_grok(")
+
+
+class TestRaisedCaps:
+    """The caps raised on measured evidence, pinned so they don't drift back."""
+
+    @pytest.mark.parametrize(
+        "slug,minimum",
+        [
+            # 17% retry rate at 10,000; largest kept digest 12,000 tokens.
+            ("omni_view", 13000),
+            # 6% retry rate at 5,000; largest kept digest 7,287 tokens.
+            ("fascinating_frontiers", 7500),
+        ],
+    )
+    def test_cap_clears_the_largest_observed_digest(self, slug, minimum):
+        config = load_config(REPO_ROOT / "shows" / f"{slug}.yaml")
+        assert config.llm.max_tokens >= minimum
+
+    def test_spacex_cap_left_alone(self):
+        """The plan named SpaceX; the data says it has never truncated.
+
+        Raising a cap that is never reached would be a no-op change to a
+        live show's config, so it is deliberately not made.
+        """
+        config = load_config(REPO_ROOT / "shows" / "spacex.yaml")
+        assert config.llm.max_tokens == 4000
+
+    def test_raised_caps_carry_their_evidence(self):
+        """A future reader must be able to see why the number is what it is."""
+        for slug in ("omni_view", "fascinating_frontiers"):
+            raw = (REPO_ROOT / "shows" / f"{slug}.yaml").read_text(encoding="utf-8")
+            head = raw.split("max_tokens:")[0]
+            assert "truncation retry" in head, f"{slug} cap lacks a rationale comment"
+
+    def test_every_show_still_loads(self):
+        """A malformed YAML comment would break the whole network."""
+        for path in sorted((REPO_ROOT / "shows").glob("*.yaml")):
+            if path.name.startswith("_"):
+                continue
+            assert yaml.safe_load(path.read_text(encoding="utf-8")) is not None


### PR DESCRIPTION
Two commits: the lint fix for #895 (which merged with the gate red), then **Phase 2** of `NERRA_IMPROVEMENT_PLAN.md`.

No audio, prompt, or spoken-script changes — nothing here is behind the landmine #17 A/B gate. **Added cost: zero.** P1-1 removes calls; the rest only changes what gets logged and when a retry fires.

---

## `af28f8c` — ruff F821 (fixes the red gate on main)

`_replace` was annotated `match: "re.Match"` while `re` was imported *inside* the enclosing function, below that line. Moved the import to module scope. `from __future__ import annotations` was already deferring evaluation, so this was lint-correctness, not runtime — the merged P0-2 behaviour is unaffected.

**Note for the plan:** its P3 item says the ruff gate has been *"red on main since before July 22"*. Not so — ruff reports exactly **one** error on merged main, and it's this one. The gate was green and caught a real defect on the first commit that introduced one. That P3 item can be closed as already-resolved.

## `d33e4d7` — Phase 2

### P1-1 — the plan named the wrong show, and here's why nobody could tell

Measured every committed credit file against each show's configured cap:

| Show | Cap | Runs | Hit the retry | Largest kept digest |
|---|---:|---:|---:|---:|
| **Omni View** | 10,000 | 117 | **21 (17%)** | 12,000 |
| **Fascinating Frontiers** | 5,000 | 107 | **7 (6%)** | 7,287 |
| SpaceX | 4,000 | 45 | **0 (0%)** | 3,870 |

The plan said SpaceX truncates every day. It never has.

The reason that was invisible is the real bug: **both retry paths replace `text`/`meta` wholesale, so the discarded call's tokens were billed by xAI and recorded nowhere.** The waste was absent from every credit file — which is exactly why it had to be inferred from run logs, and was inferred wrong.

So: fix the accounting first (`_record_discarded_call`, under its own step key so waste can never hide inside useful output — and since #895 made `save_usage` sum every bucket, it now lands in the episode total), *then* raise only the two caps the data supports. Each carries its evidence in a YAML comment. Output tokens bill on what's produced, not on the ceiling, so headroom is free on runs that never reach it.

**SpaceX is deliberately left alone**, with a test pinning that, so a future reader doesn't "fix" it from the plan.

### P1-3 — feeds failing every run

**Reddit was half-solved already.** The descriptive-UA fix shipped July 21 and works — a live probe returns 200 for r/LocalLLaMA and r/SpaceXLounge. But r/space returned **429 in the same second**, and `_fetch_url_with_retry` only retried `ConnectionError`/`Timeout` — so a throttled feed was dropped on first refusal with no second attempt.

429 and 503 are now retryable. 404/403 deliberately are **not** — retrying a dead feed is the waste this is meant to remove. Verified live: r/space and r/astronomy both go from hard failure to 200.

**Gallery CDN:** the 403 → authenticated-R2 fallback was visible only as an INFO line per image, so a bucket that had stopped being public looked like a healthy pipeline while every render silently paid the slower path up to 16×. The first 403 now prints a `::warning::` — once per run, not once per image, with a test for that distinction.

### P1-4 — newsletter false-green

"Buttondown API key validated successfully" followed by a send failure at the end of every pipeline is how people learn to ignore errors. A valid key is not a sendable account. The sending-domain refusal is now recognised specifically and reported as **one actionable warning naming the fix**, instead of a generic `logger.error`; the send stage also skips *before* composing, scrubbing, contrast-checking and rendering something Buttondown will refuse.

**Scope stated honestly, in the code as well as here:** the remembered-block file is gitignored runtime state (matching the existing double-send guardrail), so on Actions — fresh clone per run — it suppresses *within* a run, not across runs. The part that always works is the message. **The durable fix is operator-side:** configure the sending domain, or turn the newsletter off. Buttondown documents no "can this account send yet" endpoint, and guessing at an undocumented schema would be worse than an honest warning.

---

## Verification

- `ruff check engine/ run_show.py scripts/` → all checks passed.
- 39 new tests across two drift-guard files, all green; targeted suites (generator, tracking, newsletter ×3, fetcher) green.
- Full-suite comparison against baseline is running; I'll report it here.
- Live probes rather than assumptions: Reddit 429→200 after the retry change; the cap evidence is computed from committed credit files, not logs.

One environmental note: `test_quick_wins::test_dashboard_emits_alerts_array` hangs in this sandbox (the dashboard generator makes a network call). It reproduces identically on clean `HEAD`, so it is not from this PR.

## Still outstanding

**P1-2** (single-pass video render) — needs ffprobe and extracted-frame comparison against real renders, and the plan says do it alone. All of P2/P3, plus the operator-only items (Buttondown sending domain, Apple badge, Search Console, Podcast Index dedup).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational and observability changes with targeted config raises; no auth, payment, or breaking API changes. Newsletter block file is runtime-only and TTL-bounded.
> 
> **Overview**
> **Phase 2** of the improvement plan: less wasted LLM spend, clearer ops signals, and fewer false-green newsletter runs. Includes a small **ruff F821** fix (`re` import at module scope in `url_utils.py`).
> 
> **Truncation waste (P1-1):** Digest and podcast paths that hit `max_tokens` and retry at 1.5× now record the **discarded** call via `_record_discarded_call` under dedicated tracking steps, so billed tokens no longer disappear when `meta` is overwritten. **Omni View** `max_tokens` **10k → 13k** and **Fascinating Frontiers** **5k → 7k** (evidence in YAML comments); SpaceX cap unchanged.
> 
> **Feeds & CDN (P1-3):** HTTP **429/503** raise `ThrottledError` and participate in existing fetch retries (404 still not retried). Gallery library emits a **single** `::warning::` on first public CDN 403 before switching to R2 for the rest of the run.
> 
> **Newsletter (P1-4):** Buttondown “no verified sending domain” is detected, logged once as an actionable warning, remembered in gitignored `digests/_newsletter_sending_blocked.json` (7-day TTL), and causes **early skip** in preflight and `send_show_newsletter` instead of failing after full composition. Successful sends clear the marker.
> 
> **Tests:** New drift guards in `test_feed_and_cdn_resilience.py` and `test_truncation_waste.py`; config test updated for Omni View token cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903e09949b0fb6fd2c90f4fe6acfc1335b200c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->