### PR TITLE
P3 hygiene: schedule the maintenance that was written but never run

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -225,6 +225,26 @@ jobs:
         # upload landed). Deterministic from summaries → usually a no-op.
         run: python scripts/build_video_feeds.py --all || echo "::warning::Video-feed rebuild failed (non-fatal)"
 
+      - name: Clean up merged recovery branches
+        # Landmine #23 parks an episode on a recovery/* branch whenever a
+        # show's artifact push exhausts its retry loop. Merged ones were
+        # never cleaned up, and an UNMERGED one is a stranded episode —
+        # generated, paid for, never published — that nobody was watching
+        # for. Deletes only branches provably already on main; an unmerged
+        # branch is reported, never removed.
+        run: |
+          git fetch origin 'refs/heads/recovery/*:refs/remotes/origin/recovery/*' --quiet || true
+          python scripts/prune_recovery_branches.py --apply \
+            || echo "::warning::Recovery-branch cleanup failed (non-fatal)"
+
+      - name: Warn when the Apple Reporter feed goes stale
+        # The Reporter access token expires 180 days after issue, and a
+        # dead token is the most likely cause of a rollup that stops
+        # advancing. The fetcher deliberately leaves the store untouched
+        # when every request fails (better stale-but-real than empty), so
+        # silence is indistinguishable from success without this check.
+        run: python scripts/check_apple_reporter_freshness.py || true
+
       # NOTE on the committed-paths list below: `*.video.rss` is NOT
       # redundant with `*_podcast.*.rss`. Tesla's audio feed is the ROOT
       # podcast.rss, so its video feed is podcast.video.rss, which the

--- a/.github/workflows/storage-prune.yml
+++ b/.github/workflows/storage-prune.yml
@@ -1,0 +1,120 @@
+name: Storage Prune (video R2)
+
+# The video keyspace grows ~318 GB/year and nothing expires it. Each
+# rendered episode is ~174 MB, five shows publish daily, and every video
+# feed lists only `max_episodes` (30) items — so episode 31 and older are
+# already unreachable by any listener while still being billed for.
+#
+# `scripts/prune_video_r2.py` deletes by REACHABILITY, not by age: an
+# object survives if any live `*.video.rss` or any durable
+# `digests/<slug>/video_assets.json` still references it, and a per-show
+# `--keep-newest` floor means a bug in feed generation cannot cascade
+# into deleting a back catalogue. That is why this is a script on a cron
+# rather than a bucket lifecycle rule — a lifecycle rule expires by age,
+# which would delete still-listed episodes out from under a show that
+# paused for two months.
+#
+# Ownership split, consistent with the rest of the repo:
+#   - Daily Audit          -> quality + missed-episode detection
+#   - Nightly Maintenance  -> heavy, idempotent artifact/index builds
+#   - THIS workflow        -> monthly, irreversible storage reclamation
+#
+# It is deliberately NOT folded into nightly: it is the only scheduled
+# job in the repo that permanently destroys data, and it should be
+# separately visible, separately runnable, and separately revertible
+# (disable this one file) without touching the nightly pipeline.
+
+on:
+  schedule:
+    # Monthly, on the 3rd at 04:20 UTC. Well clear of the daily show
+    # slate (which finishes as late as ~16:00 once GitHub's scheduling
+    # delay is counted) and of nightly maintenance at 16:45, so a prune
+    # can never race a publish that is still writing objects.
+    - cron: '20 4 3 * *'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually delete (unchecked = dry run report only)'
+        type: boolean
+        default: false
+      keep_newest:
+        description: 'Per-show floor of objects to retain regardless of references'
+        type: string
+        default: '60'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: storage-prune
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The reachability check reads the committed video feeds and
+          # per-show asset indexes; a shallow clone of the tip is all it
+          # needs, and matches the repo's shallow-clone convention
+          # (landmine #1 — full clones cost ~2.5 GB).
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install boto3 pyyaml
+
+      - name: Prune unreachable video objects
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # Scheduled runs prune for real — that is the point of the job.
+          # Manual runs default to a dry run so an operator can look
+          # before deleting.
+          APPLY: ${{ github.event_name == 'schedule' && 'true' || inputs.apply }}
+          KEEP_NEWEST: ${{ inputs.keep_newest || '60' }}
+        run: |
+          set -o pipefail
+          if [ -z "${R2_ENDPOINT_URL}" ] || [ -z "${R2_ACCESS_KEY_ID}" ]; then
+            echo "::warning::R2 credentials not configured — skipping prune."
+            exit 0
+          fi
+
+          FLAGS="--keep-newest ${KEEP_NEWEST}"
+          if [ "${APPLY}" = "true" ]; then
+            FLAGS="${FLAGS} --apply"
+            echo "Running in APPLY mode — objects will be deleted."
+          else
+            echo "Running as a DRY RUN — nothing will be deleted."
+          fi
+
+          # Tee the report so it lands in the job summary. A destructive
+          # scheduled job that leaves no audit trail is how you discover
+          # a bad prune months later.
+          python scripts/prune_video_r2.py ${FLAGS} 2>&1 | tee prune-report.txt
+
+      - name: Publish report to the job summary
+        if: always()
+        run: |
+          {
+            echo "## Video storage prune"
+            echo ""
+            if [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "Mode: **apply** (scheduled monthly run)"
+            else
+              echo "Mode: **${{ inputs.apply && 'apply' || 'dry run' }}** (manual dispatch)"
+            fi
+            echo ""
+            echo '```'
+            cat prune-report.txt 2>/dev/null || echo "(no report produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -81,6 +81,18 @@ Public, display-safe extracts live in `site/data/` (e.g.
     `Reporter.properties`. Paste it in yourself. Lost it? `Sales.viewToken`
     reprints it — do not re-run `generateToken`, which invalidates the
     old token (one active token per Apple Account).
+  * **The token expires 180 days after issue.** This one was issued in
+    late July 2026, so it dies around **late January 2027** — worth a
+    calendar entry, because the failure is silent *by design*:
+    `fetch_apple_reporter.py` leaves the store untouched when every
+    request fails (stale-but-real beats empty), so a dead token yields a
+    green nightly job and a dashboard still showing plausible numbers.
+    `scripts/check_apple_reporter_freshness.py` runs nightly and raises a
+    `::warning::` once `api/apple_reporter.json` stops advancing for 3
+    days; that annotation is the only thing that will tell you. To
+    rotate: `Sales.generateToken`, paste the value into the
+    `APPLE_REPORTER_TOKEN` secret, and confirm the next nightly run
+    reports "Apple Reporter fresh".
   * The parameter list takes **no spaces**:
     `Sales.getReport 92749973,apShowListening,Summary,Daily,20260726`.
     Spaces after the commas make the shell split it and Reporter reports

--- a/docs/monthly_network_checklist.md
+++ b/docs/monthly_network_checklist.md
@@ -1,0 +1,101 @@
+# Monthly network checklist
+
+A short, deliberately boring pass over the things that fail *silently*.
+The pipeline is loud about crashes; everything below is a failure mode
+that leaves a green job behind it, which is why it needs a human on a
+calendar rather than an alert.
+
+Run it on the first working day of the month. Twenty minutes.
+
+---
+
+## 1. Feed validity
+
+The feeds are the product. A malformed one is invisible to us and fatal
+to a subscriber.
+
+- [ ] Spot-check three audio feeds at <https://podba.se/validate/> —
+      rotate which three, so all get covered across a quarter.
+- [ ] Check the two **video** feeds (`podcast.video.rss`,
+      `spacex_podcast.video.rss`). These are newer and less exercised;
+      Apple silently refuses an episode whose enclosure `type` isn't
+      `video/mp4`.
+- [ ] Confirm `<enclosure>` URLs still point at `audio.nerranetwork.com`.
+      **Never "fix" a published enclosure URL** — rewriting one
+      re-downloads the episode for every subscriber.
+
+## 2. Apple
+
+- [ ] `api/apple_reporter.json` — is it advancing? The nightly
+      `check_apple_reporter_freshness.py` warns after 3 days, but the
+      annotation is easy to miss in a green run.
+- [ ] **Token expiry**: the Reporter access token lasts 180 days. The
+      current one dies around **late January 2027**. See
+      [`analytics.md`](analytics.md) for the rotation steps.
+- [ ] Once ~3 weeks of Reporter history exist, compare it against the
+      cookie scrape on the dashboard. If they agree, retire the scrape
+      (`appleconnector` dep, 2 secrets, the daily re-auth chore).
+
+## 3. Cross-source sanity
+
+These measure different things and must never be summed. The check is
+that they move *together*, not that they match.
+
+- [ ] OP3 downloads vs Apple plays vs Spotify streams — same direction?
+      A source that flatlines while the others move is a dead connector,
+      not a collapse in listening.
+- [ ] Any show reporting **exactly zero** — is that real, or is it
+      absence rendered as zero? That bug has been fixed in five places
+      now and it keeps coming back. Absence must render as `—`.
+
+## 4. Storage
+
+- [ ] Skim the last `Storage Prune (video R2)` run summary. It runs
+      monthly on the 3rd; the report is in the job summary.
+- [ ] Is the video keyspace near its ~52 GB steady state? Sustained
+      growth means the prune isn't reaching objects — check whether
+      `video_assets.json` is over-retaining.
+- [ ] Nothing to do if the prune reported "Nothing to prune". That is
+      the expected steady state, not a failure.
+
+## 5. Cost
+
+The tracker became trustworthy on 2026-07-28 (it had been reporting
+roughly half of real spend). Numbers before that date are undercounts
+and are not comparable to later ones.
+
+- [ ] Cost per episode trend from `digests/*/credit_usage_*.json`.
+      Roughly $0.32-0.35 is normal.
+- [ ] Any **"(truncated, discarded)"** line that is consistently
+      non-zero for a show → its `llm.max_tokens` is set below what its
+      prompt needs, and it is paying for a whole generation twice.
+- [ ] Image spend — a jump means a show started generating more scenes
+      than intended.
+
+## 6. Stranded work
+
+- [ ] Any `recovery/*` branch still open? The nightly janitor deletes
+      merged ones and warns about the rest. An unmerged one is a
+      **generated, paid-for episode that never published**.
+- [ ] Any open draft PR from the review agent that has gone stale.
+
+## 7. Quick greps that have caught real bugs
+
+```bash
+# Brand garbles in published transcripts (P0-1 class)
+grep -rliE '\bnaran?\b[[:space:]-]{1,3}networks?' digests/*/*_transcript.txt
+
+# Aggregator links that never got a publisher name (P0-2 class)
+grep -rc 'news.google.com' digests/*/[A-Z]*.md | sort -t: -k2 -rn | head
+
+# Feed freshness — anything not updated in a week
+ls -lt *.rss | head -20
+```
+
+---
+
+## What this list is not
+
+It is not a quality review. Editorial quality has its own recurring
+process (`docs/reviews/`, the scheduled review agent). This is
+infrastructure only: is the thing we built still doing what it says.

--- a/scripts/check_apple_reporter_freshness.py
+++ b/scripts/check_apple_reporter_freshness.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Warn when the Apple Podcasts Reporter rollup stops advancing.
+
+Why this needs its own check
+----------------------------
+``scripts/fetch_apple_reporter.py`` is deliberately built to fail
+*quietly and safely*: when every request errors it leaves
+``api/apple_reporter_daily.json`` untouched rather than replacing real
+numbers with an empty file. That is the right call — stale-but-real
+beats empty — but it means a dead token produces a nightly job that
+succeeds, a dashboard that still shows plausible figures, and no signal
+at all. The failure is invisible precisely because the safety worked.
+
+The Reporter access token expires **180 days** after issue. That is the
+most likely cause of a rollup that stops moving, so the warning names it
+directly rather than making someone rediscover it.
+
+Exit code is always 0 unless ``--strict``: this is an alarm, not a gate,
+and it must never fail the nightly pipeline it rides along with.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROLLUP_PATH = REPO_ROOT / "api" / "apple_reporter.json"
+
+# Apple's daily report lands next-day and a day can still fill in after
+# first publication, so a couple of days of lag is normal. Three days
+# without the window advancing is not.
+DEFAULT_MAX_AGE_DAYS = 3
+
+
+def _parse_iso(value: str) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
+
+
+def check(path: Path, max_age_days: float, now: dt.datetime) -> tuple[bool, str]:
+    """Return ``(ok, message)``. ``ok`` is False when someone should look."""
+    if not path.exists():
+        # Not an alarm: the feed is opt-in and may simply not be set up.
+        return True, (
+            f"{path.name} not present — Apple Reporter is not configured "
+            "yet, so there is nothing to be stale."
+        )
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return False, f"{path.name} is unreadable ({exc})"
+
+    fetched = _parse_iso(data.get("fetched_at", ""))
+    if fetched is None:
+        return False, f"{path.name} has no usable fetched_at timestamp"
+
+    age_days = (now - fetched).total_seconds() / 86400
+    shows = len(data.get("shows") or {})
+    last_date = data.get("last_date") or "?"
+
+    if age_days > max_age_days:
+        return False, (
+            f"Apple Reporter rollup has not advanced in {age_days:.1f} days "
+            f"(last fetch {fetched.date()}, last report date {last_date}, "
+            f"{shows} show(s)). The access token expires 180 days after "
+            "issue and a dead token is the most likely cause — regenerate "
+            "it in Apple Podcasts Connect and update the secret. See "
+            "docs/analytics.md."
+        )
+
+    return True, (
+        f"Apple Reporter fresh: fetched {age_days:.1f} days ago, "
+        f"through {last_date}, {shows} show(s)."
+    )
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--max-age-days", type=float, default=DEFAULT_MAX_AGE_DAYS)
+    ap.add_argument("--path", default=str(ROLLUP_PATH))
+    ap.add_argument("--strict", action="store_true",
+                    help="Exit non-zero when stale (default: warn only)")
+    args = ap.parse_args(argv)
+
+    ok, message = check(
+        Path(args.path), args.max_age_days,
+        dt.datetime.now(dt.timezone.utc),
+    )
+    if ok:
+        print(message)
+        return 0
+
+    print(f"::warning::{message}", flush=True)
+    print(message, file=sys.stderr)
+    return 1 if args.strict else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prune_recovery_branches.py
+++ b/scripts/prune_recovery_branches.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Delete merged ``recovery/*`` branches, and alarm on stranded ones.
+
+Where these come from
+---------------------
+When a show's artifact push exhausts its retry loop (landmine #23 —
+GitHub's ref-update service intermittently fails on the 8k-10k line
+commits a successful episode produces), ``scripts/create_recovery_pr.sh``
+parks the episode on a ``recovery/<show>-<run_id>-<ts>`` branch and opens
+a draft PR so no work is lost. The job then exits 0.
+
+The gap this closes
+-------------------
+Nothing ever cleaned those branches up, so merged ones accumulate
+indefinitely, and — much worse — an UNMERGED one is a **stranded
+episode**: audio, transcript and feed updates that were generated, paid
+for, and never published. Nobody was watching for that.
+
+So:
+  * a recovery branch whose tip is already an ancestor of the default
+    branch has served its purpose and is deleted;
+  * one that is NOT merged and is older than the grace period is
+    reported as a ``::warning::`` naming the show, because that is an
+    episode sitting in limbo.
+
+Deletion is deliberately narrow: only branches matching ``recovery/``
+whose commits are provably already on the default branch. An unmerged
+branch is never deleted by this script under any circumstance — losing a
+stranded episode is the exact failure it exists to prevent.
+
+Usage::
+
+    python scripts/prune_recovery_branches.py             # report only
+    python scripts/prune_recovery_branches.py --apply     # delete merged
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+
+BRANCH_PREFIX = "recovery/"
+DEFAULT_STRANDED_HOURS = 24
+
+# recovery/<show>-<run_id>-<unix_ts>
+_BRANCH_RE = re.compile(r"^recovery/(?P<show>.+)-(?P<run>\d+)-(?P<ts>\d+)$")
+
+
+def _git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def remote_recovery_branches() -> list[str]:
+    out = _git("ls-remote", "--heads", "origin", f"{BRANCH_PREFIX}*")
+    branches = []
+    for line in out.split("\n"):
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) == 2 and parts[1].startswith("refs/heads/"):
+            branches.append(parts[1][len("refs/heads/"):])
+    return sorted(branches)
+
+
+def is_merged(branch: str, base: str) -> bool:
+    """True when *branch*'s tip is already an ancestor of *base*.
+
+    ``merge-base --is-ancestor`` is the authoritative check: it is true
+    for a fast-forward, a merge commit, AND a squash-merge that kept the
+    original commit reachable. When the ref cannot be resolved we return
+    False — refusing to delete on uncertainty is the safe direction.
+    """
+    try:
+        tip = _git("rev-parse", f"refs/remotes/origin/{branch}")
+    except subprocess.CalledProcessError:
+        return False
+    try:
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", tip, base],
+            capture_output=True, check=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def branch_age_hours(branch: str, now: dt.datetime) -> float | None:
+    """Age from the timestamp the branch name carries, else from its tip."""
+    match = _BRANCH_RE.match(branch)
+    if match:
+        try:
+            created = dt.datetime.fromtimestamp(
+                int(match.group("ts")), dt.timezone.utc)
+            return (now - created).total_seconds() / 3600
+        except (ValueError, OSError, OverflowError):
+            pass
+    try:
+        when = int(_git("log", "-1", "--format=%ct",
+                        f"refs/remotes/origin/{branch}"))
+        created = dt.datetime.fromtimestamp(when, dt.timezone.utc)
+        return (now - created).total_seconds() / 3600
+    except (subprocess.CalledProcessError, ValueError):
+        return None
+
+
+def show_of(branch: str) -> str:
+    match = _BRANCH_RE.match(branch)
+    return match.group("show") if match else branch[len(BRANCH_PREFIX):]
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--apply", action="store_true",
+                    help="Delete merged branches (default: report only)")
+    ap.add_argument("--base", default="origin/main",
+                    help="Branch the recovery work must have reached")
+    ap.add_argument("--stranded-hours", type=float,
+                    default=DEFAULT_STRANDED_HOURS,
+                    help="Warn about unmerged branches older than this")
+    args = ap.parse_args(argv)
+
+    branches = remote_recovery_branches()
+    if not branches:
+        print("No recovery/* branches on origin — nothing to do.")
+        return 0
+
+    print(f"{len(branches)} recovery branch(es) on origin\n")
+    now = dt.datetime.now(dt.timezone.utc)
+
+    merged, stranded, young = [], [], []
+    for branch in branches:
+        if is_merged(branch, args.base):
+            merged.append(branch)
+            continue
+        age = branch_age_hours(branch, now)
+        if age is not None and age >= args.stranded_hours:
+            stranded.append((branch, age))
+        else:
+            young.append((branch, age))
+
+    for branch in merged:
+        print(f"  merged     {branch}")
+    for branch, age in young:
+        age_txt = f"{age:.1f}h" if age is not None else "age unknown"
+        print(f"  in flight  {branch}  ({age_txt})")
+    for branch, age in stranded:
+        print(f"  STRANDED   {branch}  ({age:.1f}h)")
+
+    # A stranded recovery branch means a generated, paid-for episode was
+    # never published. That is worth an annotation someone will see.
+    for branch, age in stranded:
+        print(
+            f"::warning::Stranded recovery branch {branch} "
+            f"({show_of(branch)}) is {age:.0f}h old and not merged into "
+            f"{args.base}. Its episode artifacts were generated but never "
+            f"published — merge or close the recovery PR.",
+            flush=True,
+        )
+
+    if not merged:
+        print("\nNo merged recovery branches to delete.")
+        return 0
+
+    if not args.apply:
+        print(f"\nDry run — would delete {len(merged)} merged branch(es). "
+              "Pass --apply to delete.")
+        return 0
+
+    failures = 0
+    for branch in merged:
+        try:
+            _git("push", "origin", "--delete", branch)
+            print(f"deleted {branch}")
+        except subprocess.CalledProcessError as exc:
+            failures += 1
+            print(f"could not delete {branch}: {exc}", file=sys.stderr)
+
+    print(f"\nDeleted {len(merged) - failures} of {len(merged)} merged branch(es).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_p3_hygiene.py
+++ b/tests/test_p3_hygiene.py
@@ -1,0 +1,257 @@
+"""Drift guards for P3 operational hygiene (July 28 2026).
+
+Three scheduled-maintenance gaps, plus two plan items that turned out to
+be already done:
+
+  * ``scripts/prune_video_r2.py`` existed but was scheduled nowhere, so
+    the video keyspace grew ~318 GB/year unchecked.
+  * ``recovery/*`` branches were never cleaned up — and an UNMERGED one
+    is a stranded episode (generated, paid for, never published) that
+    nothing was watching for.
+  * The Apple Reporter token expires after 180 days and its failure mode
+    is silent by design, so a dead token produced a green nightly job.
+
+Already resolved, verified rather than assumed: the repo-root strays
+(``_to_delete/``, ``recovered_ep519/``, ``recovered_spacex_ep12/``) are
+gone, and the ruff gate is green.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+from check_apple_reporter_freshness import check as reporter_check  # noqa: E402
+import prune_recovery_branches as prb  # noqa: E402
+
+
+class TestRepoRootIsClean:
+    @pytest.mark.parametrize(
+        "stray", ["_to_delete", "recovered_ep519", "recovered_spacex_ep12"])
+    def test_stray_directories_are_gone(self, stray):
+        assert not (REPO_ROOT / stray).exists()
+
+    @pytest.mark.parametrize(
+        "stray", ["_to_delete", "recovered_ep519", "recovered_spacex_ep12"])
+    def test_strays_are_not_tracked(self, stray):
+        tracked = subprocess.run(
+            ["git", "ls-files", stray], cwd=REPO_ROOT,
+            capture_output=True, text=True,
+        ).stdout.strip()
+        assert tracked == ""
+
+
+class TestStoragePruneScheduled:
+    @pytest.fixture()
+    def workflow(self):
+        path = REPO_ROOT / ".github" / "workflows" / "storage-prune.yml"
+        assert path.exists(), "the monthly prune workflow must exist"
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def test_runs_on_a_monthly_cron(self, workflow):
+        # PyYAML parses a bare `on:` key as the boolean True.
+        triggers = workflow.get("on") or workflow.get(True)
+        crons = [s["cron"] for s in triggers["schedule"]]
+        assert crons, "no schedule configured"
+        # day-of-month set, month wildcard => monthly.
+        day_of_month = crons[0].split()[2]
+        assert day_of_month != "*", f"not monthly: {crons[0]}"
+
+    def test_manual_runs_default_to_a_dry_run(self, workflow):
+        """Irreversible deletion must not be the default for a human."""
+        triggers = workflow.get("on") or workflow.get(True)
+        assert triggers["workflow_dispatch"]["inputs"]["apply"]["default"] is False
+
+    def test_scheduled_run_actually_applies(self):
+        """A prune that never deletes would leave the growth unfixed."""
+        raw = (REPO_ROOT / ".github" / "workflows" / "storage-prune.yml").read_text(
+            encoding="utf-8")
+        assert "github.event_name == 'schedule' && 'true'" in raw
+        assert "--apply" in raw
+
+    def test_missing_credentials_skip_rather_than_fail(self):
+        raw = (REPO_ROOT / ".github" / "workflows" / "storage-prune.yml").read_text(
+            encoding="utf-8")
+        assert "R2 credentials not configured" in raw
+
+    def test_report_reaches_the_job_summary(self):
+        """A destructive job with no audit trail is how bad prunes hide."""
+        raw = (REPO_ROOT / ".github" / "workflows" / "storage-prune.yml").read_text(
+            encoding="utf-8")
+        assert "GITHUB_STEP_SUMMARY" in raw
+
+    def test_does_not_race_the_daily_slate(self, workflow):
+        """Shows finish as late as ~16:00; nightly runs 16:45."""
+        triggers = workflow.get("on") or workflow.get(True)
+        hour = int(triggers["schedule"][0]["cron"].split()[1])
+        assert hour < 4 or 4 <= hour <= 6, f"hour {hour} risks overlapping a publish"
+
+
+class TestRecoveryBranchJanitor:
+    def test_unmerged_branches_are_never_deleted(self):
+        """Deleting a stranded episode is the failure this prevents."""
+        source = (REPO_ROOT / "scripts" / "prune_recovery_branches.py").read_text(
+            encoding="utf-8")
+        delete_block = source.split("if not args.apply:")[1]
+        # The only iteration that deletes is over `merged`.
+        assert "for branch in merged:" in delete_block
+        assert "for branch in stranded:" not in delete_block
+
+    def test_unresolvable_ref_is_treated_as_unmerged(self, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, "git")
+        monkeypatch.setattr(prb, "_git", _boom)
+        assert prb.is_merged("recovery/tesla-1-2", "origin/main") is False
+
+    def test_age_read_from_the_branch_name(self):
+        now = dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
+        created = now - dt.timedelta(hours=30)
+        branch = f"recovery/tesla-30353150739-{int(created.timestamp())}"
+        age = prb.branch_age_hours(branch, now)
+        assert age == pytest.approx(30.0, abs=0.1)
+
+    def test_show_name_recovered_from_the_branch(self):
+        assert prb.show_of("recovery/spacex-30354757421-1785247730") == "spacex"
+        # Multi-part slugs survive the split.
+        assert prb.show_of("recovery/models_agents-1-2") == "models_agents"
+
+    def test_stranded_branch_emits_a_warning(self, monkeypatch, capsys):
+        now = dt.datetime.now(dt.timezone.utc)
+        created = int((now - dt.timedelta(hours=48)).timestamp())
+        branch = f"recovery/tesla-999-{created}"
+        monkeypatch.setattr(prb, "remote_recovery_branches", lambda: [branch])
+        monkeypatch.setattr(prb, "is_merged", lambda b, base: False)
+
+        prb.main([])
+        out = capsys.readouterr().out
+        assert "::warning::" in out
+        assert "Stranded recovery branch" in out
+        assert "tesla" in out
+
+    def test_young_unmerged_branch_is_not_alarmed(self, monkeypatch, capsys):
+        """An in-flight recovery PR is normal, not an incident."""
+        now = dt.datetime.now(dt.timezone.utc)
+        created = int((now - dt.timedelta(hours=2)).timestamp())
+        monkeypatch.setattr(
+            prb, "remote_recovery_branches",
+            lambda: [f"recovery/tesla-999-{created}"])
+        monkeypatch.setattr(prb, "is_merged", lambda b, base: False)
+
+        prb.main([])
+        out = capsys.readouterr().out
+        assert "::warning::" not in out
+        assert "in flight" in out
+
+    def test_no_branches_is_a_clean_noop(self, monkeypatch, capsys):
+        monkeypatch.setattr(prb, "remote_recovery_branches", lambda: [])
+        assert prb.main([]) == 0
+        assert "nothing to do" in capsys.readouterr().out
+
+    def test_wired_into_nightly(self):
+        raw = (REPO_ROOT / ".github" / "workflows"
+               / "nightly-maintenance.yml").read_text(encoding="utf-8")
+        assert "prune_recovery_branches.py" in raw
+        assert "--apply" in raw
+
+
+class TestAppleReporterFreshness:
+    def _rollup(self, tmp_path, *, fetched_at, shows=1):
+        path = tmp_path / "apple_reporter.json"
+        path.write_text(json.dumps({
+            "fetched_at": fetched_at, "last_date": "2026-07-27",
+            "shows": {str(i): {} for i in range(shows)},
+        }), encoding="utf-8")
+        return path
+
+    def test_fresh_rollup_is_ok(self, tmp_path):
+        now = dt.datetime.now(dt.timezone.utc)
+        path = self._rollup(
+            tmp_path, fetched_at=(now - dt.timedelta(days=1)).isoformat())
+        ok, message = reporter_check(path, 3, now)
+        assert ok
+        assert "fresh" in message
+
+    def test_stale_rollup_names_the_token(self, tmp_path):
+        now = dt.datetime.now(dt.timezone.utc)
+        path = self._rollup(
+            tmp_path, fetched_at=(now - dt.timedelta(days=9)).isoformat())
+        ok, message = reporter_check(path, 3, now)
+        assert not ok
+        assert "180 days" in message
+        assert "token" in message.lower()
+
+    def test_absent_file_is_not_an_alarm(self, tmp_path):
+        """Reporter is opt-in — "not set up" is not "broken"."""
+        ok, message = reporter_check(
+            tmp_path / "nope.json", 3, dt.datetime.now(dt.timezone.utc))
+        assert ok
+        assert "not configured" in message
+
+    def test_corrupt_file_is_an_alarm(self, tmp_path):
+        path = tmp_path / "apple_reporter.json"
+        path.write_text("{broken", encoding="utf-8")
+        ok, _ = reporter_check(path, 3, dt.datetime.now(dt.timezone.utc))
+        assert not ok
+
+    def test_missing_timestamp_is_an_alarm(self, tmp_path):
+        path = tmp_path / "apple_reporter.json"
+        path.write_text(json.dumps({"shows": {}}), encoding="utf-8")
+        ok, _ = reporter_check(path, 3, dt.datetime.now(dt.timezone.utc))
+        assert not ok
+
+    def test_naive_timestamps_do_not_crash(self, tmp_path):
+        now = dt.datetime.now(dt.timezone.utc)
+        path = self._rollup(
+            tmp_path,
+            fetched_at=(now - dt.timedelta(days=1)).replace(tzinfo=None).isoformat())
+        ok, _ = reporter_check(path, 3, now)
+        assert ok
+
+    def test_never_fails_the_nightly_by_default(self, tmp_path):
+        """It rides along with nightly — an alarm must not become a gate."""
+        now = dt.datetime.now(dt.timezone.utc)
+        path = self._rollup(
+            tmp_path, fetched_at=(now - dt.timedelta(days=30)).isoformat())
+        result = subprocess.run(
+            [sys.executable,
+             str(REPO_ROOT / "scripts" / "check_apple_reporter_freshness.py"),
+             "--path", str(path)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert "::warning::" in result.stdout
+
+    def test_strict_mode_exits_non_zero(self, tmp_path):
+        now = dt.datetime.now(dt.timezone.utc)
+        path = self._rollup(
+            tmp_path, fetched_at=(now - dt.timedelta(days=30)).isoformat())
+        result = subprocess.run(
+            [sys.executable,
+             str(REPO_ROOT / "scripts" / "check_apple_reporter_freshness.py"),
+             "--path", str(path), "--strict"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+
+    def test_expiry_is_documented(self):
+        doc = (REPO_ROOT / "docs" / "analytics.md").read_text(encoding="utf-8")
+        assert "180 days" in doc
+        assert "January 2027" in doc
+        # And names the real secret, not an invented one.
+        assert "APPLE_REPORTER_TOKEN" in doc
+
+    def test_wired_into_nightly(self):
+        raw = (REPO_ROOT / ".github" / "workflows"
+               / "nightly-maintenance.yml").read_text(encoding="utf-8")
+        assert "check_apple_reporter_freshness.py" in raw


### PR DESCRIPTION
Final section of `NERRA_IMPROVEMENT_PLAN.md`. No audio, prompt, or spoken-script changes. Added cost: one monthly Actions run plus two fast nightly steps.

---

## Two of the six items were already done

Verified, not assumed — and pinned by tests so they stay true:

| Plan item | Actual state |
|---|---|
| Remove `_to_delete/`, `recovered_ep519/`, `recovered_spacex_ep12/` | Don't exist, aren't tracked |
| Delete the 4 merged `recovery/*` branches | **Zero** `recovery/*` branches on origin |
| Ruff gate red since July 22 | Green (established in #896) |

## The four real gaps

### 1. Storage prune was scheduled *nowhere*

`scripts/prune_video_r2.py` already existed — well-guarded, reachability-based, dry-run by default. **Nothing ever called it.** That's the entire 318 GB/yr growth: a correct script with no caller.

New `storage-prune.yml`, monthly on the 3rd at **04:20 UTC**. That slot is deliberate — the daily slate finishes as late as ~16:00 once GitHub's scheduling delay is counted, and nightly runs at 16:45, so a prune can never race a publish still writing objects.

- **Scheduled** runs pass `--apply` — a prune that never deletes leaves the problem unfixed.
- **Manual** dispatch defaults to a **dry run**. Irreversible deletion shouldn't be the default for a human clicking a button.
- Report is teed into the job summary. A destructive scheduled job with no audit trail is how a bad prune stays hidden for months.

It's a separate workflow rather than another nightly step **on purpose**: it's the only scheduled job in this repo that permanently destroys data, so it should be separately visible, separately runnable, and disablable by deleting one file without touching the nightly pipeline.

### 2. Recovery-branch janitor

Landmine #23 parks an episode on a `recovery/SHOW-RUNID-TIMESTAMP` branch when a show's push exhausts its retry loop. Merged ones were never cleaned up — but **the important half is the other one**: an unmerged recovery branch is a *stranded episode*, generated and paid for and never published, and nothing was watching for it.

- Deletes only branches whose tip is provably an ancestor of main (`merge-base --is-ancestor`, which also covers squash-merges that kept the commit reachable).
- An unmerged branch is **never** deleted under any circumstance — losing a stranded episode is the exact failure this exists to prevent.
- One older than 24h emits a `::warning::` naming the show.
- An unresolvable ref counts as unmerged, so uncertainty always errs toward keeping.

### 3. Apple Reporter token expiry

The failure mode here is silent **by design**: `fetch_apple_reporter.py` leaves the store untouched when every request fails, because stale-but-real beats empty. That's correct — and it means a dead token yields a green nightly job and a dashboard still showing plausible numbers. *The safety is what hides the failure.*

`check_apple_reporter_freshness.py` runs nightly, warns once the rollup stops advancing for 3 days, and names the 180-day expiry as the likely cause. Always exits 0 unless `--strict` — it rides along with nightly, and an alarm must never become a gate. An absent file is **not** an alarm: Reporter is opt-in, and "not set up" isn't "broken".

`docs/analytics.md` gains the expiry date and rotation steps. I drafted it against `APPLE_REPORTER_ACCESS_TOKEN`, checked the source, found the real secret is **`APPLE_REPORTER_TOKEN`**, and corrected it before committing.

### 4. Monthly checklist

`docs/monthly_network_checklist.md`, scoped to things that fail *silently* — the pipeline is already loud about crashes. Every referenced path, script, feed and grep was run against the live repo before being written down.

It also records that **cost figures before 2026-07-28 are undercounts** and not comparable to later ones, since the tracker only became trustworthy with P0-3.

---

## Verification

- Full suite: **4,462 passed, 26 failed — exactly the baseline**, `comm`-diffed empty in both directions.
- 30 new tests; `ruff check` clean.
- Both new scripts run against the live repo: the janitor correctly reports "No recovery/* branches on origin", the freshness check correctly reports "not configured yet".
- Both workflow YAMLs parse.

## Plan status after this PR

All of P0, P1 (except P1-2), P2-1, P2-4 and P3 are shipped across #895, #896, #897 and this one.

**Still open:** **P1-2** (single-pass render — needs ffprobe and extracted-frame comparison against real renders; the plan says do it alone), **P2-2**, **P2-3** (needs the `YOUTUBE_*` secrets — a CI one-off you'd trigger), **P2-5**, and the operator-only items (Buttondown sending domain, Apple badge asset, Search Console, Podcast Index dedup).