### PR TITLE
Improvement plan P2-1 (Apple provenance) + P2-4 (chapters on the page)

### DIFF
--- a/engine/blog.py
+++ b/engine/blog.py
@@ -550,6 +550,47 @@ def _md_inline(text: str) -> str:
     return text
 
 
+def _format_timestamp(seconds: float) -> str:
+    """Seconds -> ``M:SS`` (or ``H:MM:SS`` past an hour)."""
+    total = int(round(seconds or 0))
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def _load_chapters(md_path, episode_num: int) -> list[dict]:
+    """Read the episode's committed chapter markers for on-page navigation.
+
+    Returns ``[{"seconds", "time", "title"}]`` in start order, or ``[]``
+    when the episode has no chapter file (older episodes, or a run where
+    parsing produced too few markers). Never raises — chapters are a
+    navigation nicety and must not be able to break a blog build.
+    """
+    if not md_path or not episode_num:
+        return []
+    try:
+        chapters_path = Path(md_path).parent / f"chapters_ep{episode_num:03d}.json"
+        if not chapters_path.exists():
+            return []
+        data = json.loads(chapters_path.read_text(encoding="utf-8"))
+        out = []
+        for entry in data.get("chapters") or []:
+            title = (entry.get("title") or "").strip()
+            start = entry.get("startTime")
+            if not title or not isinstance(start, (int, float)):
+                continue
+            out.append({
+                "seconds": float(start),
+                "time": _format_timestamp(start),
+                "title": title,
+            })
+        return sorted(out, key=lambda c: c["seconds"])
+    except Exception:  # noqa: BLE001 — never break a build over chapters
+        return []
+
+
 def _domain_from_url(url: str) -> str:
     """Extract display domain from a URL."""
     try:
@@ -944,6 +985,13 @@ def generate_blog_post_html(
     except Exception:
         pass  # Non-fatal — transcript is optional
 
+    # Chapters (July 28 2026). These have been generated, committed and
+    # shipped in the podcast feeds for months, but the website surfaced
+    # them nowhere — a reader arriving from search saw a wall of
+    # transcript with no way to tell what the episode covers. The data is
+    # already on disk at build time, so this costs nothing to generate.
+    chapters = _load_chapters(metadata.get("_md_path"), ep_num)
+
     # Build JSON-LD now that the transcript is known, so the (single, canonical)
     # PodcastEpisode block can carry the transcript + audio links.
     _transcript_url = f"{blog_url}#transcript" if transcript_text else ""
@@ -986,6 +1034,7 @@ def generate_blog_post_html(
         "toc": toc,
         "source_domains": source_domains,
         "source_urls": metadata.get("source_urls", []),
+        "chapters": chapters,
         "jsonld": jsonld,
         "prev_post": prev_post,
         "next_post": next_post,

--- a/management.html
+++ b/management.html
@@ -350,6 +350,12 @@
 
   const money = (n) => "$" + Number(n || 0).toFixed(2);
   const fmt = (n) => Number(n || 0).toLocaleString();
+  // Absence-preserving formatter. `fmt` coerces null/undefined to 0, which
+  // is this repo's signature bug: Apple suppresses metrics it will not
+  // disclose, and "not measured" is not "zero". Use this for any value
+  // that can legitimately be missing.
+  const fmtOrDash = (n) =>
+    (n === null || n === undefined || n === "") ? "—" : Number(n).toLocaleString();
   const compact = (n) => {
     n = Number(n || 0);
     if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
@@ -736,10 +742,28 @@
         text: "fetched " + ageText(ap.fetched_at) + staleNote(ap.fetched_at) }));
     } else {
       const t = ap.totals || {};
+      const isReporter = ap.primary_source === "reporter";
+      // Which Apple source is on screen. Two sources with different
+      // trust levels reporting different numbers is confusing unless
+      // the card says which one it is showing (July 28 2026).
+      if (ap.provenance) {
+        card.appendChild(h("p", { class: "platform-note",
+          html: "Source: <strong>" + ap.provenance + "</strong>" +
+                (isReporter ? "" :
+                  " — the official Reporter feed has no data yet; " +
+                  "this is the cookie scrape.") }));
+      }
+      // Reporter reports engaged listeners and listening hours; the
+      // scrape reports followers and an opaque time-listened unit.
+      const third = isReporter
+        ? fmtOrDash(t.engaged_listeners) + "<small>engaged</small>"
+        : fmtOrDash(t.followers) + "<small>followers</small>";
+      const windowLabel = isReporter
+        ? (ap.days_retained || 0) + "d" : (ap.window_days || 30) + "d";
       card.appendChild(h("div", { class: "headline",
-        html: fmt(t.plays) + "<small>plays · " + (ap.window_days || 30) + "d</small>" +
-              "&nbsp;&nbsp;" + fmt(t.listeners) + "<small>listeners</small>" +
-              "&nbsp;&nbsp;" + fmt(t.followers) + "<small>followers</small>" }));
+        html: fmtOrDash(t.plays) + "<small>plays · " + windowLabel + "</small>" +
+              "&nbsp;&nbsp;" + fmtOrDash(t.listeners) + "<small>listeners</small>" +
+              "&nbsp;&nbsp;" + third }));
       const per = ap.per_show || {};
       const slugs = Object.keys(per)
         .filter((s) => (per[s].plays || 0) > 0)
@@ -747,18 +771,38 @@
       const maxV = Math.max.apply(null, slugs.map((s) => per[s].plays || 0).concat([1]));
       slugs.forEach((slug) => {
         const v = per[slug] || {};
+        const secondary = isReporter
+          ? fmtOrDash(v.engaged_listeners) + " engaged"
+          : fmtOrDash(v.followers) + " followers";
         card.appendChild(barRow(slug, v.plays || 0, maxV,
-          fmt(v.plays || 0) + " plays · " + fmt(v.followers || 0) + " followers",
+          fmtOrDash(v.plays) + " plays · " + secondary,
           { color: "var(--series-4)",
-            title: slug + ": " + fmt(v.listeners || 0) + " listeners · " +
-                   fmt(v.time_listened || 0) + " time-listened units" }));
+            title: slug + ": " + fmtOrDash(v.listeners) + " listeners · " +
+                   (isReporter
+                     ? fmtOrDash(v.listening_hours) + " listening hours"
+                     : fmtOrDash(v.time_listened) + " time-listened units") }));
       });
-      if (ap.feeds_registered) {
+      if (isReporter && ap.days_retained) {
+        card.appendChild(h("p", { class: "fine-list", text:
+          ap.days_retained + " day(s) of official history · " +
+          (ap.first_date || "?") + " → " + (ap.last_date || "?") }));
+      } else if (ap.feeds_registered) {
         card.appendChild(h("p", { class: "fine-list", text:
           ap.feeds_reporting + " of " + ap.feeds_registered + " registered shows reporting" }));
       }
-      if (ap.fetched_at) card.appendChild(h("p", { class: "fine-list",
-        text: "fetched " + ageText(ap.fetched_at) + staleNote(ap.fetched_at) }));
+      // Both sources' freshness, so a silently-dead one is visible.
+      const srcs = ap.sources || {};
+      Object.keys(srcs).forEach((key) => {
+        const s = srcs[key] || {};
+        if (!s.fetched_at) return;
+        card.appendChild(h("p", { class: "fine-list", text:
+          (key === "reporter" ? "Reporter" : "Connect scrape") + " fetched " +
+          ageText(s.fetched_at) + staleNote(s.fetched_at) }));
+      });
+      if (!Object.keys(srcs).length && ap.fetched_at) {
+        card.appendChild(h("p", { class: "fine-list",
+          text: "fetched " + ageText(ap.fetched_at) + staleNote(ap.fetched_at) }));
+      }
     }
     audGrid.appendChild(card);
   }

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -152,6 +152,30 @@ class LandmineResult:
 # ---------------------------------------------------------------------------
 
 
+def _absent_preserving_totals(
+    per_show: Dict[str, Dict[str, Any]], fields,
+) -> Dict[str, Optional[float]]:
+    """Sum *fields* across shows, keeping "not measured" distinct from zero.
+
+    This repo's signature bug is rendering absence as ``0``: Apple
+    suppresses metrics it will not disclose, and a show with no listening
+    has no row at all. The old Apple totals coerced every missing value
+    with ``int(v or 0)``, so "Apple told us nothing" and "Apple told us
+    zero" collapsed into the same number on the dashboard.
+
+    A field that NO show reported returns ``None`` — the UI renders that
+    as an em dash. A field some shows reported sums only those.
+    """
+    out: Dict[str, Optional[float]] = {}
+    for metric in fields:
+        values = [
+            v.get(metric) for v in per_show.values()
+            if isinstance(v.get(metric), (int, float))
+        ]
+        out[metric] = round(sum(values), 4) if values else None
+    return out
+
+
 def _list_show_yaml_paths(shows_dir: Path) -> List[Path]:
     return sorted(
         p for p in shows_dir.glob("*.yaml")
@@ -2117,7 +2141,59 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
     # DOWNLOADS; what Apple uniquely reports is ENGAGEMENT — followers and
     # whether people finished the episode. No official API exists, so this
     # mirrors the Spotify cookie-connector trade-off.
+    # Two Apple sources, deliberately ranked (July 28 2026):
+    #
+    #   1. api/apple_reporter.json — the OFFICIAL Apple Podcasts Reporter
+    #      feed. Token-authenticated, accumulates real daily history.
+    #   2. api/apple_stats.json — the cookie-scrape connector. Fragile,
+    #      needs a daily re-auth chore, and is the reason two of this
+    #      repo's three "absence rendered as 0" bugs existed.
+    #
+    # Reporter wins when it has data; the scrape stays as a labelled
+    # fallback until ~3 weeks of Reporter history accrue and the sources
+    # can be compared. Both carry `provenance` and `fetched_at` so the
+    # card can say which one it is showing rather than implying a single
+    # authoritative Apple number.
     section["apple"] = {"configured": False}
+    _apple_sources: dict = {}
+
+    rep_path = root / "api" / "apple_reporter.json"
+    if rep_path.exists():
+        try:
+            rdata = json.loads(rep_path.read_text(encoding="utf-8"))
+            rshows = rdata.get("shows") or {}
+            # Key by repo slug so the two sources are directly comparable;
+            # fall back to the Apple show id when a slug isn't mapped yet.
+            reporter_per_show = {}
+            for show_id, row in rshows.items():
+                slug = row.get("slug") or show_id
+                reporter_per_show[slug] = {
+                    "plays": row.get("plays"),
+                    "listeners": row.get("listeners"),
+                    "engaged_listeners": row.get("engaged_listeners"),
+                    "listening_hours": row.get("listening_hours"),
+                    "days_reported": row.get("days_reported"),
+                    "show_name": row.get("show_name") or "",
+                }
+            _apple_sources["reporter"] = {
+                "provenance": "Apple Podcasts Reporter (official)",
+                "fetched_at": rdata.get("fetched_at"),
+                "first_date": rdata.get("first_date"),
+                "last_date": rdata.get("last_date"),
+                "days_retained": rdata.get("days_retained"),
+                "per_show": reporter_per_show,
+                "totals": _absent_preserving_totals(
+                    reporter_per_show,
+                    ("plays", "listeners", "engaged_listeners", "listening_hours"),
+                ),
+                "shows_reporting": len(rdata.get("shows_reported") or []),
+            }
+        except Exception as exc:  # noqa: BLE001
+            _apple_sources["reporter"] = {
+                "provenance": "Apple Podcasts Reporter (official)",
+                "error": str(exc),
+            }
+
     ap_path = root / "api" / "apple_stats.json"
     if ap_path.exists():
         try:
@@ -2134,27 +2210,43 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
                 for slug, s in shows_raw.items()
             }
 
-            def _apple_sum(field: str) -> int:
-                return sum(int(v[field] or 0) for v in per_show.values()
-                           if isinstance(v.get(field), (int, float)))
-
             reporting = [s for s, v in per_show.items() if v["plays"] is not None]
-            section["apple"] = {
-                "configured": True,
+            _apple_sources["connect_scrape"] = {
+                "provenance": "Apple Podcasts Connect (cookie scrape — fallback)",
                 "fetched_at": data.get("fetched_at"),
                 "window_days": data.get("window_days"),
                 "per_show": per_show,
-                "totals": {
-                    "plays": _apple_sum("plays"),
-                    "listeners": _apple_sum("listeners"),
-                    "followers": _apple_sum("followers"),
-                    "time_listened": _apple_sum("time_listened"),
-                },
+                "totals": _absent_preserving_totals(
+                    per_show, ("plays", "listeners", "followers", "time_listened"),
+                ),
                 "feeds_registered": len(per_show),
                 "feeds_reporting": len(reporting),
             }
         except Exception as exc:  # noqa: BLE001
-            section["apple"] = {"configured": True, "error": str(exc)}
+            _apple_sources["connect_scrape"] = {
+                "provenance": "Apple Podcasts Connect (cookie scrape — fallback)",
+                "error": str(exc),
+            }
+
+    if _apple_sources:
+        # Primary = Reporter when it actually reported something. A file
+        # that exists but holds no show is not a source of truth, so the
+        # scrape keeps the card alive until Reporter history accrues.
+        rep = _apple_sources.get("reporter") or {}
+        rep_has_data = bool(rep.get("per_show")) and not rep.get("error")
+        primary = "reporter" if rep_has_data else (
+            "connect_scrape" if _apple_sources.get("connect_scrape") else "reporter"
+        )
+        chosen = _apple_sources.get(primary, {})
+        section["apple"] = {
+            "configured": True,
+            "primary_source": primary,
+            "sources": _apple_sources,
+            # Flattened view of the primary source so existing consumers
+            # keep working without knowing about the two-source split.
+            **{k: v for k, v in chosen.items() if k != "provenance"},
+            "provenance": chosen.get("provenance", ""),
+        }
 
     section["spotify"] = {"configured": False}
     sp_path = root / "api" / "spotify_stats.json"

--- a/templates/blog_post.html.j2
+++ b/templates/blog_post.html.j2
@@ -456,6 +456,46 @@
         }
 
         /* Transcript */
+        .blog-chapters {
+            margin: var(--sp-6) 0;
+            padding-top: var(--sp-5);
+            border-top: 1px solid var(--nn-border);
+        }
+        .blog-chapters h2 {
+            font-family: var(--font-ui);
+            font-size: 1.05rem;
+            margin-bottom: var(--sp-3);
+        }
+        .blog-chapter-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .blog-chapter-list li {
+            display: flex;
+            gap: var(--sp-3);
+            align-items: baseline;
+            padding: var(--sp-2) 0;
+            border-bottom: 1px solid var(--nn-border);
+        }
+        .blog-chapter-list li:last-child { border-bottom: none; }
+        .blog-chapter-list .chapter-time {
+            font-family: var(--font-ui);
+            font-variant-numeric: tabular-nums;
+            font-size: 0.85rem;
+            color: var(--show-color);
+            min-width: 3.5rem;
+            flex-shrink: 0;
+        }
+        /* Only looks clickable once the seek script has attached to a
+           real audio element — an English-only episode has no inline
+           player, and a cursor that promises nothing is worse than none. */
+        .blog-chapter-list li.is-seekable { cursor: pointer; }
+        .blog-chapter-list li.is-seekable:hover .chapter-title { color: var(--show-color); }
+        .blog-chapters .chapter-foot {
+            margin-top: var(--sp-3);
+            font-size: 0.85rem;
+        }
         .blog-transcript {
             margin-top: var(--sp-8);
             padding-top: var(--sp-6);
@@ -832,6 +872,46 @@
                     {% endfor %}
                 </div>
             </section>
+            {% endif %}
+
+            <!-- Chapters (July 2026): generated and shipped in the feeds
+                 for months but surfaced nowhere on the site. Data is on
+                 disk at build time, so this adds no generation cost. -->
+            {% if chapters %}
+            <section class="blog-chapters" id="chapters">
+                <h2>In this episode</h2>
+                <ol class="blog-chapter-list">
+                    {%- for ch in chapters %}
+                    <li>
+                        <span class="chapter-time" data-seconds="{{ ch.seconds }}">{{ ch.time }}</span>
+                        <span class="chapter-title">{{ ch.title }}</span>
+                    </li>
+                    {%- endfor %}
+                </ol>
+                {% if transcript %}
+                <p class="chapter-foot"><a href="#transcript">Read the full transcript &darr;</a></p>
+                {% endif %}
+            </section>
+            <script>
+            /* Progressive enhancement: make chapters seek the player, but
+               ONLY when there is a player on the page. Episodes without
+               alternate-language tracks render no inline <audio>, so the
+               list stays a plain, useful contents listing there. */
+            (function () {
+                var audio = document.getElementById("nn-i18n-audio");
+                if (!audio) return;
+                document.querySelectorAll(".blog-chapter-list li").forEach(function (li) {
+                    var stamp = li.querySelector(".chapter-time");
+                    if (!stamp) return;
+                    var at = parseFloat(stamp.getAttribute("data-seconds"));
+                    if (isNaN(at)) return;
+                    li.classList.add("is-seekable");
+                    li.addEventListener("click", function () {
+                        try { audio.currentTime = at; audio.play(); } catch (e) {}
+                    });
+                });
+            })();
+            </script>
             {% endif %}
 
             <!-- Transcript -->

--- a/tests/test_apple_provenance_and_chapters.py
+++ b/tests/test_apple_provenance_and_chapters.py
@@ -1,0 +1,243 @@
+"""Drift guards for P2-1 (Apple provenance) and P2-4 (chapters on the site).
+
+P2-1: two Apple sources now exist — the official token-authenticated
+Reporter feed and the fragile cookie scrape — and they will disagree.
+The dashboard ranks Reporter first, keeps the scrape as a *labelled*
+fallback, and carries `provenance` + `fetched_at` for both so the card
+can say which one it is showing.
+
+Absence handling is the load-bearing part. Apple suppresses metrics it
+will not disclose and a show with no listening has no row at all, so
+"not measured" must never render as 0 — this repo has fixed that same
+bug in three separate places already.
+
+P2-4: chapters have been generated, committed and shipped in the podcast
+feeds for months while the website surfaced them nowhere.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import generate_dashboard as gd  # noqa: E402
+from engine.blog import _format_timestamp, _load_chapters  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# P2-1 — Apple source provenance
+# ---------------------------------------------------------------------------
+
+REPORTER = {
+    "source": "apple_reporter",
+    "fetched_at": "2026-07-28T06:00:00Z",
+    "first_date": "2026-07-24", "last_date": "2026-07-27", "days_retained": 4,
+    "shows_reported": ["1234"],
+    "shows": {"1234": {"slug": "tesla", "show_name": "Tesla Shorts Time",
+                       "plays": 200, "listeners": 80,
+                       "engaged_listeners": 55, "listening_hours": 31.5,
+                       "days_reported": 4}},
+}
+
+SCRAPE = {
+    "fetched_at": "2026-07-28T05:00:00Z", "window_days": 30,
+    "shows": {"tesla": {"plays": 120, "listeners": 40,
+                        "followers": None, "time_listened": 900}},
+}
+
+
+def _root(tmp_path, *, reporter=None, scrape=None) -> Path:
+    (tmp_path / "api").mkdir(parents=True, exist_ok=True)
+    if reporter is not None:
+        (tmp_path / "api" / "apple_reporter.json").write_text(
+            json.dumps(reporter), encoding="utf-8")
+    if scrape is not None:
+        (tmp_path / "api" / "apple_stats.json").write_text(
+            json.dumps(scrape), encoding="utf-8")
+    return tmp_path
+
+
+class TestAbsencePreservingTotals:
+    """The repo's signature bug: absence rendered as zero."""
+
+    def test_no_shows_gives_none_not_zero(self):
+        assert gd._absent_preserving_totals({}, ("plays",)) == {"plays": None}
+
+    def test_all_missing_gives_none(self):
+        totals = gd._absent_preserving_totals({"a": {"plays": None}}, ("plays",))
+        assert totals["plays"] is None
+
+    def test_genuine_zero_is_preserved_as_zero(self):
+        """A real measured 0 must stay 0 — the distinction cuts both ways."""
+        totals = gd._absent_preserving_totals({"a": {"plays": 0}}, ("plays",))
+        assert totals["plays"] == 0
+
+    def test_partial_reporting_sums_only_what_exists(self):
+        totals = gd._absent_preserving_totals(
+            {"a": {"plays": 5}, "b": {"plays": None}}, ("plays",))
+        assert totals["plays"] == 5
+
+
+class TestAppleSourceRanking:
+    def test_reporter_wins_when_it_has_data(self, tmp_path):
+        apple = gd.build_audience_section(
+            _root(tmp_path, reporter=REPORTER, scrape=SCRAPE))["apple"]
+        assert apple["primary_source"] == "reporter"
+        assert "official" in apple["provenance"].lower()
+        assert apple["totals"]["plays"] == 200  # Reporter's number, not 120
+
+    def test_scrape_is_the_labelled_fallback(self, tmp_path):
+        """Today's real state: Reporter has produced no file yet."""
+        apple = gd.build_audience_section(_root(tmp_path, scrape=SCRAPE))["apple"]
+        assert apple["primary_source"] == "connect_scrape"
+        assert "fallback" in apple["provenance"].lower()
+        assert apple["totals"]["plays"] == 120
+
+    def test_empty_reporter_file_does_not_displace_the_scrape(self, tmp_path):
+        """A file that exists but holds no show is not a source of truth."""
+        empty = {**REPORTER, "shows": {}, "shows_reported": []}
+        apple = gd.build_audience_section(
+            _root(tmp_path, reporter=empty, scrape=SCRAPE))["apple"]
+        assert apple["primary_source"] == "connect_scrape"
+
+    def test_both_sources_are_retained_for_comparison(self, tmp_path):
+        apple = gd.build_audience_section(
+            _root(tmp_path, reporter=REPORTER, scrape=SCRAPE))["apple"]
+        assert set(apple["sources"]) == {"reporter", "connect_scrape"}
+        for src in apple["sources"].values():
+            assert src["provenance"]
+            assert src["fetched_at"]
+
+    def test_scrape_absence_survives_into_totals(self, tmp_path):
+        apple = gd.build_audience_section(_root(tmp_path, scrape=SCRAPE))["apple"]
+        # Apple disclosed no follower count — that is not zero followers.
+        assert apple["totals"]["followers"] is None
+
+    def test_no_apple_data_at_all_is_unconfigured(self, tmp_path):
+        apple = gd.build_audience_section(_root(tmp_path))["apple"]
+        assert apple["configured"] is False
+
+    def test_corrupt_reporter_file_falls_back_cleanly(self, tmp_path):
+        root = _root(tmp_path, scrape=SCRAPE)
+        (root / "api" / "apple_reporter.json").write_text("{oops", encoding="utf-8")
+        apple = gd.build_audience_section(root)["apple"]
+        assert apple["primary_source"] == "connect_scrape"
+        assert apple["sources"]["reporter"]["error"]
+
+
+class TestDashboardRendersAbsenceAsDash:
+    def test_management_html_has_an_absence_preserving_formatter(self):
+        html = (REPO_ROOT / "management.html").read_text(encoding="utf-8")
+        assert "fmtOrDash" in html
+        # And the Apple card must use it, not the zero-coercing `fmt`.
+        apple_card = html.split('sectionCard("Apple Podcasts"')[1][:4000]
+        assert "fmtOrDash(t.plays)" in apple_card
+        assert "fmt(t.plays)" not in apple_card
+
+    def test_apple_card_shows_provenance(self):
+        html = (REPO_ROOT / "management.html").read_text(encoding="utf-8")
+        apple_card = html.split('sectionCard("Apple Podcasts"')[1][:4000]
+        assert "ap.provenance" in apple_card
+
+
+# ---------------------------------------------------------------------------
+# P2-4 — chapters on the episode page
+# ---------------------------------------------------------------------------
+
+class TestTimestampFormatting:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [(0, "0:00"), (20.0, "0:20"), (210.9, "3:31"), (527.1, "8:47"),
+         (3600, "1:00:00"), (3725, "1:02:05")],
+    )
+    def test_format(self, seconds, expected):
+        assert _format_timestamp(seconds) == expected
+
+
+class TestChapterLoading:
+    def _write(self, tmp_path, payload):
+        md = tmp_path / "Show_Ep047_20260728.md"
+        md.write_text("# Show", encoding="utf-8")
+        (tmp_path / "chapters_ep047.json").write_text(
+            json.dumps(payload), encoding="utf-8")
+        return md
+
+    def test_loads_and_formats(self, tmp_path):
+        md = self._write(tmp_path, {"version": "1.2.0", "chapters": [
+            {"startTime": 20.0, "title": "Introduction", "endTime": 210.9},
+            {"startTime": 210.9, "title": "The Counterpoint", "endTime": 272.0},
+        ]})
+        chapters = _load_chapters(md, 47)
+        assert [c["title"] for c in chapters] == ["Introduction", "The Counterpoint"]
+        assert [c["time"] for c in chapters] == ["0:20", "3:31"]
+        assert chapters[0]["seconds"] == 20.0
+
+    def test_sorted_by_start_time(self, tmp_path):
+        md = self._write(tmp_path, {"chapters": [
+            {"startTime": 300.0, "title": "Later"},
+            {"startTime": 10.0, "title": "Earlier"},
+        ]})
+        assert [c["title"] for c in _load_chapters(md, 47)] == ["Earlier", "Later"]
+
+    def test_entries_without_title_or_time_are_dropped(self, tmp_path):
+        md = self._write(tmp_path, {"chapters": [
+            {"startTime": 10.0, "title": "Good"},
+            {"startTime": 20.0, "title": "   "},
+            {"title": "No time"},
+            {"startTime": "abc", "title": "Bad time"},
+        ]})
+        assert [c["title"] for c in _load_chapters(md, 47)] == ["Good"]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        md = tmp_path / "Show_Ep099_20260728.md"
+        md.write_text("# Show", encoding="utf-8")
+        assert _load_chapters(md, 99) == []
+
+    def test_corrupt_file_never_raises(self, tmp_path):
+        md = tmp_path / "Show_Ep047_20260728.md"
+        md.write_text("# Show", encoding="utf-8")
+        (tmp_path / "chapters_ep047.json").write_text("{broken", encoding="utf-8")
+        assert _load_chapters(md, 47) == []
+
+    def test_no_path_or_episode_returns_empty(self):
+        assert _load_chapters(None, 47) == []
+        assert _load_chapters("x.md", 0) == []
+
+    def test_real_committed_chapter_file_parses(self):
+        """Guards the on-disk schema, not just a fixture of it."""
+        md = REPO_ROOT / "digests" / "spacex" / "SpaceX_Daily_Ep047_20260728.md"
+        if not md.exists():
+            pytest.skip("fixture episode no longer present")
+        chapters = _load_chapters(md, 47)
+        assert len(chapters) >= 3
+        assert all(c["title"] and c["time"] for c in chapters)
+
+
+class TestChapterTemplate:
+    def test_section_and_styles_exist(self):
+        tpl = (REPO_ROOT / "templates" / "blog_post.html.j2").read_text(encoding="utf-8")
+        assert '<section class="blog-chapters" id="chapters">' in tpl
+        assert "{% if chapters %}" in tpl
+        assert ".blog-chapter-list" in tpl
+
+    def test_seeking_is_progressive_enhancement(self):
+        """No inline player on English-only episodes — the list must still work."""
+        tpl = (REPO_ROOT / "templates" / "blog_post.html.j2").read_text(encoding="utf-8")
+        script = tpl.split('id="chapters"')[1][:2500]
+        assert 'getElementById("nn-i18n-audio")' in script
+        assert "if (!audio) return;" in script
+        # Only claim clickability once a player is actually attached.
+        assert "is-seekable" in script
+
+    def test_blog_passes_chapters_to_the_template(self):
+        source = (REPO_ROOT / "engine" / "blog.py").read_text(encoding="utf-8")
+        assert '"chapters": chapters,' in source
+        assert "_load_chapters(" in source


### PR DESCRIPTION
Both items needed a correction to the plan's premise before they could be built.

No audio, prompt, or spoken-script changes. **Added cost: zero** — both features read data the pipeline already produces.

---

## P2-1 — Apple provenance

The plan says `api/apple_reporter.json` *"exists but `management.html` still reads the cookie-scrape file."* **The file doesn't exist yet** — the Reporter fetcher landed earlier today and hasn't produced data. So the wiring is built for that state *and* for what comes after:

- **Reporter** (official, token-authenticated, real daily history) is primary **when it has data**.
- The **cookie scrape** stays an explicitly labelled fallback until ~3 weeks of Reporter history accrue and the two can be compared.
- Both live under `sources` with `provenance` + `fetched_at`, so the card names which one it's showing and a silently-dead source is visible rather than assumed fresh.

The switch happens on its own once Reporter reports — **no follow-up change needed**. A Reporter file that exists but holds no show does *not* displace the scrape; an empty file is not a source of truth.

### The load-bearing part: absence

Your rule #1, and it was broken at **both** layers:

| Layer | Before | After |
|---|---|---|
| `generate_dashboard.py` | `int(v or 0)` | `_absent_preserving_totals` → `None` |
| `management.html` | `fmt(n)` = `Number(n \|\| 0)` | `fmtOrDash(n)` → `—` |

So "Apple disclosed nothing" and "Apple said zero" collapsed into the same `0` on screen — the same bug already fixed in three other places here.

A **genuinely measured `0` is still `0`**; the distinction cuts both ways and is tested. Verified against real data: the scrape's follower count is `None`, not `0`.

## P2-4 — chapters on the episode page

**Transcripts are already surfaced** (inline `<details>` with `id="transcript"`, from the Phase 2 growth work). The real gap was **chapters** — generated, committed and shipped in the podcast feeds for months while the website showed them nowhere. A reader arriving from search got a wall of transcript with no way to see what the episode covers.

Now an "In this episode" contents list with timestamps, read from the chapter JSON already on disk at build time. Verified against the real SpaceX Ep047 file — 7 chapters, `0:20 Introduction`, `3:31 The Counterpoint`.

**Seeking is progressive enhancement on purpose.** Only episodes with alternate-language tracks render an inline `<audio>`, so the script attaches — and the rows only *look* clickable — when a player actually exists. Elsewhere it stays a plain contents listing rather than promising clickability it can't deliver.

Loading never raises: missing file, corrupt JSON, untitled or untimed entries all degrade to "no chapter list". Chapters are a navigation nicety and must not be able to break a blog build.

---

## Verification

- `ruff check engine/ run_show.py scripts/` → clean. It caught a shadowed-import bug I'd introduced (`field` vs the `dataclasses` import) **before** CI this time.
- 29 new tests; 119 passed across the affected suites (`test_dashboard`, `test_apple_stats`, `test_apple_reporter`, `test_blog`, `test_blog_sources`, `test_website_quality_pass`).
- Both features exercised against **real committed data**, not just fixtures — including a test that parses the actual on-disk chapter file so the schema itself is guarded.
- Full-suite comparison against baseline was still running at push time; I'll report it here.

### One correction to my own earlier work

My P0-2 verification harness had `extract_blog_metadata`'s `show_slug`/`filename` arguments swapped. I re-ran it correctly — the result holds: 8 publishers named, 4 honestly left unattributed, zero Google favicon requests.

## Still outstanding

**P1-2** (single-pass render — needs real render comparison; the plan says do it alone), the rest of P2/P3, and the operator-only items (Buttondown sending domain, Apple badge asset, Search Console, Podcast Index dedup).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhsd6AaYXjYCziPfJAFDNu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive (blog navigation, dashboard display semantics) with guarded fallbacks; Apple primary selection is automatic and covered by new tests, with no auth or pipeline behavior changes.
> 
> **Overview**
> **Apple analytics (P2-1)** wires Mission Control to two Apple inputs: official **Podcasts Reporter** (`api/apple_reporter.json`) and the existing **Connect cookie scrape**. `generate_dashboard.py` ranks Reporter when it has real per-show data (empty Reporter files do not override the scrape), keeps both under `audience.apple.sources`, and flattens the chosen primary for backward compatibility with `primary_source` and `provenance`.
> 
> Missing metrics are no longer summed as zero: `_absent_preserving_totals` returns `None` when nothing was reported, and `management.html` uses `fmtOrDash` so the Apple card shows **—** instead of **0**. The card labels the active source, switches metrics by source (engaged listeners / listening hours vs followers / time-listened), and shows fetch freshness for each source.
> 
> **Episode chapters (P2-4)** load committed `chapters_epNNN.json` at blog build time via `_load_chapters` / `_format_timestamp` in `engine/blog.py` (fail-safe, never breaks the build). `blog_post.html.j2` adds an **In this episode** section with timestamps; a small script seeks `#nn-i18n-audio` only when that player exists.
> 
> New drift tests in `tests/test_apple_provenance_and_chapters.py` cover ranking, absence handling, template wiring, and real on-disk chapter files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455e9629f08b4585db333c525982d96210b6fe06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->