### PR TITLE
P1-2: single-pass long-form render (opt-in, measured ~30% faster)

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 import subprocess
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
@@ -1372,6 +1373,224 @@ def write_chapter_metadata(chapters_path: Path, out_path: Path,
     return out_path
 
 
+def _single_pass_enabled() -> bool:
+    """Whether to fuse the slideshow and composite into one ffmpeg run.
+
+    Opt-in (default OFF) for now. The fused graph is verified equivalent
+    on synthetic renders — identical ffprobe geometry/codec/duration,
+    54 dB average PSNR, pixel-identical overlay regions — but it has not
+    yet been A/B'd against a REAL episode with real scene imagery,
+    captions and chapter metadata. Flipping the default before that
+    happens would risk every video show's nightly render on a change
+    nobody has watched end to end.
+
+    Operator: set ``NERRA_SINGLE_PASS_RENDER=1``, compare one episode,
+    then make it the default here. The two-stage path stays as the
+    automatic fallback either way — a failure in the fused command is
+    caught and re-rendered the old way.
+    """
+    return os.getenv("NERRA_SINGLE_PASS_RENDER", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _uniform_slideshow_plan(
+    scene_paths: Sequence[Path], audio_duration_s: float,
+) -> Tuple[List[Path], float]:
+    """Scene list + per-scene hold for the non-scheduled slideshow.
+
+    Extracted so the two-stage and single-pass paths compute the plan
+    from ONE implementation. The cycling rule (no image held longer than
+    ``_MAX_SCENE_HOLD_S``, capped at ``_MAX_SLIDESHOW_SLOTS`` ffmpeg
+    inputs) is load-bearing on real episodes — Ep505 held one image for
+    168 s before it existed, and Ep537 timed out the pipeline at 74
+    uncapped slots — so the two paths must not be able to drift apart.
+    """
+    scenes = list(scene_paths)
+    if audio_duration_s <= 0:
+        return scenes, _SCENE_DURATION_SECONDS  # legacy 12 s
+
+    hold = max(8.0, audio_duration_s / len(scenes))
+    if hold > _MAX_SCENE_HOLD_S and len(scenes) > 1:
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
+        target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
+        target = min(target, _MAX_SLIDESHOW_SLOTS)
+        scenes = [scenes[i % len(scenes)] for i in range(target)]
+        hold = max(8.0, audio_duration_s / len(scenes))
+    return scenes, hold
+
+
+def _single_pass_scene_plan(
+    schedule, scene_paths, audio_duration_s: float,
+) -> Tuple[List[Path], Optional[List[float]], float]:
+    """Resolve ``(scenes, per_scene_durations, uniform_duration)``.
+
+    A chapter-aware schedule supplies its own per-scene holds; otherwise
+    the uniform plan applies and ``per_scene_durations`` is None (which
+    reproduces the legacy graph exactly).
+    """
+    if schedule:
+        return ([p for p, _ in schedule],
+                [d for _, d in schedule],
+                _SCENE_DURATION_SECONDS)
+    if not scene_paths:
+        return [], None, _SCENE_DURATION_SECONDS
+    scenes, hold = _uniform_slideshow_plan(scene_paths, audio_duration_s)
+    return scenes, None, hold
+
+
+def _single_pass_long_form_filter_graph(
+    scene_count: int, *,
+    scene_duration: float = _SCENE_DURATION_SECONDS,
+    scene_durations: Optional[Sequence[float]] = None,
+    width: int = 1920, height: int = 1080,
+    fps: int = 30,
+    crossfade: float = _SLIDESHOW_XFADE_S,
+    subtitles_path: Optional[str] = None,
+    with_url_pill: bool = False,
+) -> str:
+    """One filter graph for slideshow + overlays + captions (P1-2).
+
+    The two-stage path renders the Ken Burns slideshow to an intermediate
+    MP4, then feeds that file back in as ``[0:v]`` of the composite. That
+    costs a full extra encode AND a full extra decode of a 1080p file
+    that exists only to be consumed seconds later — roughly 42% of a
+    video show's wall clock — and it puts every delivered pixel through
+    two lossy passes.
+
+    Fusing them means the scene STILLS become the inputs, so the input
+    indices all shift. Two-stage numbering is fixed at bg(0) / audio(1) /
+    brand(2) / url-pill(3); here the scenes occupy ``0 .. n-1`` and
+    everything else moves up by ``n - 1``. Getting that wrong is silent —
+    ffmpeg happily overlays the wrong stream — so the offsets are derived
+    from ``scene_count`` in one place rather than written out.
+
+    The slideshow half is :func:`_slideshow_filter_graph` verbatim, with
+    its ``[v]`` output relabelled ``[bg]``. Reusing it (rather than
+    reimplementing) is deliberate: the xfade offset arithmetic and the
+    per-scene duration handling are subtle, already tested, and must not
+    fork between the two paths.
+    """
+    slideshow = _slideshow_filter_graph(
+        scene_count,
+        scene_duration=scene_duration,
+        scene_durations=scene_durations,
+        width=width, height=height, fps=fps,
+        crossfade=crossfade,
+    )
+    # The slideshow graph's terminal label is always ``[v]``; the
+    # composite needs it as ``[bg]``. Only the final occurrence is the
+    # output (intermediate labels are [s0], [x1], ...), so replace from
+    # the right.
+    if not slideshow.endswith("[v]"):
+        raise ValueError("slideshow graph did not end with [v]")
+    graph = slideshow[: -len("[v]")] + "[bg]"
+
+    # Scenes consume inputs 0..n-1, so audio/brand/pill shift up.
+    brand_idx = scene_count + 1
+    pill_idx = scene_count + 2
+
+    graph += (
+        f";[{brand_idx}:v]format=rgba[brand];"
+        f"[bg][brand]overlay=x=24:y=24[branded]"
+    )
+    if with_url_pill:
+        graph += (
+            f";[{pill_idx}:v]format=rgba[urlpill];"
+            "[branded][urlpill]overlay=x=W-w-24:y=24[stamped]"
+        )
+        post_brand_label = "[stamped]"
+    else:
+        post_brand_label = "[branded]"
+
+    if subtitles_path:
+        escaped = _subtitles_path_escape(subtitles_path)
+        graph += (
+            f";{post_brand_label}subtitles='{escaped}'"
+            f":force_style='{_SUBTITLES_FORCE_STYLE}'[v]"
+        )
+    else:
+        graph += f";{post_brand_label}null[v]"
+    return graph
+
+
+def _single_pass_long_form_cmd(
+    scene_paths: Sequence[Path], audio_in: str, brand_in: str,
+    output: str, *,
+    scene_duration: float = _SCENE_DURATION_SECONDS,
+    scene_durations: Optional[Sequence[float]] = None,
+    width: int = 1920, height: int = 1080,
+    fps: int = 30,
+    crossfade: float = _SLIDESHOW_XFADE_S,
+    subtitles_path: Optional[str] = None,
+    url_pill_in: Optional[str] = None,
+    chapter_metadata_in: Optional[str] = None,
+) -> List[str]:
+    """Full ffmpeg command for the fused single-pass long-form render.
+
+    Input order is load-bearing and mirrors the filter graph exactly:
+    scenes ``0..n-1``, audio ``n``, brand ``n+1``, optional URL pill
+    ``n+2``, optional ffmetadata last (it carries no streams, so it
+    never appears in the graph — only in ``-map_metadata``).
+
+    Each scene input keeps the two-stage path's ``-t`` padding so the
+    xfade overlap cannot shorten a scene's visible time.
+    """
+    use_xfade = crossfade and crossfade > 0 and len(scene_paths) >= 2
+    input_pad = (crossfade if use_xfade else 0.0) + 0.5
+    durs: List[float] = (
+        [float(d) for d in scene_durations]
+        if scene_durations is not None
+        else [scene_duration] * len(scene_paths)
+    )
+
+    inputs: List[str] = []
+    for i, path in enumerate(scene_paths):
+        inputs.extend([
+            "-loop", "1",
+            "-framerate", str(fps),
+            "-t", f"{durs[i] + input_pad:.2f}",
+            "-i", str(path),
+        ])
+
+    n = len(scene_paths)
+    inputs.extend(["-i", audio_in])
+    inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", brand_in])
+    if url_pill_in:
+        inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", url_pill_in])
+
+    meta_inputs: List[str] = []
+    meta_map: List[str] = []
+    if chapter_metadata_in:
+        meta_index = n + 3 if url_pill_in else n + 2
+        meta_inputs = ["-f", "ffmetadata", "-i", chapter_metadata_in]
+        meta_map = ["-map_metadata", str(meta_index)]
+
+    return [
+        "ffmpeg", "-y", "-threads", "0",
+        *inputs,
+        *meta_inputs,
+        "-filter_complex",
+        _single_pass_long_form_filter_graph(
+            n,
+            scene_duration=scene_duration,
+            scene_durations=scene_durations,
+            width=width, height=height, fps=fps,
+            crossfade=crossfade,
+            subtitles_path=subtitles_path,
+            with_url_pill=bool(url_pill_in),
+        ),
+        "-map", "[v]", "-map", f"{n}:a",
+        *meta_map,
+        *_VIDEO_ENCODE,
+        "-r", str(fps),
+        *_AUDIO_ENCODE,
+        "-shortest",
+        "-movflags", "+faststart",
+        output,
+    ]
+
+
 def _long_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                    output: str, *,
                    fps: int = 30,
@@ -1730,6 +1949,47 @@ def build_long_form_video(
             _run_ffmpeg(cmd, label="long-form video")
             return output_path
 
+        # Single-pass fusion (P1-2). Renders the slideshow and the
+        # composite as ONE filter graph, removing a full intermediate
+        # encode + decode of a 1080p file that exists only to be
+        # consumed seconds later, and with it the last generational
+        # loss. Opt-in via NERRA_SINGLE_PASS_RENDER=1 — see
+        # _single_pass_long_form_cmd. Only the pure-stills paths qualify;
+        # the hybrid clips path above has already produced a real video
+        # background and is untouched.
+        if _single_pass_enabled():
+            sp_scenes, sp_durations, sp_uniform = _single_pass_scene_plan(
+                schedule, scene_paths, audio_duration_s,
+            )
+            if sp_scenes:
+                try:
+                    cmd = _single_pass_long_form_cmd(
+                        sp_scenes, str(audio_path), str(brand_path),
+                        str(output_path),
+                        scene_duration=sp_uniform,
+                        scene_durations=sp_durations,
+                        fps=fps,
+                        subtitles_path=(
+                            str(subtitles_path) if subtitles_path else None),
+                        url_pill_in=(
+                            str(url_pill_path) if url_pill_path else None),
+                        chapter_metadata_in=chapter_meta,
+                    )
+                    logger.info(
+                        "Building long-form video → %s (SINGLE-PASS, "
+                        "scenes=%d, captions=%s)",
+                        output_path.name, len(sp_scenes), bool(subtitles_path),
+                    )
+                    _run_ffmpeg(cmd, label="long-form video (single-pass)")
+                    return output_path
+                except (subprocess.CalledProcessError, RuntimeError) as exc:
+                    # Never lose a render to the new path: fall through to
+                    # the proven two-stage pipeline below.
+                    logger.warning(
+                        "Single-pass render failed (%s) — falling back to "
+                        "the two-stage pipeline", exc,
+                    )
+
         if schedule:
             # Chapter-aware plan: the scheduler already decided both the
             # scene ORDER and each scene's hold, so we render the
@@ -1751,31 +2011,19 @@ def build_long_form_video(
                     "to single cover", exc,
                 )
         else:
-            slideshow_scenes = list(scene_paths)
-            if audio_duration_s > 0:
-                scene_duration_s = max(8.0, audio_duration_s / len(slideshow_scenes))
-                # Cycle the scene list so no single image holds longer than
-                # _MAX_SCENE_HOLD_S (module constant; June 2026 motion pass lowered
-                # it 25 → 15 s). The May 12 retune halved Grok spend to 4
-                # images/aspect, which left each scene on screen ~2-3 minutes on a
-                # full-length episode (Ep505: 4 scenes over 673 s = 168 s/image) —
-                # visually static. Reusing the SAME images in rotation restores
-                # visual rhythm at zero additional image cost.
-                if scene_duration_s > _MAX_SCENE_HOLD_S and len(slideshow_scenes) > 1:
-                    from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
-                    target = math.ceil(audio_duration_s / _MAX_SCENE_HOLD_S)
-                    # Cap ffmpeg inputs — see scene_scheduler._MAX_SLIDESHOW_SLOTS
-                    # (Ep537: 74 uncapped slots timed out the pipeline).
-                    target = min(target, _MAX_SLIDESHOW_SLOTS)
-                    slideshow_scenes = [
-                        slideshow_scenes[i % len(slideshow_scenes)]
-                        for i in range(target)
-                    ]
-                    scene_duration_s = max(
-                        8.0, audio_duration_s / len(slideshow_scenes),
-                    )
-            else:
-                scene_duration_s = _SCENE_DURATION_SECONDS  # legacy 12 s
+            # Cycle the scene list so no single image holds longer than
+            # _MAX_SCENE_HOLD_S (module constant; June 2026 motion pass lowered
+            # it 25 → 15 s). The May 12 retune halved Grok spend to 4
+            # images/aspect, which left each scene on screen ~2-3 minutes on a
+            # full-length episode (Ep505: 4 scenes over 673 s = 168 s/image) —
+            # visually static. Reusing the SAME images in rotation restores
+            # visual rhythm at zero additional image cost.
+            #
+            # Shared with the single-pass path via _uniform_slideshow_plan so
+            # the two renderers cannot compute different plans (July 2026).
+            slideshow_scenes, scene_duration_s = _uniform_slideshow_plan(
+                scene_paths, audio_duration_s,
+            )
             try:
                 _render_slideshow(
                     slideshow_scenes, slideshow_path,

--- a/tests/test_single_pass_render.py
+++ b/tests/test_single_pass_render.py
@@ -1,0 +1,229 @@
+"""Drift guards for the single-pass long-form render (P1-2, July 28 2026).
+
+The two-stage path renders the Ken Burns slideshow to an intermediate
+MP4, then feeds that file back in as ``[0:v]`` of the composite — a full
+extra encode AND decode of a 1080p file that exists only to be consumed
+seconds later, plus a second lossy generation on every delivered pixel.
+
+Fusing them shifts every ffmpeg input index: two-stage numbering is fixed
+at bg(0)/audio(1)/brand(2)/pill(3), but with the scene stills as inputs
+the extras move to ``n``, ``n+1``, ``n+2``. Getting that wrong is
+**silent** — ffmpeg will happily overlay the wrong stream — so most of
+these tests are about index arithmetic.
+
+Measured on a real 24 s / 4-scene render in this repo (intermediates
+cleared between runs, since ``_render_slideshow`` is idempotent and a
+warm intermediate makes the two-stage path look artificially fast):
+
+    two-stage    31.3 s, 32.2 s
+    single-pass  22.2 s, 22.2 s        (~30% faster)
+
+    ffprobe resolution / fps / codec / pix_fmt / audio / duration:
+        identical
+    PSNR single vs two-stage: 54.4 dB average, 37.7 dB min
+    overlay regions: RMS 0.06 (brand) and 0.00 (URL pill)
+
+The path ships **opt-in** because none of that was measured against a
+real episode with real imagery, captions and chapter metadata yet.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import engine.video as video  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCENES = [Path(f"/tmp/scene{i}.png") for i in range(4)]
+
+
+class TestDefaultIsUnchanged:
+    """The flag is off by default; legacy behaviour must be untouched."""
+
+    def test_disabled_without_the_env_var(self, monkeypatch):
+        monkeypatch.delenv("NERRA_SINGLE_PASS_RENDER", raising=False)
+        assert video._single_pass_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    def test_enabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("NERRA_SINGLE_PASS_RENDER", value)
+        assert video._single_pass_enabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "off", "no"])
+    def test_disabled_values(self, monkeypatch, value):
+        monkeypatch.setenv("NERRA_SINGLE_PASS_RENDER", value)
+        assert video._single_pass_enabled() is False
+
+
+class TestInputIndexArithmetic:
+    """The silent failure mode: overlaying the wrong stream."""
+
+    @pytest.mark.parametrize("n", [1, 2, 4, 9, 30])
+    def test_brand_and_pill_indices_follow_scene_count(self, n):
+        graph = video._single_pass_long_form_filter_graph(
+            n, with_url_pill=True)
+        assert f"[{n + 1}:v]format=rgba[brand]" in graph
+        assert f"[{n + 2}:v]format=rgba[urlpill]" in graph
+
+    @pytest.mark.parametrize("n", [1, 2, 4, 9])
+    def test_no_index_collides_with_a_scene(self, n):
+        """A scene index reused for an overlay would silently corrupt it."""
+        graph = video._single_pass_long_form_filter_graph(
+            n, with_url_pill=True)
+        overlay_indices = {
+            int(m) for m in re.findall(r"\[(\d+):v\]format=rgba", graph)
+        }
+        assert overlay_indices.isdisjoint(range(n))
+
+    def test_audio_is_mapped_from_the_scene_count_index(self):
+        cmd = video._single_pass_long_form_cmd(
+            SCENES, "a.m4a", "brand.png", "out.mp4")
+        assert "-map" in cmd
+        assert f"{len(SCENES)}:a" in cmd
+
+    def test_metadata_index_accounts_for_the_pill(self):
+        n = len(SCENES)
+        without = video._single_pass_long_form_cmd(
+            SCENES, "a.m4a", "brand.png", "out.mp4", chapter_metadata_in="m.txt")
+        assert without[without.index("-map_metadata") + 1] == str(n + 2)
+
+        with_pill = video._single_pass_long_form_cmd(
+            SCENES, "a.m4a", "brand.png", "out.mp4",
+            url_pill_in="url.png", chapter_metadata_in="m.txt")
+        assert with_pill[with_pill.index("-map_metadata") + 1] == str(n + 3)
+
+    def test_input_order_matches_the_graph(self):
+        """Inputs must appear scenes → audio → brand → pill."""
+        cmd = video._single_pass_long_form_cmd(
+            SCENES, "audio.m4a", "brand.png", "out.mp4", url_pill_in="url.png")
+        inputs = [cmd[i + 1] for i, tok in enumerate(cmd) if tok == "-i"]
+        assert inputs[:len(SCENES)] == [str(p) for p in SCENES]
+        assert inputs[len(SCENES):] == ["audio.m4a", "brand.png", "url.png"]
+
+
+class TestGraphShape:
+    def test_slideshow_half_is_reused_verbatim(self):
+        """Forking the xfade offset arithmetic would be a latent bug."""
+        slideshow = video._slideshow_filter_graph(4)
+        fused = video._single_pass_long_form_filter_graph(4)
+        assert fused.startswith(slideshow[: -len("[v]")])
+
+    def test_slideshow_output_is_relabelled_to_bg(self):
+        fused = video._single_pass_long_form_filter_graph(4)
+        assert "[bg]" in fused
+        assert fused.endswith("[v]")
+
+    def test_terminates_in_v_for_every_branch(self):
+        for kwargs in ({}, {"with_url_pill": True},
+                       {"subtitles_path": "/tmp/x.ass"},
+                       {"with_url_pill": True, "subtitles_path": "/tmp/x.ass"}):
+            assert video._single_pass_long_form_filter_graph(
+                4, **kwargs).endswith("[v]")
+
+    def test_subtitles_applied_after_overlays(self):
+        """Captions must sit on top of the pills, as in the two-stage graph."""
+        graph = video._single_pass_long_form_filter_graph(
+            4, with_url_pill=True, subtitles_path="/tmp/x.ass")
+        assert graph.index("[stamped]subtitles=") > graph.index("[urlpill]")
+
+    def test_per_scene_durations_are_honoured(self):
+        graph = video._single_pass_long_form_filter_graph(
+            3, scene_durations=[5.0, 9.0, 4.0])
+        # xfade offsets are cumulative visible time: 5.0, then 14.0.
+        assert "offset=5.00" in graph
+        assert "offset=14.00" in graph
+
+    def test_mismatched_durations_raise(self):
+        with pytest.raises(ValueError):
+            video._single_pass_long_form_filter_graph(
+                3, scene_durations=[5.0, 9.0])
+
+    def test_uses_the_delivery_encode_profile(self):
+        """It produces the delivered file, not an intermediate."""
+        cmd = video._single_pass_long_form_cmd(
+            SCENES, "a.m4a", "brand.png", "out.mp4")
+        assert "-crf" in cmd
+        assert cmd[cmd.index("-crf") + 1] == "22"
+        assert "+faststart" in cmd
+
+
+class TestScenePlanIsShared:
+    """Both renderers must compute the same plan from one implementation."""
+
+    def test_uniform_plan_cycles_long_episodes(self):
+        """Reusing images in rotation restores motion at zero image cost."""
+        scenes = [Path(f"s{i}.png") for i in range(4)]
+        planned, hold = video._uniform_slideshow_plan(scenes, 600.0)
+        assert len(planned) > len(scenes)
+        # 4 scenes over 600 s would be 150 s/image (Ep505's static-render
+        # bug); cycling cuts that hard. The 24-slot input cap deliberately
+        # wins over the 15 s target on long episodes, so this asserts the
+        # improvement, not the target.
+        assert hold < 600.0 / len(scenes)
+
+    def test_uniform_plan_respects_the_input_cap(self):
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
+        scenes = [Path(f"s{i}.png") for i in range(4)]
+        planned, _ = video._uniform_slideshow_plan(scenes, 100000.0)
+        assert len(planned) <= _MAX_SLIDESHOW_SLOTS
+
+    def test_zero_duration_falls_back_to_the_legacy_hold(self):
+        scenes = [Path("s0.png")]
+        planned, hold = video._uniform_slideshow_plan(scenes, 0.0)
+        assert planned == scenes
+        assert hold == video._SCENE_DURATION_SECONDS
+
+    def test_schedule_supplies_its_own_durations(self):
+        schedule = [(Path("a.png"), 7.0), (Path("b.png"), 11.0)]
+        scenes, durations, _ = video._single_pass_scene_plan(schedule, None, 100.0)
+        assert scenes == [Path("a.png"), Path("b.png")]
+        assert durations == [7.0, 11.0]
+
+    def test_no_schedule_yields_uniform_and_no_per_scene_list(self):
+        scenes_in = [Path(f"s{i}.png") for i in range(3)]
+        scenes, durations, hold = video._single_pass_scene_plan(
+            None, scenes_in, 30.0)
+        assert durations is None       # reproduces the legacy graph exactly
+        assert hold > 0
+        assert scenes == scenes_in
+
+    def test_no_scenes_is_empty(self):
+        assert video._single_pass_scene_plan(None, [], 30.0)[0] == []
+
+    def test_two_stage_uses_the_shared_planner(self):
+        """Guards against the two paths drifting apart."""
+        source = (REPO_ROOT / "engine" / "video.py").read_text(encoding="utf-8")
+        assert source.count("def _uniform_slideshow_plan") == 1
+        # def + the two-stage call site + the single-pass call site.
+        assert source.count("_uniform_slideshow_plan(") >= 3
+        # And the two-stage branch must no longer inline its own copy of
+        # the cycling arithmetic.
+        two_stage = source.split("slideshow_scenes, scene_duration_s =")[1][:600]
+        assert "i % len(" not in two_stage
+
+
+class TestFallbackIsPreserved:
+    def test_hybrid_broll_path_is_untouched(self):
+        """The clips path already produces a video background."""
+        source = (REPO_ROOT / "engine" / "video.py").read_text(encoding="utf-8")
+        # The single-pass branch must sit AFTER the hybrid early-return.
+        assert source.index("_render_hybrid_slideshow(visuals") < source.index(
+            "if _single_pass_enabled():")
+
+    def test_failure_falls_back_to_two_stage(self):
+        source = (REPO_ROOT / "engine" / "video.py").read_text(encoding="utf-8")
+        block = source.split("if _single_pass_enabled():")[1][:2200]
+        assert "except (subprocess.CalledProcessError, RuntimeError)" in block
+        assert "falling back to" in block
+        # It must NOT return on failure — control has to reach the old path.
+        assert block.index("falling back to") > block.index("_run_ffmpeg(")
+
+    def test_two_stage_command_builder_still_exists(self):
+        assert callable(video._long_form_cmd)
+        assert callable(video._render_slideshow)


### PR DESCRIPTION
The last code item in `NERRA_IMPROVEMENT_PLAN.md`, and the one it flagged as highest-risk. No audio, prompt, or spoken-script changes.

---

## What it does

The two-stage path renders the Ken Burns slideshow to an intermediate MP4, then feeds that file back in as `[0:v]` of the composite — a full extra encode **and** decode of a 1080p file that exists only to be consumed seconds later, plus a second lossy generation on every delivered pixel.

## Measured, not projected

Real render, 4 scenes / 24 s, **intermediates cleared between runs**:

| | Run 1 | Run 2 |
|---|---|---|
| two-stage | 31.3 s | 32.2 s |
| single-pass | **22.2 s** | **22.2 s** |

**~30% faster** — not the plan's projected 42%.

**The first measurement said the opposite**, and it's worth knowing why: a wired two-stage run clocked 10.5 s, which would have inverted the whole premise. `_render_slideshow` is **idempotent**, so a warm intermediate makes the old path look artificially fast. Clearing intermediates is the only way to measure this honestly — that's recorded in the test docstring rather than left for the next person to rediscover.

## Equivalence — the plan's mandated checks

- **ffprobe** resolution / fps / codec / pix_fmt / audio / duration → **identical**, both directly and through `build_long_form_video`.
- **PSNR** 54.4 dB average (>50 dB is effectively indistinguishable), 37.7 dB min at a crossfade frame.
- **Overlay regions** RMS **0.06** (brand pill) and **0.00** (URL pill) — with a control confirming the pills are actually *drawn* (RMS 83.19 against the raw scene). Without that control, "both renders are equally wrong" would have passed as a match.

## One deliberate inversion of the plan

**It ships opt-in (`NERRA_SINGLE_PASS_RENDER=1`), not as the default.**

The plan wanted single-pass default with two-stage behind the flag. Everything above is *synthetic assets* — no real episode with real imagery, captions and chapter metadata has been through it. Making it the default would put five shows' nightly renders on a change nobody has watched end to end.

**To adopt:** set the env var, compare one real episode, then flip the default in `_single_pass_enabled()`. The two-stage path stays the automatic fallback either way — a failure in the fused command is caught and re-rendered the old way rather than losing the render.

## The dangerous part

Input index arithmetic, and most of the tests are about it. Two-stage numbering is fixed at bg(0)/audio(1)/brand(2)/pill(3); with the scene stills as inputs, the extras move to `n`, `n+1`, `n+2`. Getting it wrong is **silent** — ffmpeg happily overlays the wrong stream. So the offsets derive from `scene_count` in one place, and a test asserts no overlay index can ever collide with a scene index.

## Two things deliberately not forked

- The slideshow half **reuses `_slideshow_filter_graph` verbatim** (its `[v]` relabelled `[bg]`). The xfade offset arithmetic and per-scene duration handling are subtle and already tested.
- The scene-cycling rule moved into `_uniform_slideshow_plan`, now called by **both** renderers. That logic encodes two real incidents — Ep505's 168 s static images and Ep537's 74-slot pipeline timeout — and the paths must not drift apart.

The **hybrid b-roll path is untouched**, as the plan requires: it already produces a video background, so the fusion doesn't apply. A test pins the single-pass branch as sitting after the hybrid early-return.

## Verification

- 40 new tests; **all 102 existing video-command tests pass unchanged** with the flag off.
- `ruff check` clean. Full-suite comparison was still running at push time; I'll report it here.
- Two of my own test assertions were wrong and the code was right — the 24-slot input cap intentionally wins over the 15 s hold target on long episodes. Corrected to assert the real contract.

## Plan status

This completes every code item in the plan. Remaining are secret-gated or operator-only: **P2-3** (needs `YOUTUBE_*`), **P2-2**, **P2-5**, Buttondown sending domain, Apple badge asset, Search Console, Podcast Index dedup.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vhsd6AaYXjYCziPfJAFDNu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core nightly long-form ffmpeg assembly for all shows when the flag is enabled; wrong input indexing would corrupt output silently, though tests and two-stage fallback mitigate rollout risk while it remains opt-in.
> 
> **Overview**
> **Opt-in single-pass long-form render** (`NERRA_SINGLE_PASS_RENDER=1`, default off): pure-stills episodes can fuse the Ken Burns slideshow and brand/caption composite into **one** `filter_complex`, skipping the intermediate 1080p MP4 encode/decode and a second lossy generation on delivered pixels. Hybrid b-roll paths are unchanged.
> 
> The fused graph **reuses** `_slideshow_filter_graph` (output relabelled `[bg]`) and derives overlay input indices from `scene_count` so audio, brand, URL pill, and chapter metadata land at `n`, `n+1`, `n+2` without silent mis-wiring. On failure, `build_long_form_video` **logs and falls through** to the existing two-stage pipeline.
> 
> **Scene cycling** for long episodes is extracted to `_uniform_slideshow_plan` (and `_single_pass_scene_plan` for chapter schedules) so single-pass and two-stage paths cannot drift on hold times and `_MAX_SLIDESHOW_SLOTS` caps.
> 
> Adds **`tests/test_single_pass_render.py`** (~40 tests) for env flag parsing, input index arithmetic, graph shape, shared planner contracts, and fallback ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d65394703d97901922fba3c4a91bab186fb61d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->