### PR TITLE
Cost-efficiency pass: measure what's unmeasured, stop what doesn't work

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -235,6 +235,11 @@ jobs:
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # Escape hatch for the single-pass render (default ON in
+          # engine.video since the July 29 2026 A/B). Set the repo
+          # variable to 0 to force the legacy two-stage path here too,
+          # so one switch covers the dub renders as well as run-show.
+          NERRA_SINGLE_PASS_RENDER: ${{ vars.NERRA_SINGLE_PASS_RENDER }}
         run: |
           LATEST="${{ github.event.inputs.latest }}"
           [ -z "$LATEST" ] && LATEST=3
@@ -263,6 +268,11 @@ jobs:
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          # Escape hatch for the single-pass render (default ON in
+          # engine.video since the July 29 2026 A/B). Set the repo
+          # variable to 0 to force the legacy two-stage path here too,
+          # so one switch covers the dub renders as well as run-show.
+          NERRA_SINGLE_PASS_RENDER: ${{ vars.NERRA_SINGLE_PASS_RENDER }}
         run: |
           LATEST="${{ github.event.inputs.latest }}"
           [ -z "$LATEST" ] && LATEST=3

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -458,17 +458,18 @@ jobs:
           # 15-min TTS + 74-scene xfade graph. Slot cap (24) is the primary
           # fix; this headroom covers long TTS + long-form + 2 Shorts.
           PIPELINE_TIMEOUT_SECONDS: '3000'
-          # Opt-in single-pass video render (engine.video._single_pass_enabled).
-          # Fuses the slideshow and composite into one ffmpeg graph, ~30%
-          # faster on long-form. Verified equivalent on synthetic renders
-          # but not yet A/B'd against a real episode, so it stays OFF by
-          # default and is driven by a repository variable rather than a
-          # commit — set NERRA_SINGLE_PASS_RENDER=1 under Settings →
-          # Secrets and variables → Actions → Variables, watch ONE episode
-          # on a video show, then either flip the default in
-          # _single_pass_enabled() or delete the variable. Unset is falsy,
-          # and a failure in the fused command re-renders the old way, so
-          # neither state can break a run.
+          # Single-pass video render (engine.video._single_pass_enabled).
+          # Fuses the slideshow and composite into one ffmpeg graph,
+          # removing an intermediate 1080p encode+decode: 23-34% faster
+          # on the two shapes production actually ships, with outputs
+          # verified equivalent (same duration/frames/geometry, pixel
+          # diff < 0.3/255, identical scene timeline — July 29 2026 A/B).
+          # DEFAULT ON in code since that A/B. The repo variable is now
+          # only an escape hatch: set NERRA_SINGLE_PASS_RENDER=0 under
+          # Settings → Secrets and variables → Actions → Variables to
+          # force the legacy two-stage path. A failure in the fused
+          # command re-renders the old way regardless, so neither state
+          # can break a run.
           NERRA_SINGLE_PASS_RENDER: ${{ vars.NERRA_SINGLE_PASS_RENDER }}
 
       - name: Validate output

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,37 @@ nerranetwork/
 
 ### Script Relationships
 
+
+> **Per-show review history lives in**
+> [`docs/show_review_history.md`](docs/show_review_history.md) — every
+> dated quality-pass narrative (root causes, what was fixed, what was
+> deferred), moved out of this file on 2026-07-29 so a session does not
+> pay to load ~60 KB of history it rarely needs. The entries below keep
+> each show's structural facts. Canonical write-ups:
+> [`docs/reviews/`](docs/reviews/); scored predictions +
+> `do_not_retry`: [`docs/reviews/ledger/`](docs/reviews/ledger/).
+
+**Live constraints from those passes** (kept here because they bind
+today's work, not just explain yesterday's):
+
+- **SpaceX AI section:** the Colossus/Anthropic material is REAL — do not
+  "correct" or relitigate it (operator-confirmed, June 13 2026).
+- **Length levers are digest-side only.** Podcast-side expansion retries
+  are banned network-wide (July 18 playbook `do_not_retry`: ~10 misses vs
+  1 hit) and were switched off in the show YAMLs on 2026-07-29 wherever a
+  digest-side lever exists. Chronic under-length on FF / PT / UC / Tesla /
+  EI is a DIGEST ceiling — do not re-attack it at the script.
+- **De-seed by shape, never with a quotable example.** Every seeded
+  template tic in this network's history came from a prompt supplying the
+  literal sentence it wanted; three generations of them are in the
+  archive. New prompt guidance describes the shape and bans the verbatim.
+- **The grok-4.3 narrative-length plateau is accepted** (operator
+  confirmed; it resists escalation). Not a bug to re-open.
+- **MIT is NOT ready for live trading** and its `execution/live.py` layer
+  is dormant behind a kill switch. Two operator to-dos remain open:
+  `scripts/recompute_mit_benchmarks.py --apply` (needs market-data
+  access) and SnapTrade Phase-0 verification.
+
 - **FF and PT** are "nearly identical twins" — same structure, same functions,
   different news topics and X account
 - **TST** shares most patterns with FF/PT but adds: complex pronunciation
@@ -122,644 +153,25 @@ nerranetwork/
   emoji formatting via `engine.publisher.format_tst_digest_for_x()`
 - **OV** is structurally different — different TTS approach (no streaming, uses
   env vars for voice settings), simpler functions.
-  **June 10 2026 quality pass** (review:
-  [`docs/reviews/omni_view_review_2026_06_10.md`](docs/reviews/omni_view_review_2026_06_10.md);
-  drift guards: `tests/test_omni_view_quality_pass.py`): OV was missed by
-  every chapter/length hardening round. Two shipped chapter bugs fixed
-  (metadata-only): 7 of the last 10 episodes had NO Closing chapter (the
-  dominant "That wraps up today's Omni View…" closing-pool variant matched
-  no pattern — MAB orphan-closing class), and the dead "Understanding the
-  Issue" pattern let the auto-segment fallback title chapters from raw
-  deep-dive sentences (Ep061 "Knowing this, when you hear claims…", Ep068
-  "How are casualty figures verified…"); added `where` anchors + a Closing
-  pattern covering both variants + a deep-dive pattern matching the real
-  spoken opener. The June "strongest case ≤1×/episode" steel-man fix had
-  FAILED (12-20×/episode in Ep070/071/075, or mutated to the anonymous
-  "One side frames / The other side frames / Advocates on each side" frame
-  in Ep077 — which also violates the prompt's own attribution rule); root
-  cause was the DIGEST prompt seeding the literal "The strongest case for X
-  rests on…" lead-in, so the fix dropped that seed, requires NAMED
-  advocates, and bans the anonymous frame in both prompts (verified via
-  `--test`: 0 uses, advocates now named). Unified three contradictory
-  length targets (8-12 min / 2000 words / "40+ sentences") to one
-  (1,700-2,000w ≈ 11-13 min) + added `podcast_expand_below_target` and
-  raised `min_podcast_words` 900→1400 (the expand opt-in the June network
-  pass missed). Prompt/length edits change shipped audio — A/B-listen per
-  landmine #17; the chapter fix does not.
-  **July 18 2026 editorial realignment** (operator-directed; review:
-  [`docs/reviews/omni_view_review_2026_07_18.md`](docs/reviews/omni_view_review_2026_07_18.md);
-  drift guards: `tests/test_omni_view_quality_pass.py::TestEditorialRealignmentJuly18`):
-  repositioned to "top world stories, balanced, teen-to-senior,
-  informative AND encouraging, anti-clickbait". The 12-slot taxonomy
-  (whose mandatory daily gossip + popular-media slots forced tabloid
-  filler and twice LED episodes with tabloid items) became a 7-slot
-  slate: lead (1) + world (3) + economy/science/tech (2) + **Progress
-  watch** (1, rigor bar: named actors + a number + the complication) +
-  the retained Understanding the Issue deep dive. Steel-man is now
-  CONDITIONAL (2-3 genuinely contested stories, named advocates; the
-  "Both sides agree" family had shipped ~38×/10 eps incl. on a
-  waterslide accident) — disasters/deaths/science/culture get context +
-  what-happens-next, never manufactured sides. Plain-language layer
-  (define every institution in one clause; teen-to-senior audience in
-  every prompt). Sources: Daily Mail REMOVED (was the most-cited outlet;
-  Reuters/AP were 0×), dup-BBC + r/news removed; Reuters/AP Google-News
-  proxies, WSJ World + 9 regional feeds (Africa/Asia/LatAm) added with a
-  geographic-breadth rule (≥3 regions, ≤2/country, UK ≤1); conservative
-  tabloid `exclude_title_patterns`. Engine: `podcast_expansion_style:
-  deepen` (new LLMConfig field — the "cover more stories" retry would
-  fight the fixed slate), `min_digest_words: 1500` + digest retry (the
-  under-length root fix), `ov_validation_config` + `OV_SECTION_PATTERNS`
-  updated to the new headers (Ep068 regenerate-class). New closings pair
-  perspective coaching with one encouraging line; a per-episode
-  "go deeper: compare two outlets" pointer. Public copy updated (tagline
-  kept). All prompt/closing/source changes alter shipped audio —
-  A/B-listen the first post-merge episode per landmine #17; watch the
-  Progress Watch chapter marker for the dead-marker class.
 - **EI** runs exclusively via `run_show.py` + `shows/env_intel.yaml`; no legacy script.
-  **June 10 2026 quality pass** (review:
-  [`docs/reviews/env_intel_review_2026_06_10.md`](docs/reviews/env_intel_review_2026_06_10.md);
-  drift guards: `tests/test_env_intel_quality_pass.py`): EI was missed by
-  the Tesla/PT/four-show chapter fixes — it had no positional `where`
-  anchors, so the "Closing" chapter could land mid-script (Ep040, position
-  7 of 10) and the "That covers today's environmental intelligence"
-  closing-pool variant matched no Closing pattern (MAB orphan-closing bug).
-  Added `where: start` (Introduction) / `where: end` (Tomorrow Teaser,
-  Closing), widened the Closing pattern to both variants, and excluded the
-  closing's "your practice" from the `industry|practice` marker via
-  lookbehind. Cadence fix: EI runs odd weekdays but the spoken intro/closing
-  claimed "daily" and "back tomorrow" (7/10 transcripts) — now cadence-
-  neutral ("We'll be back with the next briefing"). The podcast prompt's
-  contradictory length target (demanded 1500–2200w while the YAML pins 900
-  and episodes ship ~750) unified to 900–1300w. Intro/closing + length
-  prompt edits change shipped audio — A/B-listen per landmine #17.
-  **June 11 2026 follow-up pass** (review:
-  [`docs/reviews/env_intel_review_2026_06_11.md`](docs/reviews/env_intel_review_2026_06_11.md)):
-  scoring the June 10 predictions against Ep044 (first post-fix episode)
-  caught the orphan-Closing prediction MISSING — Ep044 shipped with no
-  Closing chapter because the LLM merged the Tomorrow Teaser sentence and
-  the `{closing_block}` into one paragraph and the parser's first-marker-
-  per-line rule titled it "Tomorrow Teaser". Fixed by reordering the two
-  `where: end` markers so **Closing precedes Tomorrow Teaser** (Closing wins
-  a merged final line; separate lines still yield both) — config-only, no
-  audio change. Also took the deferred thin-news issue at a new lever (not
-  the `min_articles_skip` floor): Ep044's HOOK was literally "No major
-  Canadian regulatory announcements … appeared in today's feed", which
-  became the blog title/h1, the chapter title, and the spoken opener; the
-  digest prompt now forbids an absence-of-news hook and steers thin days to
-  lead with a forward-looking item (A/B render: "CCME soil vapour … comment
-  period closes in 19 days …" replaced the absence hook). Digest-prompt edit
-  changes output — A/B-listen per landmine #17.
-  **June 15 2026 third pass** (review:
-  [`docs/reviews/env_intel_review_2026_06_15.md`](docs/reviews/env_intel_review_2026_06_15.md);
-  drift guards: `tests/test_env_intel_quality_pass.py::TestDeepDiveOpenerNotTic`):
-  scored the prior predictions against Ep045 (first true post-merge,
-  normal-news episode — Closing chapter present, real hook, cadence-neutral
-  closing, 958w; orphan-Closing + absence-hook predictions both HIT). Next
-  tier: the Practitioner Deep Dive opened with the verbatim "You arrive at
-  a…" scenario in 9/10 episodes — root cause was the DIGEST prompt seeding
-  that exact example (`env_intel_digest.txt:173`), which the podcast
-  faithfully echoed (an Omni-View "strongest case" tic class). Dropped the
-  seeded example, required a rotated deep-dive entry point in both prompts,
-  and banned the verbatim "here's something I wish someone had told me…"
-  lead-in (5/10). A/B render: "A Phase I ESA flags a B.C. site within 5 km
-  of a glacial lake…" replaced "You arrive at a…". The structural format
-  (scenario → science → most-common-mistake + fix) is the show's intentional
-  B2B signature and is unchanged. Prompt edits change output — A/B-listen
-  per landmine #17.
-  **June 17 2026 fourth pass** (review:
-  [`docs/reviews/env_intel_review_2026_06_17.md`](docs/reviews/env_intel_review_2026_06_17.md);
-  drift guards: `tests/test_env_intel_quality_pass.py::TestChapterPositionalAnchors`):
-  both June-15 deep-dive tic fixes HIT on Ep046 (first true post-merge
-  episode — odd-weekday show; the "You arrive at a…" and "wish someone had
-  told me…" openers are both gone). New finding — a latent orphan-
-  Introduction bug the June-10 `where`-anchor pass left half-fixed: the
-  Introduction marker only matched the "This is Environmental Intelligence"
-  greeting, but `engine/intros.py` rotates a "Welcome to Environmental
-  Intelligence" greeting too, so every "Welcome to" episode
-  (Ep037/038/042/046 of the last ten) shipped with NO Introduction chapter
-  (the welcome + Compliance Brief got absorbed into the first content
-  chapter). Broadened the pattern to `(?:This is|Welcome to) Environmental
-  Intelligence` (metadata-only, no audio/prompt change — same orphan-
-  chapter class the June 10/11 passes fixed for the Closing variant).
-  Chronic under-length stays deferred (median 814w vs 900 floor; digest
-  ceiling, behind the four-show length A/B), as does the mid-section
-  chapter-marker keyword reliance (Ep046 had no Week Ahead chapter).
 - **M&A** (Models & Agents) runs exclusively via `run_show.py` +
   `shows/models_agents.yaml`; no legacy script.
-  **June 14 2026 quality pass** (review:
-  [`docs/reviews/models_agents_review_2026_06_14.md`](docs/reviews/models_agents_review_2026_06_14.md);
-  drift guards: `tests/test_models_agents_quality_pass.py`): two
-  listener-facing metadata bugs, both no-A/B. (1) The script-gen step
-  spelled core AI proper nouns phonetically despite the prompt ban and
-  they reached TTS *and* chapter titles (`parse_chapters` runs after the
-  repair): `An-thropic` shipped in nearly every episode (6× in Ep080, present
-  since Ep004), plus `Lah-mah` (Llama) and `Hah-sah-biss` (Hassabis) —
-  added to the blessed `engine.utils.fix_phonetic_garbles` restore layer
-  (global; removes a respelling, so outside landmine #17). (2) The Under
-  the Hood chapter marker only matched literal "under the hood" but the
-  deep-dive opens with "let's pop the hood on …" in 9-10/10 episodes, so
-  only 1/5 recent episodes got the chapter — the miss dropped several below
-  `min_chapters` (4) and fired the auto-segment fallback that titled
-  chapters from raw mid-sentence text (Ep080); added `|pop the hood` to the
-  marker (`shows/models_agents.yaml`). Deferred: digest-driven chapter
-  titles (Ep078-class residual, Tesla-deferred) and Under-the-Hood length
-  expansion (after the four-show length A/B). The "pop the hood" opener tic
-  was left unchanged (signature phrase; shipped-audio risk).
-  **June 21 2026 third pass** (review:
-  [`docs/reviews/models_agents_review_2026_06_21.md`](docs/reviews/models_agents_review_2026_06_21.md);
-  drift guards: `tests/test_models_agents_quality_pass.py::TestPhoneticGarbleRepair`):
-  all four June-14 predictions scored HIT. One recurring reader-facing text
-  bug: the SHARED pronunciation map respells `CUDA → "koo-dah"`
-  (`assets/pronunciation.py:168`, an ElevenLabs-era word-acronym guide), and
-  that respelling is written into the `_tts.txt` → the published blog/RSS
-  transcript (`engine/blog.py:767`), shipping verbatim in 12 episodes since
-  Ep040 (e.g. Ep088 "open-sourced a koo-dah kernel"). Same class as the
-  original "nassa" leak that created `fix_phonetic_garbles`; restored the same
-  way — `koo-dah → CUDA` added to `engine.utils._PHONETIC_GARBLES` (global;
-  the canonical acronym reaches both transcript and TTS, exactly as
-  `nassa → NASA` already ships). Collision-safe ("koo-dah" has no English
-  use); the collision-unsafe map guides (`LoRA → "Laura"`, `RAG → "rag"`) are
-  left alone. Sharpened the deferred chapter diagnosis: chapter quality is
-  inversely correlated with prompt compliance — Ep084/086 ship a full
-  9-chapter shape only because the host announces the banned section labels
-  aloud ("Now turning to model updates"), while prompt-compliant episodes
-  (Ep085/087/088) collapse to auto-segment fragments or sparse shapes;
-  confirms digest-driven titles as the durable lever (deferred). New deferred
-  network-wide item: pronunciation-map word-guides leaking into published
-  transcripts (durable fix = source the transcript from pre-pronunciation or
-  Whisper text). Restore-layer edit touches TTS — spot-check per landmine #17
-  (low risk; matches the NASA/Anthropic precedent that ships today).
 - **MAB** (Models & Agents for Beginners) runs via `run_show.py` +
   `shows/models_agents_beginners.yaml`; beginner/teen-focused version of M&A.
   On the custom Grok voice `kdif6sqjcyiq` (inherits `_defaults.yaml`; the old
   "ElevenLabs" note was stale per landmine #17). X posting disabled.
-  **June 25 2026 quality pass** (first dedicated MAB review:
-  [`docs/reviews/models_agents_beginners_review_2026_06_25.md`](docs/reviews/models_agents_beginners_review_2026_06_25.md);
-  drift guards: `tests/test_mab_quality_pass.py`): scored the June-10
-  four-show predictions — the "So imagine" opener de-seed HIT (0/10), the
-  length floor raise MISSED (9/10 still under 1200, digest ceiling, deferred).
-  Two prompt de-seeds (A/B). (1) The Deep Dive closer echoed a verbatim
-  three-sentence template every episode — "and that's basically what X is
-  doing when it Y / so next time someone says Z, you can tell them it is
-  basically W / not so scary, right?" (9/10 "not so scary right", Ep080/081/082
-  word-for-word); root cause was BOTH prompts seeding the literal sentences
-  (`mab_podcast.txt:138-139`, `mab_digest.txt:121-122`, the Omni-View
-  "strongest case" / EI deep-dive / FP lesson-template class). De-seeded both,
-  keeping the analogy method but requiring fresh per-episode phrasing and
-  naming the formulas as banned-as-verbatim (A/B render: digest now ends "…more
-  like chatting with someone who actually gets the point" instead of the
-  formula). (2) After the "So imagine" fix the model converged on a new
-  "Something [adj] just happened" opener (5/10) — straight from the prompt's
-  own example list (`mab_podcast.txt:125`); moved it from the example menu to
-  the BANNED list. Deferred: chronic under-length (digest ceiling, four-show
-  length A/B); "The Big Story" chapter missing on every episode (dead
-  `big story|biggest news` marker — host's opener is intentionally varied, no
-  anchor; digest-driven/position-aware titles is the durable lever, M&A
-  June-21 class); Ep081 auto-segment garbage title (same lever); the stale
-  Fish/Chatterbox pronunciation hook still injecting landmine-#17 respellings
-  (`CUDA→"kooda"` etc., 0/76 transcript impact — recommend aligning with
-  sister M&A which uses no hook). Prompt edits change output — A/B-listen per
-  landmine #17.
 - **FP** (Финансы Просто) runs via `run_show.py` +
   `shows/finansy_prosto.yaml`; Russian-language financial literacy podcast
   for women in Canada (even days only). Uses **Grok TTS** (Olya voice
   `0b875ae2`, `language_code: ru`). All content generated in Russian. X posting disabled.
-  **June 16 2026 quality pass** (first dedicated FP review; combined June 10
-  pass was `docs/russian_shows_review_2026_06_10.md`; review:
-  [`docs/reviews/finansy_prosto_review_2026_06_16.md`](docs/reviews/finansy_prosto_review_2026_06_16.md);
-  drift guards: `tests/test_finansy_prosto_quality_pass.py`): scored the
-  June-10 floor-raise as a MISS (episodes still ~5 min / ~700w — the podcast
-  tracks a ~700w digest 1:1 and may not pad, so a podcast-side floor +
-  expand-retry can't help; re-attacked at the digest). Two listener-facing
-  P0s on the Olya voice: the YouTube call-out was an ENGLISH sentence (the
-  AI-disclosure wart class the June-10 pass localized, but the call-out in
-  `engine/intros._maybe_append_youtube_cta` was missed) — now Russian for
-  FP via `_RUSSIAN_SPOKEN_SHOWS` (PR stays English, it's taught in English);
-  and the "@" handle was voiced as the word "at" ("...YouTube **at at** Nerra
-  Network", 75+ times across six shows) — now stripped network-wide. The
-  closings said "до завтра" on an even-days show (EI-class cadence bug) — now
-  cadence-neutral ("до встречи"). P1s: `_extract_hook` now recognizes the
-  Russian `ЗАГОЛОВОК:` hook label (the FP/PR digest format), stopping a wasted
-  structural regen that fired on every FP episode (`digest_structural_regen:
-  true`, Ep45-54); the structural-retry corrective suffix was hardcoded with
-  Tesla section names ("Top 12 News Items, Tesla X Takeover…") and applied to
-  all shows — now generic. The digest prompt asks for 3-4 tips / 3 quick-news
-  / 5-7 articles (matching the podcast's already-required minimum of 3 tips;
-  content is abundant at 69-129 articles/day). Call-out/closing/digest edits
-  change shipped audio — A/B-listen per landmine #17.
 - **MIT** (Modern Investing Techniques) runs via `run_show.py` +
   `shows/modern_investing.yaml`; daily investing podcast focused on Canadian
   and US markets. Weekdays only. X posting disabled.
-  **June 2026 quality pass** (drift guards: `tests/test_mit_quality_pass.py`):
-  the recursive-learning loop had been DEAD on every episode —
-  `_analyze_strategy_patterns` was called but never defined, the NameError
-  was swallowed by pre_fetch's try/except, and all three learning blocks
-  shipped as "temporarily unavailable" (now implemented: FAVOR/AVOID sector
-  guidance). Two trades closed with NaN exit prices (yfinance returns NaN
-  floats that pass `is None`) had poisoned `cumulative_pnl` into NaN —
-  "Running Total: $nan" on air; all aggregations now route through
-  `_finite()` and `_close_trade` rejects non-finite prices. The summary
-  gained `cumulative_alpha_vs_nasdaq` (the headline metric previously read
-  from a key that never existed — actual record: +20.6% across 26
-  benchmarked trades, finally stated on air via the portfolio block).
-  Lesson cooldowns now ESCALATE with teach-count (flat 21d let
-  bid_ask_spread reteach 13×; every 3 repeats adds a full period, cap
-  180d). Trade extraction logs loudly on formatting drift vs quiet on
-  deliberate no-trade days. MIT opts into `podcast_expand_below_target`,
-  gets a hook-led X teaser linking the episode blog + performance page,
-  and the deep-dive queue carries a 6-entry evergreen Canadian bench
-  (operator schedules via `when: next`). Prompt edits (no-trade platitude
-  ban, Market Pulse macro frame) change output — A/B-listen per landmine
-  #17.
-  **July 3 2026 benchmark-integrity pass** (review:
-  [`docs/reviews/modern_investing_review_2026_07_03.md`](docs/reviews/modern_investing_review_2026_07_03.md);
-  drift guards: `tests/test_mit_benchmark_integrity.py`): audit driven by
-  the operator's live-trading intent — the measurement layer was not
-  measuring what it claims. Every FLASH trade had `nasdaq_return_pct: 0.0`
-  (the annotator compared the same close to itself → "alpha" was the raw
-  return); mid-week weekly picks were BACKDATED to Monday's open
-  (hindsight gain — Ep35 AMD picked Wed, +13.36% from Mon open); Ep50
-  "CNR (TSX)" was priced as US Core Natural Resources, not Canadian
-  National Railway; DELL/HIMS NaN closes were still spoken as breakevens
-  (the July-2 migration caught nulls, not NaN); `--test` runs appended
-  REAL trades (post_generate runs before the test-mode exit); and the
-  lessons_learned "learning loop" was an echo chamber (65 actives, ~47
-  copies of two rules — the 9/10-episode "closing-price confirmation"
-  tic). Fixed: matched-bar-window benchmark (index open→close over the
-  trade's own bars), pick-date entry integrity (no bars before the pick;
-  cron-delay wrong-day pricing killed; stale picks void after 10d), TSX
-  `.TO`/`.V` resolution + pick-time probe + price-discontinuity tripwire,
-  self-healing void of non-finite closes (tracker now 40 closed/6 voided,
-  win rate 57.5%), `NERRA_HOOKS_READONLY` set by run_show for
-  `--test`/`--rehearse` (only the MIT hook honors it so far — extending to
-  the memory shows is a deferred network item), lessons dedup-on-append +
-  ledger collapse 65→11 distinct rules, matched-window compounded alpha +
-  labeled scoreboard blocks (A/B-listen: scoreboard/lessons/bar-day-label
-  changes alter spoken output), per-bucket confidence calibration (46/46
-  picks had said "Medium"). Operator to-dos: run
-  `scripts/recompute_mit_benchmarks.py --apply` (needs market-data access;
-  realigns historical windows + reports wrong-instrument trades) for the
-  first trustworthy alpha baseline, and see the review doc's live-trading
-  readiness verdict (NOT READY — honest record +$304 over 40 sequential
-  $1k trades vs NASDAQ +15.46% ITD; accumulate 2-3 months of clean
-  post-fix record first).
-  **July 3 2026 SnapTrade execution plan** (doc:
-  [`docs/mit_snaptrade_live_trading_plan.md`](docs/mit_snaptrade_live_trading_plan.md);
-  drift guards: `tests/test_mit_benchmark_integrity.py::TestTradeSignal`):
-  design for live trading via SnapTrade (the only sanctioned Wealthsimple
-  API route; Webull US/CA trading added Dec 2025). Shipped the execution
-  bridge: `post_generate` now writes a schema-versioned
-  `trade_signal_latest.json` + per-episode copy (explicit
-  new_trade/no_trade with drift-distinguishing reason, SnapTrade-format
-  symbol — Yahoo `.TO` convention matches the tracker's resolved symbols
-  1:1 — CAD→Wealthsimple / USD→Webull routing, deterministic uuid5
-  `client_order_id` for idempotent placement; read-only runs write
-  nothing). The future `execution/` package consumes ONLY this artifact
-  — the LLM never touches the order path. Phased rollout in the doc
-  (read-only mirror → shadow mode → $150-250 micro-live on Webull →
-  scale), fail-closed risk caps, and an operator checklist (SnapTrade's
-  per-broker matrix must be verified in the dashboard: trade enablement
-  for Wealthsimple, Limit+Day support, fractional/notional). NOTE:
-  SnapTrade's sandbox is READ-ONLY (no simulated fills) — shadow mode is
-  the paper-trading layer. Podcast stays a simulation on air; live
-  execution is a private layer decoupled from the 08:16 UTC episode run
-  (executor runs its own ~13:50 UTC slot).
-  **July 4 2026 optimize-the-loop pass** (drift guards:
-  `tests/test_mit_benchmark_integrity.py::{TestMultiIndexBenchmark,TestRuleEffectiveness}`,
-  `tests/test_snaptrade_execution.py::{TestRiskGates,TestShadowExecutor}`):
-  three workstreams toward "beat all major indices". (1) **Multi-index
-  matched-window benchmarking** — every closed trade now carries
-  `benchmark_returns` for ^IXIC + ^GSPC + ^GSPTSE over the SAME bar
-  window; summary gains per-index compounded `benchmark_scores` +
-  `indices_beaten`; the scoreboard block adds a once-per-episode
-  "beating N of 3 major indices" sweep (NASDAQ stays the headline;
-  legacy trades fall back to the nasdaq field; recompute script rebuilds
-  history for all three). (2) **Rule-effectiveness scoring** — trades are
-  stamped with `rules_in_effect` (the exact rule IDs shown on pick day);
-  `_build_rule_scoreboard` compares stamped-trade alpha vs trades
-  without each rule and flags ≥8-trade no-edge rules as RETIREMENT
-  CANDIDATES (operator decision — never auto-retired). The learning loop
-  now measures whether its own rules work. (3) **Shadow mode (Phase 2)
-  LIVE** — `execution/risk.py` (pure, env-tunable hard gates; kill
-  switch defaults off) + `execution/shadow.py` (signal → gates →
-  decision-time quote → would-be marketable-limit order → committed
-  `shadow_ledger.json`, idempotent) + `mit-shadow-executor.yml`
-  (weekdays 13:50 UTC, yfinance only, no secrets); the read-only/no
-  order-placement contract still pinned. `scripts/mit_shadow_report.py`
-  = sim-vs-shadow slippage table. Scoreboard/lessons-block additions
-  change prompt context → A/B-listen per landmine #17. Same-PR second
-  batch: shadow EXITS (paired idempotent `would_sell` on the sim's exit
-  calendar → round-trip shadow P&L + sim-vs-shadow gap in the report),
-  regime block (rolling last-10 alpha + drawdown → cold streak makes
-  no-trade the default / hot streak holds the bar), FAVOR/AVOID now
-  requires n≥5 samples (was 2-3 — coin flips steered picks), performance
-  page gained the matched-window headline tile + "not capital-matched"
-  relabel + major-index sweep.
-  **July 4 2026 fidelity batch** (drift guards:
-  `tests/test_mit_benchmark_integrity.py::{TestStopLossExtraction,TestStopBreach,TestAlphaTStat}`,
-  `tests/test_dashboard_mit_section.py::TestExecutionHealth`): stop-loss
-  ENFORCEMENT — the digest narrates a stop on every pick but the sim
-  never enforced it; the stop is now parsed at pick time (never guessed),
-  carried on the trade + trade signal (future bracket orders), and
-  enforced at evaluation against intraday lows (bars carry a 4th
-  low element; gap-aware fills; entry-bar breaches never claimed; the
-  benchmark window follows the shortened hold; the review narrates
-  "stopped out" as stop discipline working). Per-trade alpha **t-stat**
-  (`alpha_t_stat` / `alpha_statistically_significant`) in the summary +
-  an on-air honesty rule in the scoreboard block (hedge "not yet
-  statistically significant" until t≥2). Dashboard `execution_health`
-  block (trade-signal freshness/staleness + shadow-ledger vitals).
-  Stop enforcement changes sim outcomes going forward; the honesty line
-  + stop narration are new prompt context → A/B-listen per landmine #17.
-  **July 4 2026 Phase-3 live executor (DORMANT)** (drift guards:
-  `tests/test_snaptrade_execution.py::{TestLiveEntry,TestLiveExits,TestLiveStatePrivacy}`):
-  operator-directed "build the next layer" — real order placement now
-  EXISTS but cannot run until armed. `execution/live.py` +
-  `scripts/mit_live_executor.py` + `mit-live-executor.yml` (13:52 UTC
-  entries / 19:45 UTC exits). Gate order, all fail-closed: kill switch
-  (repo var `LIVE_TRADING_ENABLED=1`; unset → logged no-op that never
-  loads credentials) → SnapTrade config → self-halt (2 consecutive
-  rejects halt the layer via committed `live_execution_state.json`;
-  exits still run so positions are never unmanaged) → shared risk gates
-  → daily/open-position caps → account resolution (institution match on
-  the signal's routing hint) → live quote (none = never place blind).
-  Integer-share marketable limits under `MIT_MAX_POSITION_USD` (default
-  $250); idempotent `client_order_id`; the narrated stop rides on the
-  signal for future bracket orders. Privacy split: committed state =
-  ids/status only; full `live_ledger.json` (account ids/amounts) is
-  gitignored + 90-day CI artifact. The Phase-1/2 "no placement code"
-  contract is superseded by a narrower pinned one: the SDK trading call
-  exists ONLY in `snaptrade_client.py`, invoked ONLY by `live.py`, whose
-  FIRST gate is the kill switch (a poisoned-client test proves disabled
-  runs touch nothing). No prompt/audio changes (outside landmine #17).
-  **July 18 2026 two-week scoring review** (review:
-  [`docs/reviews/modern_investing_review_2026_07_18.md`](docs/reviews/modern_investing_review_2026_07_18.md);
-  drift guards: `tests/test_mit_benchmark_integrity.py::{TestRegimeDeadlockFix,TestWeeklyMinHold,TestSweepGating,TestNoTradeReasonTaxonomy}`):
-  scored the July 3-4 predictions — 8 HIT (tic 9/10→0/10, entry
-  integrity, stops 2/2, rule stamps, 3-index closes, shadow ledger
-  complete with paired exits, dormant live layer untouched), 1 MISS,
-  1 pending. Two production design flaws fixed: (1) the regime
-  cold-streak brake DEADLOCKED the Practice Investment (2 picks in 14
-  episodes; mean poisoned by the -11.8 MDA outlier, $100 drawdown
-  threshold permanently tripped at $164 standing, and cold suppressed
-  the closes that refresh the window) — regime v2 uses the MEDIAN, a
-  full-position $250 drawdown threshold, a >7-day pick-drought escape
-  valve (SELECTIVE RESET expects the next Monday pick), and tells the
-  show to narrate capital-preservation mode on air; (2) Ep101 COST was
-  picked Thursday and closed as a one-bar "weekly hold" (entry==exit
-  bar, -2.35% while the shadow layer holding Thu→Fri made +0.26%) —
-  weekly closes now require ≥2 days since pick, shadow calendar matched.
-  The MISSed prediction: the t-stat honesty hedge was spoken in ZERO
-  episodes while the alpha was quoted in most — the caveat now lives
-  INLINE in the alpha sentence (models echo data lines, drop separate
-  instructions — a reusable lesson). Index sweep gated on n≥5 per index
-  (was comparing 37-trade NASDAQ vs 2-trade S&P/TSX). No-trade signal
-  reasons: explicit forms broadened ("Today's Pick: None" was mislabeled
-  as extraction drift), `no_practice_section` for recaps. Regime/caveat
-  text changes prompt context → A/B-listen per landmine #17. Operator
-  items still open: recompute --apply (matched alpha retains old-window
-  inflation until backfill), SnapTrade Phase-0 verification, LL-054
-  family retirement.
-  **July 24 2026 operator-directed pass** (review:
-  [`docs/reviews/modern_investing_review_2026_07_24.md`](docs/reviews/modern_investing_review_2026_07_24.md);
-  drift guards: `tests/test_mit_benchmark_integrity.py::{TestSuffixedSymbolExtraction,TestCryptoSymbolCandidates,TestInstrumentScaleMismatch,TestVoidDisclosure,TestAlphaCaveatDataShaped,TestArticleCollapseAlarm}`):
-  the trade EXTRACTOR could not parse the exchange-native symbols the
-  July-3 pass taught the digest to emit — Ep111's spoken CNR.TO weekly
-  pick was silently LOST (`no_pick_extracted`) and Ep113's "BTC-USD —
-  Bitcoin" was truncated to "BTC", validated against an unrelated $28.80
-  equity (narrated stop $64,500), routed to Webull in the trade signal,
-  and would_place'd by the SHADOW executor — the wrong instrument reached
-  the execution layer. Fixed: suffixed/hyphenated symbol extraction +
-  CRYPTO market (+ latent TSX-V alternation bug), crypto candidates force
-  the `-USD` pair with no bare fallback, a wrong-instrument tripwire
-  (stop outside [ref/3, ref×3] voids at record time + self-healing
-  migration; committed tracker migrated — Ep113 BTC voided), and an
-  announced-then-voided pick is now disclosed on air exactly once. Ep115
-  fetched 9 articles (vs 222-337 median) and shipped 6/6 x.com sources —
-  new network-wide source-collapse `::warning::` + `article_count_degraded`
-  metric in run_show; digest prompt gains x.com-as-one-publication /
-  publisher-first sourcing, the Tools-header scaffold typo fix ("…Tool:
-  Source" shipped verbatim), and Today's-Pick template instructions moved
-  out of the value slot (Ep111 echoed the parenthetical on air). Length
-  attacked at the sanctioned substrate (`digest_expand_below_target` +
-  `min_digest_words: 1500`; 10/10 scripts were under the 1800 floor). The
-  significance caveat missed a SECOND time (1/6 alpha mentions) — now
-  fused into the alpha value as a data-shaped parenthetical; a third miss
-  goes to the operator as accept-or-abandon. Prompt/caveat/digest-lever
-  edits change output — A/B-listen per landmine #17.
-
-**Tesla Shorts Time Recursive Memory System (May 2026+)**  
-TST received a full recursive improvement architecture (analogous to MIT):
-- `engine/tesla_memory.py` + three persistent trackers in `digests/tesla_shorts_time/`:
-  `tesla_narrative_tracker.json` (major programs with status, claims, confidence),
-  `tesla_performance_tracker.json` (YouTube/Shorts signals for emphasis),
-  `tesla_theme_history.json` (mined from transcripts/digests).
-- Injected on every episode via `shows/hooks/tesla.py` pre_fetch → rich context blocks
-  (`tesla_narrative_status_block`, performance signals, theme context).
-- Prompt updates in both digest and podcast prompts.
-- Public page `tesla-narrative.html` (generated nightly + on demand).
-- Post-episode hook + Sunday recap integration.
-- Operator tooling: `scripts/update_tesla_narrative.py` for easy updates without hand-editing JSON.
-- Goal: TST becomes the best long-term public chronicle of Tesla's major programs while
-  continuously optimizing for real audience engagement.
-- **June 2026 quality pass** (drift guards: `tests/test_tesla_quality_pass.py`):
-  theme mining now reads the DIGEST only (the old code mined the narrative
-  TEMPLATE text every episode — "open questions" hit count 112 and drowned
-  real topics; `_THEME_STOPWORDS` + a one-time scrub fixed existing
-  histories). `auto_update_narrative_from_digest` auto-advances per-program
-  `last_mentioned_episode/date` on every episode (the tracker had sat 13
-  days stale on a daily show) — operator-curated `status` text still only
-  changes via `scripts/update_tesla_narrative.py`. The listener-value score
-  gained a 15%-weight length component (`target_words` kwarg). Tesla opts
-  into `llm.podcast_expand_below_target: true` — the one-shot expansion
-  retry fires on ANY below-target script, not only near the 60% skip floor
-  (9 of 10 episodes had shipped 15-35% under the 1600-word target). The X
-  teaser leads with the episode hook + links the episode blog post. The
-  prompts ban the "Taking a step back from today's headlines" opener,
-  rotate three First Principles frameworks, cap the vertical-integration
-  conclusion, enforce the Takeover/Top-12 zero-overlap check, and add
-  3-tier attribution discipline. Prompt changes alter generated output —
-  A/B-listen per landmine #17 and revert via git if quality dips.
-- **June 10 2026 follow-up pass** (full review:
-  [`docs/tesla_review_2026_06_10.md`](docs/tesla_review_2026_06_10.md);
-  drift guards in `tests/test_tesla_quality_pass.py`,
-  `tests/test_chapters.py::TestPositionalConstraints`,
-  `tests/test_tesla_hook.py::TestClosingBlock`):
-  chapter markers gained positional `where: start|end` constraints +
-  once-per-title matching (the closing's "tesla shorts time" mention had
-  titled the closing "Introduction" on every episode); the spoken closing
-  now rotates 4 variants, phrases by market state, and OMITS the price
-  sentence when the quote failed validation (previously spoke "closed at
-  zero dollars, price unavailable"); the expansion retry now carries the
-  full digest (it previously saw only its own short script — it could not
-  add facts, the root cause of chronic under-length); ONE unified length
-  target (2,200–2,400 words ≈ 14–16 min, `min_podcast_words: 2000` — the
-  prompt had demanded four contradictory lengths); the performance loop is
-  LIVE (`scripts/update_tesla_performance.py` nightly derives
-  `strong_topics_last_30d` from OP3 download data — `record_performance_signal`
-  previously had zero callers); theme mining filters narrative-prose echo +
-  URLs and is idempotent per episode; program detection uses word-boundary
-  regexes (bare "unsupervised" no longer advances FSD); the spoken show
-  name dropped "Daily" to match the listing brand "Tesla Shorts Time";
-  content-tracker headlines filter junk/slur titles
-  (`_is_dedupe_worthy_title`); blog posts link the Story Tracker page.
-  Length/brand prompt changes alter shipped audio — A/B-listen per
-  landmine #17.
-- **June 20 2026 second agent pass** (review:
-  [`docs/reviews/tesla_review_2026_06_20.md`](docs/reviews/tesla_review_2026_06_20.md);
-  drift guards: `tests/test_tesla_quality_pass.py`): scored June 10 — the
-  chapter-anchoring HIT (0/10 trailing-Introduction) but the length
-  prediction MISSED (Ep507-516 1254-1676w, all under the 2000 floor).
-  Three deterministic fixes. (1) The podcast-gen step spelled Teslarati —
-  the show's #1 source — phonetically as `Tesla-rah-tee` in 25+ episodes
-  (5 of the last 10), voiced as an audible garble (Whisper of Ep516:
-  "Tesla had RadT"); added to the blessed `engine.utils.fix_phonetic_garbles`
-  restore layer (removes a respelling → outside landmine #17, A/B anyway).
-  (2) The June-10 "drop Daily from the spoken brand" decision had MISSED
-  the pre-existing brand normalizer in `engine/generator.py`, which kept
-  normalizing TOWARD "Tesla Shorts Time Daily" — so the LLM-appended
-  "Daily" shipped in the spoken intro of 100% of episodes (Ep506-516);
-  the normalizer now drops the stray "Daily" (completes the approved
-  decision; A/B-listen). (3) 13F institutional-filing spam ("LLC Purchases
-  New Stake in Tesla", 3× in Ep516) now filtered at fetch via
-  `exclude_title_patterns` in `shows/tesla.yaml` (deterministic, no-A/B,
-  FF stock-filter class). Deferred with re-diagnosis: chronic under-length
-  is the DIGEST ceiling (Top-12 items ship 3 thin sentences from
-  Google-News snippets; script tracks the digest ~1:1) — same root cause
-  as FF/UC/PT, held behind the four-show length A/B (levers: digest-
-  expansion retry / First-Principles essay expansion). Also deferred:
-  chapter body navigation — fragment auto-segment titles (8/10) AND a new
-  no-body-chapter regression (2/10; `engine/chapters.py:208` never
-  implemented its docstring's "head spans most of script" auto-segment
-  trigger) — fix is network-scoped digest-driven titles.
-- **June 10 2026 four-show pass** (MIT, M&A, MAB, FF; full review:
-  [`docs/four_show_review_2026_06_10.md`](docs/four_show_review_2026_06_10.md);
-  drift guards: `tests/test_four_show_quality_pass.py`): every show's
-  Closing chapter pattern now matches every closing-pool variant (MAB had
-  shipped 50% of episodes with NO Closing chapter; M&A's bare `agent`
-  pattern opened a spurious chapter ~30s into every episode) with
-  `where: start|end` positional anchors; ONE unified length target per
-  prompt (MIT 2,000-2,200w/floor 1800; M&A 1,600-2,200w; FF
-  1,900-2,200w/floor 1700; MAB floor 1200) replacing contradictory
-  anchors; `engine/show_memory.py` gained all four Tesla memory fixes
-  (narrative-prose echo filter, per-episode idempotency, URL stripping,
-  word-boundary program detection) + `update_performance_from_op3`; the
-  nightly performance step generalized to
-  `scripts/update_performance_trackers.py` (Tesla + M&A + FF + PT); the
-  three memory shows' theme histories were re-scrubbed; MAB's "So
-  imagine" opener tic (49 of 60 episodes — the prompt's own example was
-  the template) now requires rotating opener shapes. Length/opener
-  prompt edits change output — A/B-listen per landmine #17.
-- **FF June 12 2026 quality pass** (review:
-  [`docs/reviews/fascinating_frontiers_review_2026_06_12.md`](docs/reviews/fascinating_frontiers_review_2026_06_12.md);
-  drift guards: `tests/test_fascinating_frontiers_quality_pass.py`): the
-  June-10 four-show length fix MISSED — Ep097/098/099 (post-pass) shipped
-  1634/1390/1637w, all under the 1700 floor. Verified root cause is the
-  **digest ceiling**, not the target: FF's RSS feeds return snippets
-  (not full text) → digests run 1027-1597w → the podcast can't exceed
-  them without the padding/invention both prompts ban (Ep099 script 1664w
-  > its digest 1572w). The expand-retry fires every episode and plateaus;
-  on the thinnest day it padded 6 stories with title-case headline
-  restatements. Deferred the only non-padding lever (expand the Cosmic
-  Deep Dive, which is licensed to use the model's own astrophysics
-  knowledge) until the operator's four-show length A/B settles. Shipped
-  two deterministic, no-A/B fixes: (1) `fix_phonetic_garbles` extended for
-  the space names the model spelled phonetically despite the ban —
-  "En-sell-uh-dus"→Enceladus (Ep048/088/094), "Tee-en-wen"→Tianwen
-  (Ep090); (2) a theme-mining self-reference filter — the show's own name
-  ("fascinating frontiers") had been mined as a top "recurring theme"
-  every episode (Ep97/98/99 led their top_themes with it); only the full
-  show-name bigram is filtered, never component tokens.
-- **FF June 16 2026 quality pass** (review:
-  [`docs/reviews/fascinating_frontiers_review_2026_06_16.md`](docs/reviews/fascinating_frontiers_review_2026_06_16.md);
-  drift guards: `tests/test_fascinating_frontiers_quality_pass.py::TestStockMarketTitleFilter`):
-  both June-12 predictions HIT (garbles gone, show-name no longer a top
-  theme). New finding: since the SpaceX/SPCX IPO (June 12) the Google-News
-  "SpaceX" queries flood FF — a *science* show — with pure stock-market
-  items; Ep103 shipped FOUR of fifteen stories as market action (an $85.7B
-  funding round told twice, a "$60B merger with Cursor", NASDAQ index
-  inclusion, a 20% share move), off-brand and overlapping SpaceX Daily /
-  Modern Investing. Fixed at fetch time via stock/market
-  `exclude_title_patterns` (same accepted class as the almanac filter —
-  deterministic, no A/B) + a digest-prompt `NO STOCK / MARKET ITEMS` scope
-  bullet (A/B-listen). Live-verified on today's feeds: 7 SPCX items dropped,
-  Falcon 9 *launch* kept (a bare `nasdaq/nyse` pattern was tried and removed
-  after it dropped that launch story). The chronic under-length / Cosmic Deep
-  Dive lever stays deferred pending the four-show length A/B. The `@`→"at at"
-  YouTube-CTA wart in Ep103 was already fixed upstream by the June-16 FP pass.
-  Prompt edit changes output — A/B-listen per landmine #17.
-  **June 24 2026 third pass** (review:
-  [`docs/reviews/fascinating_frontiers_review_2026_06_24.md`](docs/reviews/fascinating_frontiers_review_2026_06_24.md);
-  drift guards: `tests/test_fascinating_frontiers_quality_pass.py::TestChapterClosingOrdering`):
-  scored June-16 — launch-false-drop prediction HIT; the stock-filter
-  prediction PARTIAL (dailies clean, but the Sunday recap Ep108 re-surfaced
-  pre-filter Ep103 SPCX content via the content lake — `engine/weekly_recap.py`
-  bypasses the fetch filter; self-healing next cycle, deferred). Headline: the
-  orphan-Closing chapter class the snapshot's loose `chapter_issues` check
-  missed — Ep110/Ep111 shipped with NO Closing chapter (ended on Tomorrow
-  Teaser) and Ep109 shipped a spurious out-of-order Cosmic Deep Dive chapter.
-  Root cause: the sign-off "…see you next time" matches the teaser's `Next
-  time` and Teaser was listed before Closing; the real "Keep an eye on…"/
-  "Watch for…" teaser openers (6/8) matched no pattern; and bare `deep dive`
-  only ever matched the cross-promo "daily deep dive into everything Tesla".
-  Fixed (metadata-only, no audio): Closing before Tomorrow Teaser, teaser
-  broadened to line-anchored `^Keep an eye on`/`^Watch for`, bare `deep
-  dive`/`under the hood` dropped (EI June-11 / SpaceX June-18 / FP June-23
-  ordering-rule class) — verified by re-parsing real Ep108-111 (all now end
-  Tomorrow Teaser -> Closing). Chronic under-length + the digest-driven
-  mid-section chapter titles stay deferred.
 - **PR** (Привет, Русский!) runs via `run_show.py` +
   `shows/privet_russian.yaml`; bilingual Russian language learning podcast
   for English speakers. Even days only. Uses **Grok TTS** (custom Olya voice
   `0b875ae2`, `language_code: ru` — `shows/privet_russian.yaml`). X posting
   disabled.
-- **June 10 2026 Planetterrian pass** (review:
-  [`docs/planetterrian_review_2026_06_10.md`](docs/planetterrian_review_2026_06_10.md);
-  drift guards: `tests/test_planetterrian_quality_pass.py`): NEW
-  network-wide missing-closing guard in `engine/pipeline.py` (PT Ep081/084
-  shipped without the supplied closing block — Ep084 ended mid-teaser; the
-  pipeline now appends the resolved `closing_block` verbatim when absent,
-  before chapter parsing); ONE unified length target (1,800–2,100 words ≈
-  12–13 min, floor 1250→1600 — the prompt had demanded three conflicting
-  lengths and all 15 recent episodes ran under target, avg ~970); chapter
-  `where` anchors + "see you next" closing coverage. Watch the first week
-  for `podcast_script_too_thin` skip markers; fall back to floor 1400 if
-  PT skips more than once. A/B-listen per landmine #17.
-  **June 18 2026 second pass** (review:
-  [`docs/reviews/planetterrian_review_2026_06_18.md`](docs/reviews/planetterrian_review_2026_06_18.md);
-  drift guards: `tests/test_planetterrian_quality_pass.py::TestChapterShapeJune18`):
-  the June-10 `where` anchors exposed two deeper chapter P0s (all
-  metadata-only, no A/B). (1) The Introduction marker matched only the
-  "Welcome" greeting, but the intro rotates four greetings — "Good to have
-  you on" / "Thanks for tuning in to" carry no "Welcome", so ~50% of
-  episodes (Ep085/086/088/093) shipped with NO Introduction chapter and the
-  whole body collapsed under the teaser-anchored first chapter
-  (orphaned-body class); now anchored on "Planetterrian … episode" (matches
-  all four greetings). (2) The spoken teaser opens "Keep an eye on…" / "Watch
-  for…" (the pattern missed it), so the teaser's `Next time` stole "See you
-  next time" from the closing line and Ep086/090 shipped with no Closing
-  chapter — fixed via the EI June-11 ordering rule (Closing precedes Tomorrow
-  Teaser) + a broadened teaser pattern. (3) The Science Deep Dive marker was
-  dead (prompt forbids announcing the section); now matches the seeded spoken
-  opener ("most people get wrong / picture / assume"). The June-10 length fix
-  scored a MISS — episodes still 1178–1378w (digest ceiling, FF/UC root
-  cause); re-attack deferred behind the four-show length A/B. Garbage
-  mid-body auto-segment chapter titles also deferred (shared LLM-title class).
-- **June 10 2026 Russian-shows pass** (FP + PR; review:
-  [`docs/russian_shows_review_2026_06_10.md`](docs/russian_shows_review_2026_06_10.md);
-  drift guards: `tests/test_russian_shows_quality_pass.py`): the spoken +
-  RSS AI disclosures are now LOCALIZED (`_AI_DISCLOSURE_RU` /
-  `_AI_DISCLOSURE_RSS_RU` in `run_show.py`, gated on `_RUSSIAN_SHOWS`) —
-  closing the "English disclosure on the Olya voice" wart from two prior
-  reviews; Russian feeds title episodes "Выпуск N: …"; closing-pool
-  coverage + `where` anchors fixed (FP's "Вот и всё" variant matched no
-  pattern; PR had ONE closing ever — now 3 rotating); floors FP 900→1000,
-  PR 650→800 (PR keeps `min_podcast_word_floor: 550`); NEW
-  `engine/vocab_tracker.py` + `shows/hooks/privet_russian.py` give PR
-  vocabulary memory — spaced-repetition review callbacks + a
-  no-reteach/theme-rotation list via `{vocab_review_section}` (Animals had
-  run 3 consecutive episodes; words never reappeared). Audio-affecting
-  changes → A/B-listen per landmine #17.
 - **FPD** (First Principles Daily) runs via `run_show.py` +
   `shows/first_principles.yaml`; a **daily narrative** show
   (`narrative_mode: true`, topic-queue-driven like UC — no news fetch).
@@ -771,141 +183,13 @@ TST received a full recursive improvement architecture (analogous to MIT):
   (`category: opportunity_area`); Ep1 is a combined debut. Patrick voice
   (inherits Grok `kdif6sqjcyiq`). Distribution OFF at launch (no newsletter,
   no X, no YouTube). Queue: `shows/topic_queues/first_principles.yaml`.
-  **June 10 2026 quality pass** (review:
-  [`docs/reviews/first_principles_review_2026_06_10.md`](docs/reviews/first_principles_review_2026_06_10.md);
-  drift guards: `tests/test_first_principles_quality_pass.py`): FP was
-  missed by the Tesla/four-show chapter hardening — no positional `where`
-  anchors, so the brand-heavy closing ("That's *First Principles Daily*…")
-  re-opened an `Introduction` chapter on the sign-off and Ep001-004 shipped
-  with no `Closing` chapter; added `where: start` (Introduction) /
-  `where: end` (Closing). The bigger fix: `podcast_expand_below_target` was
-  a DEAD path for narrative shows — the expansion retry was news-framed
-  ("cover more stories"), useless for a one-topic show, so every thin FP
-  episode (Ep002 953w, Ep004 935w) fired the retry and kept its length. The
-  retry is now narrative-aware (`_build_expansion_retry_prompt(...,
-  narrative=)` in `engine/generator.py`): narrative shows (FP + UC) expand
-  by DEEPENING the single topic from the brief. Deferred: the digest stage
-  is itself under-length (briefs 870-1498w vs the 1600 prompt floor; no
-  digest expansion retry) — the next lever. The ~10-12 min length ceiling
-  is accepted (operator confirmed grok-4.3 plateaus, resists escalation),
-  not re-litigated. Retry edit changes shipped audio when it fires —
-  A/B-listen per landmine #17.
-  **June 23 2026 second pass** (review:
-  [`docs/reviews/first_principles_review_2026_06_23.md`](docs/reviews/first_principles_review_2026_06_23.md);
-  drift guards: `tests/test_first_principles_quality_pass.py::TestClosingNotStolenByBodyMarkers`,
-  `TestLessonTemplateDeSeed`, `TestDigestExpansionRetry`): scored the June-10
-  predictions — the narrative retry was PARTIAL (scripts now exceed their
-  briefs but the thin brief still caps a few) and the chapter prediction
-  MISSED on its Closing half. P0: **7 of the first 18 episodes
-  (Ep001/004/007/009/011/015/017) shipped with NO Closing chapter** — the
-  June-10 `where` anchors fixed the duplicate-Introduction class but not
-  this one: the sign-off tagline "one example or one **opportunity**, every
-  day" (and the brand "**First Principles** Daily") let the body markers
-  *The Opportunity* / *The First Principle* steal the closing line whenever
-  they had not matched earlier in the body. Fixed by listing **Closing
-  before the body markers** (EI June-11 / SpaceX June-18 ordering rule);
-  `where: end` keeps it out of the body → 18/18 episodes get a Closing
-  chapter (metadata-only, no audio). P1: the June-10-deferred **lesson-
-  template echo** grew to 12 of ~16 episodes opening the lesson with the
-  verbatim seeded formula "a [part] whose price greatly exceeds its
-  [materials] is announcing a design problem" (Omni-View "strongest case"
-  class) — de-seeded both digest-prompt tracks, require fresh per-topic
-  phrasing (`--test`: formula gone). P1: shipped the June-10-deferred
-  **digest-stage expansion retry** (new opt-in `llm.digest_expand_below_target`
-  / `llm.min_digest_words`, default no-op; narrative-aware deepen-the-brief,
-  mirrors the podcast stage; FP opts in at 1400 — `--test`: a 1146w brief
-  lifted to 1400w). Prompt + digest-retry edits change shipped output —
-  A/B-listen per landmine #17; the chapter reorder does not.
 - **UC** (Unintended Consequences) runs via `run_show.py` +
   `shows/unintended_consequences.yaml`; a weekday **narrative** show
   (`narrative_mode: true`, topic-queue-driven — no news fetch). Patrick
   voice. X posting on via the @planetterrian account.
-  **June 12 2026 quality pass** (review:
-  [`docs/reviews/unintended_consequences_review_2026_06_12.md`](docs/reviews/unintended_consequences_review_2026_06_12.md);
-  drift guards: `tests/test_unintended_consequences_quality_pass.py`): UC
-  was missed by the Tesla/four-show/FP chapter hardening — no `where`
-  anchors, and seven keyword markers that assume the spoken prose contains
-  literal section words the podcast prompt forbids; the brand name
-  *Unintended Consequences* (contains "consequence") collided with the
-  body marker on both the intro and the sign-off, so 0/10 recent episodes
-  had a correct chapter shape (ep024 opened on "The Lesson"; ep028 ended
-  on "The Unintended Consequences"). Fixed by anchoring Introduction
-  (`where: start`) + Closing (`where: end`), dropping the unreliable middle
-  markers, and letting auto-segmentation fill the middle with in-order
-  content titles (the Introduction pattern includes a generic opening-word
-  fallback because the LLM rewrites the supplied intro on ~30% of episodes,
-  dropping the brand + "episode N") — verified 10/10, metadata-only.
-  The closing pool grew 2→4 and dropped "That wraps today's case" (the
-  prompt's WHAT TO AVOID block had banned that phrase while `intros.py`
-  supplied it verbatim on 5/10 episodes; the 2-entry pool repeated 3× in a
-  row, Ep026-028). Chronic under-length (857-1211w vs 1300 floor / 2200-
-  2800 target) is DEFERRED with the same root cause + lever as First
-  Principles: the digest is thin (700-960w), so the podcast — told to use
-  only the brief — is capped; the digest-expansion retry is the deferred
-  network lever, and the grok-4.3 narrative plateau is accepted. Closing-
-  pool + prompt edits change shipped audio — A/B-listen per landmine #17.
 - **SpaceX** (SpaceX Daily) runs via `run_show.py` + `shows/spacex.yaml`;
   engineering-first daily on SpaceX as a public company (Nasdaq: SPCX),
-  `memory_enabled`, X disabled. **June 13 2026 quality pass** (review:
-  [`docs/reviews/spacex_review_2026_06_13.md`](docs/reviews/spacex_review_2026_06_13.md);
-  drift guards: `tests/test_spacex_show.py`,
-  `tests/test_network_quality_pass.py`): two days post-launch, after the
-  operator's same-day fixes for the Ep2 AI-chapter `A I` spacing and the
-  AI-section accuracy guardrail (Colossus/Anthropic is real — do not
-  relitigate). The theme miner mined source-attribution LABELS — the
-  bare-URL strip in `engine/show_memory.py` missed the markdown
-  `[Google News](url)` label, so `"google spacex"` shipped as the #1
-  recurring theme (latent network-wide: FF `science nasa`, M&A `reddit
-  localllama`); now strips the whole `[label](url)` construct first, and
-  the polluted `spacex_theme_history.json` was rebuilt clean. The rocket
-  thrust unit `tf` (tonne-force) was spoken letter-by-letter ("280 T F",
-  twice in Ep2) — a per-show `pronunciation_overrides()` in
-  `shows/hooks/spacex.py` expands `tf → tons-force` (a unit expansion, not
-  a respelling — outside landmine #17; A/B-listen the audio change anyway).
-  Deferred with levers: the SPCX price is spoken twice/episode (Market
-  Watch segment + closing block) — the clean fix needs the Closing chapter
-  marker reordered ahead of Market Watch to avoid an orphan-closing
-  regression; and "AI & Compute" chapter lumping (swallows trailing Top
-  News when the LLM emits news after the editorial markers) — observe Ep3+
-  before a prompt change.
-  **June 18 2026 second pass** (review:
-  [`docs/reviews/spacex_review_2026_06_18.md`](docs/reviews/spacex_review_2026_06_18.md);
-  drift guard: `tests/test_spacex_show.py::TestClosingBeforeMarketWatch`):
-  both June-13 predictions HIT (themes clean, no `tf`/`T F`). Found + fixed a
-  P0 the snapshot's "clean chapters" check missed — **weekly-recap episodes
-  shipped with NO Closing chapter** (`chapters_ep003.json` ended at a
-  mis-titled "Market Watch"). The code-supplied closing block appends the
-  SPCX price into the sign-off, the Market Watch marker matches that price
-  phrase, and Market Watch was listed before Closing; dailies escaped via
-  the real Market Watch segment consuming the marker first (once-per-title),
-  but recaps have no such segment. Fixed by ordering the **Closing marker
-  ahead of Market Watch** (`where: end` keeps it pinned to the sign-off) —
-  metadata-only, no audio, zero regression on all 7 scripts. This also
-  clears the chapter blocker on the deferred price-twice fix. Deferred
-  (evidence strengthened): chronic under-length is the **Engineering Deep
-  Dive under-delivering its own spec** (140-181w vs the digest prompt's "3
-  paragraphs of 4-6 sentences" ~250-360w) — the expand-the-deep-dive lever
-  stays deferred pending the network four-show length A/B. The AI-lumping
-  and hook-jargon June-13 deferrals did NOT recur.
-  **June 19 2026 third pass** (review:
-  [`docs/reviews/spacex_review_2026_06_19.md`](docs/reviews/spacex_review_2026_06_19.md);
-  drift guards: `tests/test_pronunciation.py::TestReplaceTimes`,
-  `tests/test_spacex_show.py::TestLaunchTimePronunciation`): both June-18
-  predictions scored (deep-dive-still-short HIT — Ep8 139w; daily-Closing HIT,
-  recap pending). New P0 spoken garble: launch times **with seconds** shipped
-  mangled — the digest's `1:50:45 a.m.` was voiced "one fifty A M:45 a.m." and
-  `0850:45 UTC` as raw digits (Whisper-confirmed in Ep8 audio). The shared
-  `assets/pronunciation.py:replace_times` matcher was seconds-blind
-  (`(\d{1,2}):(\d{2})…` matched only `1:50`, stranding `:45`). Fix: drop
-  seconds (`(?::\d{2})?`), add a compact `0850:45 UTC` → "oh eight fifty U T C"
-  handler that runs before the HH:MM matcher, and tighten the trailing
-  whitespace so an absent AM/PM no longer glues the next word ("P MUTC"). A
-  latent network-wide bug surfacing on SpaceX because spaceflight reporting
-  gives T-0 to the second — the same spoken-garble class as the June-13
-  `tf`→`T F` fix. Deterministic number-normalization correctness change (not a
-  respelling) but changes spoken output — A/B-listen per landmine #17. The
-  deep-dive length lever + price-spoken-twice (8/8) stay deferred (reasons
-  hold); tomorrow-teaser "watch for the [next] <test>" frame now 6/8 (P2 monitor).
+  `memory_enabled`, X disabled.
 - **DP** (The DP Pod: The Do Positive Podcast) runs via `run_show.py` +
   `shows/dp_pod.yaml`; the network's **two-host dialogue** show (July 2026
   launch) — Dan Perra + Patrick Novak, daily ~10 min of good news in science/
@@ -931,112 +215,6 @@ TST received a full recursive improvement architecture (analogous to MIT):
   `dialogue_mode is False`), `tests/test_dp_pod_show.py` (launch shape).
   Prompt edits change shipped audio — A/B-listen per landmine #17; the first
   episodes are the calibration set for `dialogue_pause_ms` handoff pacing.
-  **July 2 2026 Ep1 rework (operator listened: "terrible and robotic"):**
-  theme song `assets/music/dp_pod.mp3` ("Do Positive", 4.5 min Suno track)
-  is the intro/outro bed; NEW `audio.debut_song_file`/`debut_song_episode`
-  (AudioConfig, generic no-op default) appends the FULL song after the
-  closing on Episode 1 only via `engine.audio.append_full_song` (after
-  chapter timestamps — the song must not stretch the proportional chapter
-  math); the debut is a DESIGNED episode via per-show overrides in
-  `engine/first_episode.py` (`_SHOW_DIGEST_EP1`/`_SHOW_PODCAST_EP1`:
-  founding statement → anchor discussion from the network's own First
-  Principles material → network tour → starter lever → on-air song intro);
-  `shows/hooks/dp_pod.py` supplies `{nerra_network_context}` (sibling-show
-  catalog + latest FP brief; setdefault-ed in pipeline/run_show so a hook
-  failure can't KeyError); the podcast prompt gained a DELIVERY — WRITE THE
-  ENERGY IN block (spoken-English volleys, ≥⅓ one-sentence turns, no
-  news-anchor phrasing — the anti-robotic levers) + a one-mention-max
-  cross-promo rule; `dialogue_pause_ms` 300→220. The shipped Ep001 was
-  retired (artifacts deleted, RSS items stripped, numbering back to 1) —
-  regenerate via workflow_dispatch; the schedule-event duplicate guard
-  doesn't apply to manual dispatch.
-  **July 2 2026 second rework (operator listened again: still robotic,
-  Dan especially; intro too short; too much show-info recap):** the LIVE
-  Ep1 intro/closing path is `engine/pipeline.py:run_generation_phase`
-  (run_show builds pod_vars but never passes them — BOTH Ep001 renders
-  aired pipeline's truncated `"please subscribe... "` literal); pipeline's
-  Ep1 block is now dialogue-aware + the generic literal completed. Grok
-  TTS docs pass (docs.x.ai): punctuation IS prosody (exclamation points
-  now encouraged where genuine), sanctioned inline tags with a hard
-  budget (≤10 of `[laugh]/[sigh]/[breath]/[pause]`, ≤4 `<emphasis>`; all
-  other wraps stay banned), documented `speed` param wired through
-  `grok_speak_chunk`→`synthesize_dialogue` (sent only when ≠1.0; dp_pod
-  pins 1.05), `dialogue_pause_ms` 220→180. Editorial repositioning
-  (All-In-inspired friends-reviewing-consequential-events): system prompt
-  celebrates builders/creators/contributors; "THE ANALYSIS IS THE SHOW"
-  (~⅓ facts / ⅔ hosts' unique-lens takes); digest widened from pure
-  good-news to consequential-with-agency + names the builders. Debut
-  override v2: 500+ word founding conversation introducing show AND
-  network, anchor material as SPRINGBOARD (≤3 recap sentences), network
-  tour capped at 3 shows/1 sentence each with editorial-boilerplate
-  phrases BANNED (the v1 render walled 5 near-verbatim "measured result…"
-  paragraphs). Second Ep001 retired the same way. Dan's voice ceiling is
-  the CLONE — docs: custom-voice quality tracks the reference clips;
-  re-record Dan's samples with expressive conversational takes (operator).
-  **July 4 2026 v4 review + community layer:** the v4 Ep001 render (much
-  improved — real disagreement, Frankl Think Positive debut, proper
-  personality closing, song appended) surfaced three fixable defects, all
-  fixed + retired the render (drift guards:
-  `tests/test_dp_pod_show.py::TestEp001V4Fixes`): the DIGEST expansion
-  retry pads by paraphrase-duplication exactly like the podcast retry did
-  (the founding brief re-told every beat; `_dedup_expansion_sentences` now
-  runs on the digest-retry output too — `engine/generator.py`, global but
-  a correctness strip); the pipeline's `effective_hook` fallback spoke a
-  raw markdown header on air when the digest lacked a HOOK line (fallback
-  now skips `#`/rule lines + strips bold; the dp_pod debut-digest override
-  also REQUIRES the HOOK line); and the cold open's passing "The Lever"
-  mention stole the Lever chapter at 74s (marker is now announce-anchored
-  — "brings us to/time for/now for The Lever" — with a SEGMENT-NAME
-  DISCIPLINE prompt block requiring short forms before announcements).
-  Website community layer ("a place to learn and encourage each other"):
-  the club page gained a **Mindset Shelf** (`_collect_dp_mindsets` in
-  `generate_html.py` extracts each digest's `### Think Positive` principle)
-  and a **Dispatch Wall** (`_collect_dp_dispatches` reads the
-  OPERATOR-CURATED `digests/dp_pod/dispatches.json` — real listener
-  dispatches only, per the club charter; empty file = honest empty state;
-  operator CLI: `scripts/add_dp_dispatch.py`).
-  Drift guards: `tests/test_dp_pod_show.py::TestCommunityLayer`.
-  **July 4 2026 level-drift fix + anthem canon (operator listened to v5:
-  "inconsistent and drifting between good sound level then quiet"):** root
-  cause is structural to dialogue mode — 30-40 independent Grok TTS calls
-  per episode, each at its own loudness, and `normalize_voice`'s
-  `loudnorm … linear=true` applies ONE gain to the whole file so inter-turn
-  variance survives to air (single-voice shows synthesize in one call and
-  never hit this). Fix: `_match_turn_levels` in `engine/tts_dialogue.py`
-  gain-matches every turn WAV to the MEDIAN mean level (volumedetect —
-  stable on 2-4s clips where loudnorm's integrated measure is not; ±12 dB
-  cap, <1 dB left alone, runs BEFORE pause padding so silence can't skew
-  the measure; verified 28 dB synthetic spread → 0). Second leak in the
-  same report: `append_full_song` concatenated the debut song at its native
-  master level — the song branch now runs `loudnorm I=-16`
-  (`_append_song_cmd`, episode branch untouched). Both change shipped audio
-  — A/B-listen per landmine #17. **Anthem:** the operator-supplied "Do
-  Positive" lyrics are canon at `assets/music/dp_pod_lyrics.md`; the
-  podcast prompt's THE SHOW ANTHEM block allows at most ONE verbatim lyric
-  phrase per episode (default ZERO — anti seeded-template), the Ep1 debut
-  override lets the song intro quote one chorus line exactly, and the club
-  page gained an Anthem section (chorus + collapsible full lyrics). Drift
-  guards: `tests/test_tts_dialogue.py::{TestTurnLevelMatching,
-  TestDebutSongLoudness}`, `tests/test_dp_pod_show.py::TestShowAnthem`
-  (including a prompt-quote-matches-canon check).
-  **July 4 2026 follow-up-episodes pass (operator approved Ep1 v6 — level
-  drift measured fixed at 0.52 dB stdev across 41 windows — and asked for
-  great regular episodes that regularly point to network shows/episodes):**
-  `shows/hooks/dp_pod.py` now builds a **FRESH ON THE NETWORK** block (each
-  sibling's actual latest episode within 3 days, read from the committed
-  `summaries_*.json` — entries are newest-FIRST, picked by max date) and a
-  **Think Positive rotation memory** (thinkers mined from recent dp_pod
-  digests → do-not-reuse list; roster in `_THINKERS`). The occasional
-  CROSS-PROMO became the regular **FROM THE NETWORK** beat: exactly ONE
-  grounded pointer per episode naming a REAL fresh episode, spoken as a
-  friend's recommendation, position/speaker rotating (never a fixed slot —
-  anti-tic); the digest gained a required-when-fresh **Network pick:** line
-  and the thinker-rotation rule. Depth lever: `min_digest_words` 700→1100
-  (Ep1 scripts capped ~1,200w vs the 1,550 target — the brief was the
-  ceiling). The shipped debut anchor `shows/dp_pod_debut_anchor.md` was
-  deleted (pin mechanism kept). Prompt/digest edits change output —
-  A/B-listen per landmine #17. Drift guards:
-  `tests/test_dp_pod_show.py::TestFollowUpEpisodes`.
 - **AOAI** (The Age of AI) — the network's **AI-hosted LIVE interview show**
   (July 2026): Mira, an AI documentarian persona (Grok voice `ara`,
   deliberately NOT the Patrick clone), phones REAL guests via a Voximplant
@@ -1354,6 +532,80 @@ any failure logs a warning and ships the exact legacy render.
   `broll_clips_used`, `thumbnail_base`, `thumbnail_variant_urls`. Drift
   guards: `tests/test_visual_reuse.py`.
 
+### Cost-efficiency pass (July 29 2026)
+
+Six changes that cut spend without touching what a listener gets. The
+rule for the whole pass was **measure first** — every item below was
+justified from committed data, not from reasoning about where waste
+"should" be. Drift guards: `tests/test_cost_efficiency_pass.py`.
+
+Context: the dashboard's tracked figure (~$29/30d) was roughly a third of
+real spend. Adding the pieces it did not count — multilingual (~$38/mo)
+and Grok Imagine (~$50-60/mo, only counted since July 28) — the true
+total is ~$110-125/mo. The two largest lines were the two least measured,
+which is why measurement leads this list.
+
+- **Per-language OP3 measurement.** Multilingual is ~1/3 of spend and its
+  audience was measured NOWHERE: the per-language enclosures carry the
+  OP3 prefix, but `fetch_op3_stats.py` only ever resolved each show's
+  English feed, so `api/op3_stats.json` had zero language-track entries
+  and a language with no listeners looked exactly like a popular one.
+  The fetcher now also resolves the 14 feeds the network actually pays to
+  produce (scoped to each show's `multilingual.languages`, not the 44
+  feed files on disk) into a separate `language_feeds` section — separate
+  because every consumer iterates `shows` keyed by slug. The dashboard
+  gains `multilingual.by_language` (downloads vs approximate cost) and
+  per-show `audience_by_language`. **This is a decision instrument, not a
+  saving:** after 2-4 weeks, a language reading zero across several weeks
+  is a candidate to switch off in the show YAML. Today's split is FR
+  ~$20/mo (7 shows), RU ~$13/mo (4), ZH ~$8/mo (3); RU feeds @NerraRU and
+  earns its keep regardless, ZH has no channel and no directory listing.
+- **16:9 scene generation follows the render.** Shorts-only policy days
+  still generated 4 fresh 16:9 Grok Imagine scenes, but those feed only
+  the long-form slideshow, its thumbnail, and the gallery — Shorts use
+  their own 9:16 set. On a shorts-only day for a show with no
+  video-podcast feed, three of four paid images were never seen. Now 1
+  (thumbnail base + gallery contribution); the 9:16 set is untouched, and
+  `video_podcast.enabled` shows still get all four because they render
+  long-form regardless of tier. ~$0.06/episode on tier-C shows.
+- **xAI search-tool spend is counted.** Server-side `x_search` /
+  `web_search` bill per SOURCE consulted; the Responses path returned
+  only text, so every search-fetching show under-reported its spend
+  (flagged as uncounted by the July 24 pass, still missing after the July
+  28 cost fix). `digests/xai_grok.py` accumulates usage per process — the
+  fetch layer has no tracker reference — and run_show drains it into the
+  episode's credit file via `engine.tracking.record_search_usage`. Rate
+  is `SEARCH_COST_PER_SOURCE` ($0.025), env-overridable with
+  `XAI_SEARCH_COST_PER_SOURCE`. Also wired `record_render_seconds`, which
+  the July 28 pass shipped with no caller.
+- **Single-pass long-form render is now the default** (was opt-in behind
+  a repo variable). A/B on both production shapes at 1920x1080: uniform
+  stills 24.6s -> 16.2s (-34%), chapter-schedule + burned-in captions
+  22.3s -> 17.2s (-23%), with outputs equivalent — identical duration,
+  frame count, geometry and codecs, mean pixel difference < 0.3/255 at
+  every sampled timestamp, identical scene timeline, matching brand pill
+  / URL pill / caption rendering. `NERRA_SINGLE_PASS_RENDER=0` forces the
+  legacy path, which also remains the automatic fallback on any fused-
+  command failure. The escape hatch now covers the RU/FR dub renders too.
+  Render-only, no audio — outside landmine #17.
+- **The podcast-side expansion retry is off** wherever a digest-side
+  lever exists (11 shows). See the superseded note in the June 2026
+  network-pass section above for the measurement. **A/B-listen the first
+  post-merge episode on a show that used to fire it** — when the retry
+  fired, its output was what shipped.
+- **`CLAUDE.md` trimmed ~185 KB -> ~124 KB** by moving the dated per-show
+  quality-pass narratives verbatim to
+  [`docs/show_review_history.md`](docs/show_review_history.md), keeping
+  each show's structural facts plus a new "Live constraints" block for
+  the rules that still bind (Colossus/Anthropic is real, length is
+  digest-side only, de-seed by shape, the grok-4.3 plateau, MIT not
+  live-trading ready). This file is loaded in full at the start of every
+  Claude Code session and replayed across the agentic loop, so its size
+  is a per-session cost on all future work — the June 2026 token review
+  found exactly this pattern was the network's largest Anthropic line
+  item before the review agent moved to Grok.
+
+
 ### Adaptive YouTube publishing policy (July 2026)
 
 Publish volume/format now adapts to what each channel actually watches
@@ -1582,6 +834,18 @@ same review ran across the other ten shows. Drift guards:
   Consequences, First Principles — all were ≥50% below target, several
   100%). Models & Agents also got an explicit `min_podcast_words: 1500`
   (was relying on the implicit default).
+  **SUPERSEDED 2026-07-29 — this flag is now `false` on the 11 shows that
+  have a digest-side lever.** Measured over 901 committed episodes, 81%
+  still shipped BELOW target *with* the retry running (Tesla 96.7%, M&A
+  95.2%): it fires on nearly every episode and almost never reaches the
+  goal, because the ceiling is the DIGEST. It also pads by
+  paraphrase-duplication (the July 28 pass had to add
+  `_dedup_expansion_sentences` to strip its near-duplicates), so what it
+  did ship was the weaker copy — and the July 18 playbook had already
+  banned podcast-side length levers network-wide. Only `env_intel` and
+  `finansy_prosto` keep it, because they have no digest lever yet;
+  give them one before switching theirs off. Drift guard:
+  `tests/test_cost_efficiency_pass.py::TestLengthLeverPolicy`.
 - **Hook-led X teasers network-wide**: Omni View / FF / Planetterrian's
   hardcoded teasers and the generic fallback (used by Unintended
   Consequences) now lead with the episode hook + link the episode blog

--- a/digests/xai_grok.py
+++ b/digests/xai_grok.py
@@ -57,6 +57,75 @@ def _get_xai_api_key() -> str:
     return (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
 
 
+# ---------------------------------------------------------------------------
+# Search-tool usage accounting
+# ---------------------------------------------------------------------------
+# xAI bills server-side search tools per SOURCE consulted, on top of the
+# usual token cost. Several shows run these every day (the per-account X
+# fetch alone is one call per configured handle), and none of it reached
+# the episode's credit summary — the Responses path returned only the
+# text, so ``credit_usage_*.json`` undercounted every search-fetching show.
+#
+# The fetch layer has no tracker reference (``engine/fetcher`` is called
+# long before the episode tracker is threaded through), so usage lands in
+# a process-wide accumulator that run_show drains once per episode — the
+# same shape ``engine/grok_imagine`` uses for image spend.
+_SEARCH_USAGE: Dict[str, Any] = {
+    "calls": 0, "sources": 0, "input_tokens": 0, "output_tokens": 0,
+}
+
+
+def _int_attr(obj: Any, *names: str) -> int:
+    """First present int-ish attribute/key among *names*, else 0.
+
+    xAI's Responses usage object is not pinned by a public schema and has
+    carried both ``num_sources_used`` and ``sources_used`` in the wild, so
+    read defensively rather than guessing one name.
+    """
+    for name in names:
+        value = None
+        if isinstance(obj, dict):
+            value = obj.get(name)
+        else:
+            value = getattr(obj, name, None)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def _record_search_usage(resp: Any, tool_count: int) -> None:
+    """Accumulate one Responses-API call's billable usage."""
+    usage = getattr(resp, "usage", None)
+    _SEARCH_USAGE["calls"] += 1
+    _SEARCH_USAGE["input_tokens"] += _int_attr(
+        usage, "input_tokens", "prompt_tokens")
+    _SEARCH_USAGE["output_tokens"] += _int_attr(
+        usage, "output_tokens", "completion_tokens")
+    sources = _int_attr(usage, "num_sources_used", "sources_used")
+    if not sources:
+        # Some responses report the count under server_side_tool_use
+        # instead of at the usage root.
+        nested = getattr(usage, "server_side_tool_use", None)
+        sources = _int_attr(nested, "num_sources_used", "sources_used")
+    _SEARCH_USAGE["sources"] += sources
+    if sources:
+        logger.info("Responses API: %d source(s) billed across %d tool(s)",
+                    sources, tool_count)
+
+
+def drain_search_usage() -> Dict[str, int]:
+    """Return the accumulated search usage and reset the accumulator.
+
+    Draining (rather than peeking) keeps a long-lived process — the daily
+    audit retry path runs several shows back to back — from charging one
+    show for another's searches.
+    """
+    snapshot = {k: int(v) for k, v in _SEARCH_USAGE.items()}
+    for key in _SEARCH_USAGE:
+        _SEARCH_USAGE[key] = 0
+    return snapshot
+
+
 def grok_generate_text(
     *,
     prompt: str,
@@ -123,6 +192,10 @@ def grok_generate_text(
                     "prompt_cache_key": str(cache_key),
                 }
             resp = _responses_create(client, **create_kwargs)
+            try:
+                _record_search_usage(resp, len(tools))
+            except Exception:  # pragma: no cover — accounting is never fatal
+                logger.debug("search usage accounting failed", exc_info=True)
             text = getattr(resp, "output_text", "") or ""
             text = text.strip()
             logging.info(

--- a/docs/show_review_history.md
+++ b/docs/show_review_history.md
@@ -1,0 +1,927 @@
+# Show review history (archive)
+
+Every dated quality-pass narrative that used to live inline in
+`CLAUDE.md`'s *Script Relationships* section, moved here verbatim on
+2026-07-29. Nothing was rewritten or dropped — only relocated.
+
+**Why:** `CLAUDE.md` is loaded in full at the start of every Claude
+Code session and replayed across the whole agentic loop, so its size
+is a per-session cost on every future piece of work. It had grown to
+~185 KB, the majority of it this history: valuable as a record, but
+not something an agent needs resident to make today's change. The
+structural facts each show needs (how it runs, its voice, its
+cadence, its live constraints) stayed in `CLAUDE.md`; the story of
+how each show got there lives here.
+
+The canonical per-pass write-ups remain in
+[`docs/reviews/`](reviews/), with scored predictions in
+[`docs/reviews/ledger/`](reviews/ledger/). This file is the
+chronological digest that used to be inline.
+
+> Landmine #17 still governs everything here: any change touching a
+> prompt, a closing pool, or shipped audio needs an operator
+> A/B-listen. Reading a past pass is not approval to redo it — check
+> the ledger's `do_not_retry` list first.
+
+## Environmental Intelligence
+
+- **June 10 2026 quality pass** (review:
+[`docs/reviews/env_intel_review_2026_06_10.md`](docs/reviews/env_intel_review_2026_06_10.md);
+drift guards: `tests/test_env_intel_quality_pass.py`): EI was missed by
+the Tesla/PT/four-show chapter fixes — it had no positional `where`
+anchors, so the "Closing" chapter could land mid-script (Ep040, position
+7 of 10) and the "That covers today's environmental intelligence"
+closing-pool variant matched no Closing pattern (MAB orphan-closing bug).
+Added `where: start` (Introduction) / `where: end` (Tomorrow Teaser,
+Closing), widened the Closing pattern to both variants, and excluded the
+closing's "your practice" from the `industry|practice` marker via
+lookbehind. Cadence fix: EI runs odd weekdays but the spoken intro/closing
+claimed "daily" and "back tomorrow" (7/10 transcripts) — now cadence-
+neutral ("We'll be back with the next briefing"). The podcast prompt's
+contradictory length target (demanded 1500–2200w while the YAML pins 900
+and episodes ship ~750) unified to 900–1300w. Intro/closing + length
+prompt edits change shipped audio — A/B-listen per landmine #17.
+**June 11 2026 follow-up pass** (review:
+[`docs/reviews/env_intel_review_2026_06_11.md`](docs/reviews/env_intel_review_2026_06_11.md)):
+scoring the June 10 predictions against Ep044 (first post-fix episode)
+caught the orphan-Closing prediction MISSING — Ep044 shipped with no
+Closing chapter because the LLM merged the Tomorrow Teaser sentence and
+the `{closing_block}` into one paragraph and the parser's first-marker-
+per-line rule titled it "Tomorrow Teaser". Fixed by reordering the two
+`where: end` markers so **Closing precedes Tomorrow Teaser** (Closing wins
+a merged final line; separate lines still yield both) — config-only, no
+audio change. Also took the deferred thin-news issue at a new lever (not
+the `min_articles_skip` floor): Ep044's HOOK was literally "No major
+Canadian regulatory announcements … appeared in today's feed", which
+became the blog title/h1, the chapter title, and the spoken opener; the
+digest prompt now forbids an absence-of-news hook and steers thin days to
+lead with a forward-looking item (A/B render: "CCME soil vapour … comment
+period closes in 19 days …" replaced the absence hook). Digest-prompt edit
+changes output — A/B-listen per landmine #17.
+**June 15 2026 third pass** (review:
+[`docs/reviews/env_intel_review_2026_06_15.md`](docs/reviews/env_intel_review_2026_06_15.md);
+drift guards: `tests/test_env_intel_quality_pass.py::TestDeepDiveOpenerNotTic`):
+scored the prior predictions against Ep045 (first true post-merge,
+normal-news episode — Closing chapter present, real hook, cadence-neutral
+closing, 958w; orphan-Closing + absence-hook predictions both HIT). Next
+tier: the Practitioner Deep Dive opened with the verbatim "You arrive at
+a…" scenario in 9/10 episodes — root cause was the DIGEST prompt seeding
+that exact example (`env_intel_digest.txt:173`), which the podcast
+faithfully echoed (an Omni-View "strongest case" tic class). Dropped the
+seeded example, required a rotated deep-dive entry point in both prompts,
+and banned the verbatim "here's something I wish someone had told me…"
+lead-in (5/10). A/B render: "A Phase I ESA flags a B.C. site within 5 km
+of a glacial lake…" replaced "You arrive at a…". The structural format
+(scenario → science → most-common-mistake + fix) is the show's intentional
+B2B signature and is unchanged. Prompt edits change output — A/B-listen
+per landmine #17.
+**June 17 2026 fourth pass** (review:
+[`docs/reviews/env_intel_review_2026_06_17.md`](docs/reviews/env_intel_review_2026_06_17.md);
+drift guards: `tests/test_env_intel_quality_pass.py::TestChapterPositionalAnchors`):
+both June-15 deep-dive tic fixes HIT on Ep046 (first true post-merge
+episode — odd-weekday show; the "You arrive at a…" and "wish someone had
+told me…" openers are both gone). New finding — a latent orphan-
+Introduction bug the June-10 `where`-anchor pass left half-fixed: the
+Introduction marker only matched the "This is Environmental Intelligence"
+greeting, but `engine/intros.py` rotates a "Welcome to Environmental
+Intelligence" greeting too, so every "Welcome to" episode
+(Ep037/038/042/046 of the last ten) shipped with NO Introduction chapter
+(the welcome + Compliance Brief got absorbed into the first content
+chapter). Broadened the pattern to `(?:This is|Welcome to) Environmental
+Intelligence` (metadata-only, no audio/prompt change — same orphan-
+chapter class the June 10/11 passes fixed for the Closing variant).
+Chronic under-length stays deferred (median 814w vs 900 floor; digest
+ceiling, behind the four-show length A/B), as does the mid-section
+chapter-marker keyword reliance (Ep046 had no Week Ahead chapter).
+
+## Fascinating Frontiers
+
+- **FF June 12 2026 quality pass** (review:
+[`docs/reviews/fascinating_frontiers_review_2026_06_12.md`](docs/reviews/fascinating_frontiers_review_2026_06_12.md);
+drift guards: `tests/test_fascinating_frontiers_quality_pass.py`): the
+June-10 four-show length fix MISSED — Ep097/098/099 (post-pass) shipped
+1634/1390/1637w, all under the 1700 floor. Verified root cause is the
+**digest ceiling**, not the target: FF's RSS feeds return snippets
+(not full text) → digests run 1027-1597w → the podcast can't exceed
+them without the padding/invention both prompts ban (Ep099 script 1664w
+> its digest 1572w). The expand-retry fires every episode and plateaus;
+on the thinnest day it padded 6 stories with title-case headline
+restatements. Deferred the only non-padding lever (expand the Cosmic
+Deep Dive, which is licensed to use the model's own astrophysics
+knowledge) until the operator's four-show length A/B settles. Shipped
+two deterministic, no-A/B fixes: (1) `fix_phonetic_garbles` extended for
+the space names the model spelled phonetically despite the ban —
+"En-sell-uh-dus"→Enceladus (Ep048/088/094), "Tee-en-wen"→Tianwen
+(Ep090); (2) a theme-mining self-reference filter — the show's own name
+("fascinating frontiers") had been mined as a top "recurring theme"
+every episode (Ep97/98/99 led their top_themes with it); only the full
+show-name bigram is filtered, never component tokens.
+
+- **FF June 16 2026 quality pass** (review:
+[`docs/reviews/fascinating_frontiers_review_2026_06_16.md`](docs/reviews/fascinating_frontiers_review_2026_06_16.md);
+drift guards: `tests/test_fascinating_frontiers_quality_pass.py::TestStockMarketTitleFilter`):
+both June-12 predictions HIT (garbles gone, show-name no longer a top
+theme). New finding: since the SpaceX/SPCX IPO (June 12) the Google-News
+"SpaceX" queries flood FF — a *science* show — with pure stock-market
+items; Ep103 shipped FOUR of fifteen stories as market action (an $85.7B
+funding round told twice, a "$60B merger with Cursor", NASDAQ index
+inclusion, a 20% share move), off-brand and overlapping SpaceX Daily /
+Modern Investing. Fixed at fetch time via stock/market
+`exclude_title_patterns` (same accepted class as the almanac filter —
+deterministic, no A/B) + a digest-prompt `NO STOCK / MARKET ITEMS` scope
+bullet (A/B-listen). Live-verified on today's feeds: 7 SPCX items dropped,
+Falcon 9 *launch* kept (a bare `nasdaq/nyse` pattern was tried and removed
+after it dropped that launch story). The chronic under-length / Cosmic Deep
+Dive lever stays deferred pending the four-show length A/B. The `@`→"at at"
+YouTube-CTA wart in Ep103 was already fixed upstream by the June-16 FP pass.
+Prompt edit changes output — A/B-listen per landmine #17.
+**June 24 2026 third pass** (review:
+[`docs/reviews/fascinating_frontiers_review_2026_06_24.md`](docs/reviews/fascinating_frontiers_review_2026_06_24.md);
+drift guards: `tests/test_fascinating_frontiers_quality_pass.py::TestChapterClosingOrdering`):
+scored June-16 — launch-false-drop prediction HIT; the stock-filter
+prediction PARTIAL (dailies clean, but the Sunday recap Ep108 re-surfaced
+pre-filter Ep103 SPCX content via the content lake — `engine/weekly_recap.py`
+bypasses the fetch filter; self-healing next cycle, deferred). Headline: the
+orphan-Closing chapter class the snapshot's loose `chapter_issues` check
+missed — Ep110/Ep111 shipped with NO Closing chapter (ended on Tomorrow
+Teaser) and Ep109 shipped a spurious out-of-order Cosmic Deep Dive chapter.
+Root cause: the sign-off "…see you next time" matches the teaser's `Next
+time` and Teaser was listed before Closing; the real "Keep an eye on…"/
+"Watch for…" teaser openers (6/8) matched no pattern; and bare `deep dive`
+only ever matched the cross-promo "daily deep dive into everything Tesla".
+Fixed (metadata-only, no audio): Closing before Tomorrow Teaser, teaser
+broadened to line-anchored `^Keep an eye on`/`^Watch for`, bare `deep
+dive`/`under the hood` dropped (EI June-11 / SpaceX June-18 / FP June-23
+ordering-rule class) — verified by re-parsing real Ep108-111 (all now end
+Tomorrow Teaser -> Closing). Chronic under-length + the digest-driven
+mid-section chapter titles stay deferred.
+
+## First Principles Daily
+
+- **June 10 2026 quality pass** (review:
+[`docs/reviews/first_principles_review_2026_06_10.md`](docs/reviews/first_principles_review_2026_06_10.md);
+drift guards: `tests/test_first_principles_quality_pass.py`): FP was
+missed by the Tesla/four-show chapter hardening — no positional `where`
+anchors, so the brand-heavy closing ("That's *First Principles Daily*…")
+re-opened an `Introduction` chapter on the sign-off and Ep001-004 shipped
+with no `Closing` chapter; added `where: start` (Introduction) /
+`where: end` (Closing). The bigger fix: `podcast_expand_below_target` was
+a DEAD path for narrative shows — the expansion retry was news-framed
+("cover more stories"), useless for a one-topic show, so every thin FP
+episode (Ep002 953w, Ep004 935w) fired the retry and kept its length. The
+retry is now narrative-aware (`_build_expansion_retry_prompt(...,
+narrative=)` in `engine/generator.py`): narrative shows (FP + UC) expand
+by DEEPENING the single topic from the brief. Deferred: the digest stage
+is itself under-length (briefs 870-1498w vs the 1600 prompt floor; no
+digest expansion retry) — the next lever. The ~10-12 min length ceiling
+is accepted (operator confirmed grok-4.3 plateaus, resists escalation),
+not re-litigated. Retry edit changes shipped audio when it fires —
+A/B-listen per landmine #17.
+**June 23 2026 second pass** (review:
+[`docs/reviews/first_principles_review_2026_06_23.md`](docs/reviews/first_principles_review_2026_06_23.md);
+drift guards: `tests/test_first_principles_quality_pass.py::TestClosingNotStolenByBodyMarkers`,
+`TestLessonTemplateDeSeed`, `TestDigestExpansionRetry`): scored the June-10
+predictions — the narrative retry was PARTIAL (scripts now exceed their
+briefs but the thin brief still caps a few) and the chapter prediction
+MISSED on its Closing half. P0: **7 of the first 18 episodes
+(Ep001/004/007/009/011/015/017) shipped with NO Closing chapter** — the
+June-10 `where` anchors fixed the duplicate-Introduction class but not
+this one: the sign-off tagline "one example or one **opportunity**, every
+day" (and the brand "**First Principles** Daily") let the body markers
+*The Opportunity* / *The First Principle* steal the closing line whenever
+they had not matched earlier in the body. Fixed by listing **Closing
+before the body markers** (EI June-11 / SpaceX June-18 ordering rule);
+`where: end` keeps it out of the body → 18/18 episodes get a Closing
+chapter (metadata-only, no audio). P1: the June-10-deferred **lesson-
+template echo** grew to 12 of ~16 episodes opening the lesson with the
+verbatim seeded formula "a [part] whose price greatly exceeds its
+[materials] is announcing a design problem" (Omni-View "strongest case"
+class) — de-seeded both digest-prompt tracks, require fresh per-topic
+phrasing (`--test`: formula gone). P1: shipped the June-10-deferred
+**digest-stage expansion retry** (new opt-in `llm.digest_expand_below_target`
+/ `llm.min_digest_words`, default no-op; narrative-aware deepen-the-brief,
+mirrors the podcast stage; FP opts in at 1400 — `--test`: a 1146w brief
+lifted to 1400w). Prompt + digest-retry edits change shipped output —
+A/B-listen per landmine #17; the chapter reorder does not.
+
+## Four-show pass (MIT, M&A, MAB, FF)
+
+- **June 10 2026 four-show pass** (MIT, M&A, MAB, FF; full review:
+[`docs/four_show_review_2026_06_10.md`](docs/four_show_review_2026_06_10.md);
+drift guards: `tests/test_four_show_quality_pass.py`): every show's
+Closing chapter pattern now matches every closing-pool variant (MAB had
+shipped 50% of episodes with NO Closing chapter; M&A's bare `agent`
+pattern opened a spurious chapter ~30s into every episode) with
+`where: start|end` positional anchors; ONE unified length target per
+prompt (MIT 2,000-2,200w/floor 1800; M&A 1,600-2,200w; FF
+1,900-2,200w/floor 1700; MAB floor 1200) replacing contradictory
+anchors; `engine/show_memory.py` gained all four Tesla memory fixes
+(narrative-prose echo filter, per-episode idempotency, URL stripping,
+word-boundary program detection) + `update_performance_from_op3`; the
+nightly performance step generalized to
+`scripts/update_performance_trackers.py` (Tesla + M&A + FF + PT); the
+three memory shows' theme histories were re-scrubbed; MAB's "So
+imagine" opener tic (49 of 60 episodes — the prompt's own example was
+the template) now requires rotating opener shapes. Length/opener
+prompt edits change output — A/B-listen per landmine #17.
+
+## Models & Agents
+
+- **June 14 2026 quality pass** (review:
+[`docs/reviews/models_agents_review_2026_06_14.md`](docs/reviews/models_agents_review_2026_06_14.md);
+drift guards: `tests/test_models_agents_quality_pass.py`): two
+listener-facing metadata bugs, both no-A/B. (1) The script-gen step
+spelled core AI proper nouns phonetically despite the prompt ban and
+they reached TTS *and* chapter titles (`parse_chapters` runs after the
+repair): `An-thropic` shipped in nearly every episode (6× in Ep080, present
+since Ep004), plus `Lah-mah` (Llama) and `Hah-sah-biss` (Hassabis) —
+added to the blessed `engine.utils.fix_phonetic_garbles` restore layer
+(global; removes a respelling, so outside landmine #17). (2) The Under
+the Hood chapter marker only matched literal "under the hood" but the
+deep-dive opens with "let's pop the hood on …" in 9-10/10 episodes, so
+only 1/5 recent episodes got the chapter — the miss dropped several below
+`min_chapters` (4) and fired the auto-segment fallback that titled
+chapters from raw mid-sentence text (Ep080); added `|pop the hood` to the
+marker (`shows/models_agents.yaml`). Deferred: digest-driven chapter
+titles (Ep078-class residual, Tesla-deferred) and Under-the-Hood length
+expansion (after the four-show length A/B). The "pop the hood" opener tic
+was left unchanged (signature phrase; shipped-audio risk).
+**June 21 2026 third pass** (review:
+[`docs/reviews/models_agents_review_2026_06_21.md`](docs/reviews/models_agents_review_2026_06_21.md);
+drift guards: `tests/test_models_agents_quality_pass.py::TestPhoneticGarbleRepair`):
+all four June-14 predictions scored HIT. One recurring reader-facing text
+bug: the SHARED pronunciation map respells `CUDA → "koo-dah"`
+(`assets/pronunciation.py:168`, an ElevenLabs-era word-acronym guide), and
+that respelling is written into the `_tts.txt` → the published blog/RSS
+transcript (`engine/blog.py:767`), shipping verbatim in 12 episodes since
+Ep040 (e.g. Ep088 "open-sourced a koo-dah kernel"). Same class as the
+original "nassa" leak that created `fix_phonetic_garbles`; restored the same
+way — `koo-dah → CUDA` added to `engine.utils._PHONETIC_GARBLES` (global;
+the canonical acronym reaches both transcript and TTS, exactly as
+`nassa → NASA` already ships). Collision-safe ("koo-dah" has no English
+use); the collision-unsafe map guides (`LoRA → "Laura"`, `RAG → "rag"`) are
+left alone. Sharpened the deferred chapter diagnosis: chapter quality is
+inversely correlated with prompt compliance — Ep084/086 ship a full
+9-chapter shape only because the host announces the banned section labels
+aloud ("Now turning to model updates"), while prompt-compliant episodes
+(Ep085/087/088) collapse to auto-segment fragments or sparse shapes;
+confirms digest-driven titles as the durable lever (deferred). New deferred
+network-wide item: pronunciation-map word-guides leaking into published
+transcripts (durable fix = source the transcript from pre-pronunciation or
+Whisper text). Restore-layer edit touches TTS — spot-check per landmine #17
+(low risk; matches the NASA/Anthropic precedent that ships today).
+
+## Models & Agents for Beginners
+
+- **June 25 2026 quality pass** (first dedicated MAB review:
+[`docs/reviews/models_agents_beginners_review_2026_06_25.md`](docs/reviews/models_agents_beginners_review_2026_06_25.md);
+drift guards: `tests/test_mab_quality_pass.py`): scored the June-10
+four-show predictions — the "So imagine" opener de-seed HIT (0/10), the
+length floor raise MISSED (9/10 still under 1200, digest ceiling, deferred).
+Two prompt de-seeds (A/B). (1) The Deep Dive closer echoed a verbatim
+three-sentence template every episode — "and that's basically what X is
+doing when it Y / so next time someone says Z, you can tell them it is
+basically W / not so scary, right?" (9/10 "not so scary right", Ep080/081/082
+word-for-word); root cause was BOTH prompts seeding the literal sentences
+(`mab_podcast.txt:138-139`, `mab_digest.txt:121-122`, the Omni-View
+"strongest case" / EI deep-dive / FP lesson-template class). De-seeded both,
+keeping the analogy method but requiring fresh per-episode phrasing and
+naming the formulas as banned-as-verbatim (A/B render: digest now ends "…more
+like chatting with someone who actually gets the point" instead of the
+formula). (2) After the "So imagine" fix the model converged on a new
+"Something [adj] just happened" opener (5/10) — straight from the prompt's
+own example list (`mab_podcast.txt:125`); moved it from the example menu to
+the BANNED list. Deferred: chronic under-length (digest ceiling, four-show
+length A/B); "The Big Story" chapter missing on every episode (dead
+`big story|biggest news` marker — host's opener is intentionally varied, no
+anchor; digest-driven/position-aware titles is the durable lever, M&A
+June-21 class); Ep081 auto-segment garbage title (same lever); the stale
+Fish/Chatterbox pronunciation hook still injecting landmine-#17 respellings
+(`CUDA→"kooda"` etc., 0/76 transcript impact — recommend aligning with
+sister M&A which uses no hook). Prompt edits change output — A/B-listen per
+landmine #17.
+
+## Modern Investing Techniques
+
+- **June 2026 quality pass** (drift guards: `tests/test_mit_quality_pass.py`):
+the recursive-learning loop had been DEAD on every episode —
+`_analyze_strategy_patterns` was called but never defined, the NameError
+was swallowed by pre_fetch's try/except, and all three learning blocks
+shipped as "temporarily unavailable" (now implemented: FAVOR/AVOID sector
+guidance). Two trades closed with NaN exit prices (yfinance returns NaN
+floats that pass `is None`) had poisoned `cumulative_pnl` into NaN —
+"Running Total: $nan" on air; all aggregations now route through
+`_finite()` and `_close_trade` rejects non-finite prices. The summary
+gained `cumulative_alpha_vs_nasdaq` (the headline metric previously read
+from a key that never existed — actual record: +20.6% across 26
+benchmarked trades, finally stated on air via the portfolio block).
+Lesson cooldowns now ESCALATE with teach-count (flat 21d let
+bid_ask_spread reteach 13×; every 3 repeats adds a full period, cap
+180d). Trade extraction logs loudly on formatting drift vs quiet on
+deliberate no-trade days. MIT opts into `podcast_expand_below_target`,
+gets a hook-led X teaser linking the episode blog + performance page,
+and the deep-dive queue carries a 6-entry evergreen Canadian bench
+(operator schedules via `when: next`). Prompt edits (no-trade platitude
+ban, Market Pulse macro frame) change output — A/B-listen per landmine
+#17.
+**July 3 2026 benchmark-integrity pass** (review:
+[`docs/reviews/modern_investing_review_2026_07_03.md`](docs/reviews/modern_investing_review_2026_07_03.md);
+drift guards: `tests/test_mit_benchmark_integrity.py`): audit driven by
+the operator's live-trading intent — the measurement layer was not
+measuring what it claims. Every FLASH trade had `nasdaq_return_pct: 0.0`
+(the annotator compared the same close to itself → "alpha" was the raw
+return); mid-week weekly picks were BACKDATED to Monday's open
+(hindsight gain — Ep35 AMD picked Wed, +13.36% from Mon open); Ep50
+"CNR (TSX)" was priced as US Core Natural Resources, not Canadian
+National Railway; DELL/HIMS NaN closes were still spoken as breakevens
+(the July-2 migration caught nulls, not NaN); `--test` runs appended
+REAL trades (post_generate runs before the test-mode exit); and the
+lessons_learned "learning loop" was an echo chamber (65 actives, ~47
+copies of two rules — the 9/10-episode "closing-price confirmation"
+tic). Fixed: matched-bar-window benchmark (index open→close over the
+trade's own bars), pick-date entry integrity (no bars before the pick;
+cron-delay wrong-day pricing killed; stale picks void after 10d), TSX
+`.TO`/`.V` resolution + pick-time probe + price-discontinuity tripwire,
+self-healing void of non-finite closes (tracker now 40 closed/6 voided,
+win rate 57.5%), `NERRA_HOOKS_READONLY` set by run_show for
+`--test`/`--rehearse` (only the MIT hook honors it so far — extending to
+the memory shows is a deferred network item), lessons dedup-on-append +
+ledger collapse 65→11 distinct rules, matched-window compounded alpha +
+labeled scoreboard blocks (A/B-listen: scoreboard/lessons/bar-day-label
+changes alter spoken output), per-bucket confidence calibration (46/46
+picks had said "Medium"). Operator to-dos: run
+`scripts/recompute_mit_benchmarks.py --apply` (needs market-data access;
+realigns historical windows + reports wrong-instrument trades) for the
+first trustworthy alpha baseline, and see the review doc's live-trading
+readiness verdict (NOT READY — honest record +$304 over 40 sequential
+$1k trades vs NASDAQ +15.46% ITD; accumulate 2-3 months of clean
+post-fix record first).
+**July 3 2026 SnapTrade execution plan** (doc:
+[`docs/mit_snaptrade_live_trading_plan.md`](docs/mit_snaptrade_live_trading_plan.md);
+drift guards: `tests/test_mit_benchmark_integrity.py::TestTradeSignal`):
+design for live trading via SnapTrade (the only sanctioned Wealthsimple
+API route; Webull US/CA trading added Dec 2025). Shipped the execution
+bridge: `post_generate` now writes a schema-versioned
+`trade_signal_latest.json` + per-episode copy (explicit
+new_trade/no_trade with drift-distinguishing reason, SnapTrade-format
+symbol — Yahoo `.TO` convention matches the tracker's resolved symbols
+1:1 — CAD→Wealthsimple / USD→Webull routing, deterministic uuid5
+`client_order_id` for idempotent placement; read-only runs write
+nothing). The future `execution/` package consumes ONLY this artifact
+— the LLM never touches the order path. Phased rollout in the doc
+(read-only mirror → shadow mode → $150-250 micro-live on Webull →
+scale), fail-closed risk caps, and an operator checklist (SnapTrade's
+per-broker matrix must be verified in the dashboard: trade enablement
+for Wealthsimple, Limit+Day support, fractional/notional). NOTE:
+SnapTrade's sandbox is READ-ONLY (no simulated fills) — shadow mode is
+the paper-trading layer. Podcast stays a simulation on air; live
+execution is a private layer decoupled from the 08:16 UTC episode run
+(executor runs its own ~13:50 UTC slot).
+**July 4 2026 optimize-the-loop pass** (drift guards:
+`tests/test_mit_benchmark_integrity.py::{TestMultiIndexBenchmark,TestRuleEffectiveness}`,
+`tests/test_snaptrade_execution.py::{TestRiskGates,TestShadowExecutor}`):
+three workstreams toward "beat all major indices". (1) **Multi-index
+matched-window benchmarking** — every closed trade now carries
+`benchmark_returns` for ^IXIC + ^GSPC + ^GSPTSE over the SAME bar
+window; summary gains per-index compounded `benchmark_scores` +
+`indices_beaten`; the scoreboard block adds a once-per-episode
+"beating N of 3 major indices" sweep (NASDAQ stays the headline;
+legacy trades fall back to the nasdaq field; recompute script rebuilds
+history for all three). (2) **Rule-effectiveness scoring** — trades are
+stamped with `rules_in_effect` (the exact rule IDs shown on pick day);
+`_build_rule_scoreboard` compares stamped-trade alpha vs trades
+without each rule and flags ≥8-trade no-edge rules as RETIREMENT
+CANDIDATES (operator decision — never auto-retired). The learning loop
+now measures whether its own rules work. (3) **Shadow mode (Phase 2)
+LIVE** — `execution/risk.py` (pure, env-tunable hard gates; kill
+switch defaults off) + `execution/shadow.py` (signal → gates →
+decision-time quote → would-be marketable-limit order → committed
+`shadow_ledger.json`, idempotent) + `mit-shadow-executor.yml`
+(weekdays 13:50 UTC, yfinance only, no secrets); the read-only/no
+order-placement contract still pinned. `scripts/mit_shadow_report.py`
+= sim-vs-shadow slippage table. Scoreboard/lessons-block additions
+change prompt context → A/B-listen per landmine #17. Same-PR second
+batch: shadow EXITS (paired idempotent `would_sell` on the sim's exit
+calendar → round-trip shadow P&L + sim-vs-shadow gap in the report),
+regime block (rolling last-10 alpha + drawdown → cold streak makes
+no-trade the default / hot streak holds the bar), FAVOR/AVOID now
+requires n≥5 samples (was 2-3 — coin flips steered picks), performance
+page gained the matched-window headline tile + "not capital-matched"
+relabel + major-index sweep.
+**July 4 2026 fidelity batch** (drift guards:
+`tests/test_mit_benchmark_integrity.py::{TestStopLossExtraction,TestStopBreach,TestAlphaTStat}`,
+`tests/test_dashboard_mit_section.py::TestExecutionHealth`): stop-loss
+ENFORCEMENT — the digest narrates a stop on every pick but the sim
+never enforced it; the stop is now parsed at pick time (never guessed),
+carried on the trade + trade signal (future bracket orders), and
+enforced at evaluation against intraday lows (bars carry a 4th
+low element; gap-aware fills; entry-bar breaches never claimed; the
+benchmark window follows the shortened hold; the review narrates
+"stopped out" as stop discipline working). Per-trade alpha **t-stat**
+(`alpha_t_stat` / `alpha_statistically_significant`) in the summary +
+an on-air honesty rule in the scoreboard block (hedge "not yet
+statistically significant" until t≥2). Dashboard `execution_health`
+block (trade-signal freshness/staleness + shadow-ledger vitals).
+Stop enforcement changes sim outcomes going forward; the honesty line
++ stop narration are new prompt context → A/B-listen per landmine #17.
+**July 4 2026 Phase-3 live executor (DORMANT)** (drift guards:
+`tests/test_snaptrade_execution.py::{TestLiveEntry,TestLiveExits,TestLiveStatePrivacy}`):
+operator-directed "build the next layer" — real order placement now
+EXISTS but cannot run until armed. `execution/live.py` +
+`scripts/mit_live_executor.py` + `mit-live-executor.yml` (13:52 UTC
+entries / 19:45 UTC exits). Gate order, all fail-closed: kill switch
+(repo var `LIVE_TRADING_ENABLED=1`; unset → logged no-op that never
+loads credentials) → SnapTrade config → self-halt (2 consecutive
+rejects halt the layer via committed `live_execution_state.json`;
+exits still run so positions are never unmanaged) → shared risk gates
+→ daily/open-position caps → account resolution (institution match on
+the signal's routing hint) → live quote (none = never place blind).
+Integer-share marketable limits under `MIT_MAX_POSITION_USD` (default
+$250); idempotent `client_order_id`; the narrated stop rides on the
+signal for future bracket orders. Privacy split: committed state =
+ids/status only; full `live_ledger.json` (account ids/amounts) is
+gitignored + 90-day CI artifact. The Phase-1/2 "no placement code"
+contract is superseded by a narrower pinned one: the SDK trading call
+exists ONLY in `snaptrade_client.py`, invoked ONLY by `live.py`, whose
+FIRST gate is the kill switch (a poisoned-client test proves disabled
+runs touch nothing). No prompt/audio changes (outside landmine #17).
+**July 18 2026 two-week scoring review** (review:
+[`docs/reviews/modern_investing_review_2026_07_18.md`](docs/reviews/modern_investing_review_2026_07_18.md);
+drift guards: `tests/test_mit_benchmark_integrity.py::{TestRegimeDeadlockFix,TestWeeklyMinHold,TestSweepGating,TestNoTradeReasonTaxonomy}`):
+scored the July 3-4 predictions — 8 HIT (tic 9/10→0/10, entry
+integrity, stops 2/2, rule stamps, 3-index closes, shadow ledger
+complete with paired exits, dormant live layer untouched), 1 MISS,
+1 pending. Two production design flaws fixed: (1) the regime
+cold-streak brake DEADLOCKED the Practice Investment (2 picks in 14
+episodes; mean poisoned by the -11.8 MDA outlier, $100 drawdown
+threshold permanently tripped at $164 standing, and cold suppressed
+the closes that refresh the window) — regime v2 uses the MEDIAN, a
+full-position $250 drawdown threshold, a >7-day pick-drought escape
+valve (SELECTIVE RESET expects the next Monday pick), and tells the
+show to narrate capital-preservation mode on air; (2) Ep101 COST was
+picked Thursday and closed as a one-bar "weekly hold" (entry==exit
+bar, -2.35% while the shadow layer holding Thu→Fri made +0.26%) —
+weekly closes now require ≥2 days since pick, shadow calendar matched.
+The MISSed prediction: the t-stat honesty hedge was spoken in ZERO
+episodes while the alpha was quoted in most — the caveat now lives
+INLINE in the alpha sentence (models echo data lines, drop separate
+instructions — a reusable lesson). Index sweep gated on n≥5 per index
+(was comparing 37-trade NASDAQ vs 2-trade S&P/TSX). No-trade signal
+reasons: explicit forms broadened ("Today's Pick: None" was mislabeled
+as extraction drift), `no_practice_section` for recaps. Regime/caveat
+text changes prompt context → A/B-listen per landmine #17. Operator
+items still open: recompute --apply (matched alpha retains old-window
+inflation until backfill), SnapTrade Phase-0 verification, LL-054
+family retirement.
+**July 24 2026 operator-directed pass** (review:
+[`docs/reviews/modern_investing_review_2026_07_24.md`](docs/reviews/modern_investing_review_2026_07_24.md);
+drift guards: `tests/test_mit_benchmark_integrity.py::{TestSuffixedSymbolExtraction,TestCryptoSymbolCandidates,TestInstrumentScaleMismatch,TestVoidDisclosure,TestAlphaCaveatDataShaped,TestArticleCollapseAlarm}`):
+the trade EXTRACTOR could not parse the exchange-native symbols the
+July-3 pass taught the digest to emit — Ep111's spoken CNR.TO weekly
+pick was silently LOST (`no_pick_extracted`) and Ep113's "BTC-USD —
+Bitcoin" was truncated to "BTC", validated against an unrelated $28.80
+equity (narrated stop $64,500), routed to Webull in the trade signal,
+and would_place'd by the SHADOW executor — the wrong instrument reached
+the execution layer. Fixed: suffixed/hyphenated symbol extraction +
+CRYPTO market (+ latent TSX-V alternation bug), crypto candidates force
+the `-USD` pair with no bare fallback, a wrong-instrument tripwire
+(stop outside [ref/3, ref×3] voids at record time + self-healing
+migration; committed tracker migrated — Ep113 BTC voided), and an
+announced-then-voided pick is now disclosed on air exactly once. Ep115
+fetched 9 articles (vs 222-337 median) and shipped 6/6 x.com sources —
+new network-wide source-collapse `::warning::` + `article_count_degraded`
+metric in run_show; digest prompt gains x.com-as-one-publication /
+publisher-first sourcing, the Tools-header scaffold typo fix ("…Tool:
+Source" shipped verbatim), and Today's-Pick template instructions moved
+out of the value slot (Ep111 echoed the parenthetical on air). Length
+attacked at the sanctioned substrate (`digest_expand_below_target` +
+`min_digest_words: 1500`; 10/10 scripts were under the 1800 floor). The
+significance caveat missed a SECOND time (1/6 alpha mentions) — now
+fused into the alpha value as a data-shaped parenthetical; a third miss
+goes to the operator as accept-or-abandon. Prompt/caveat/digest-lever
+edits change output — A/B-listen per landmine #17.
+
+**Tesla Shorts Time Recursive Memory System (May 2026+)**  
+TST received a full recursive improvement architecture (analogous to MIT):
+- `engine/tesla_memory.py` + three persistent trackers in `digests/tesla_shorts_time/`:
+`tesla_narrative_tracker.json` (major programs with status, claims, confidence),
+`tesla_performance_tracker.json` (YouTube/Shorts signals for emphasis),
+`tesla_theme_history.json` (mined from transcripts/digests).
+- Injected on every episode via `shows/hooks/tesla.py` pre_fetch → rich context blocks
+(`tesla_narrative_status_block`, performance signals, theme context).
+- Prompt updates in both digest and podcast prompts.
+- Public page `tesla-narrative.html` (generated nightly + on demand).
+- Post-episode hook + Sunday recap integration.
+- Operator tooling: `scripts/update_tesla_narrative.py` for easy updates without hand-editing JSON.
+- Goal: TST becomes the best long-term public chronicle of Tesla's major programs while
+continuously optimizing for real audience engagement.
+
+## Omni View
+
+- **June 10 2026 quality pass** (review:
+[`docs/reviews/omni_view_review_2026_06_10.md`](docs/reviews/omni_view_review_2026_06_10.md);
+drift guards: `tests/test_omni_view_quality_pass.py`): OV was missed by
+every chapter/length hardening round. Two shipped chapter bugs fixed
+(metadata-only): 7 of the last 10 episodes had NO Closing chapter (the
+dominant "That wraps up today's Omni View…" closing-pool variant matched
+no pattern — MAB orphan-closing class), and the dead "Understanding the
+Issue" pattern let the auto-segment fallback title chapters from raw
+deep-dive sentences (Ep061 "Knowing this, when you hear claims…", Ep068
+"How are casualty figures verified…"); added `where` anchors + a Closing
+pattern covering both variants + a deep-dive pattern matching the real
+spoken opener. The June "strongest case ≤1×/episode" steel-man fix had
+FAILED (12-20×/episode in Ep070/071/075, or mutated to the anonymous
+"One side frames / The other side frames / Advocates on each side" frame
+in Ep077 — which also violates the prompt's own attribution rule); root
+cause was the DIGEST prompt seeding the literal "The strongest case for X
+rests on…" lead-in, so the fix dropped that seed, requires NAMED
+advocates, and bans the anonymous frame in both prompts (verified via
+`--test`: 0 uses, advocates now named). Unified three contradictory
+length targets (8-12 min / 2000 words / "40+ sentences") to one
+(1,700-2,000w ≈ 11-13 min) + added `podcast_expand_below_target` and
+raised `min_podcast_words` 900→1400 (the expand opt-in the June network
+pass missed). Prompt/length edits change shipped audio — A/B-listen per
+landmine #17; the chapter fix does not.
+**July 18 2026 editorial realignment** (operator-directed; review:
+[`docs/reviews/omni_view_review_2026_07_18.md`](docs/reviews/omni_view_review_2026_07_18.md);
+drift guards: `tests/test_omni_view_quality_pass.py::TestEditorialRealignmentJuly18`):
+repositioned to "top world stories, balanced, teen-to-senior,
+informative AND encouraging, anti-clickbait". The 12-slot taxonomy
+(whose mandatory daily gossip + popular-media slots forced tabloid
+filler and twice LED episodes with tabloid items) became a 7-slot
+slate: lead (1) + world (3) + economy/science/tech (2) + **Progress
+watch** (1, rigor bar: named actors + a number + the complication) +
+the retained Understanding the Issue deep dive. Steel-man is now
+CONDITIONAL (2-3 genuinely contested stories, named advocates; the
+"Both sides agree" family had shipped ~38×/10 eps incl. on a
+waterslide accident) — disasters/deaths/science/culture get context +
+what-happens-next, never manufactured sides. Plain-language layer
+(define every institution in one clause; teen-to-senior audience in
+every prompt). Sources: Daily Mail REMOVED (was the most-cited outlet;
+Reuters/AP were 0×), dup-BBC + r/news removed; Reuters/AP Google-News
+proxies, WSJ World + 9 regional feeds (Africa/Asia/LatAm) added with a
+geographic-breadth rule (≥3 regions, ≤2/country, UK ≤1); conservative
+tabloid `exclude_title_patterns`. Engine: `podcast_expansion_style:
+deepen` (new LLMConfig field — the "cover more stories" retry would
+fight the fixed slate), `min_digest_words: 1500` + digest retry (the
+under-length root fix), `ov_validation_config` + `OV_SECTION_PATTERNS`
+updated to the new headers (Ep068 regenerate-class). New closings pair
+perspective coaching with one encouraging line; a per-episode
+"go deeper: compare two outlets" pointer. Public copy updated (tagline
+kept). All prompt/closing/source changes alter shipped audio —
+A/B-listen the first post-merge episode per landmine #17; watch the
+Progress Watch chapter marker for the dead-marker class.
+
+## Planetterrian Daily
+
+- **June 10 2026 Planetterrian pass** (review:
+[`docs/planetterrian_review_2026_06_10.md`](docs/planetterrian_review_2026_06_10.md);
+drift guards: `tests/test_planetterrian_quality_pass.py`): NEW
+network-wide missing-closing guard in `engine/pipeline.py` (PT Ep081/084
+shipped without the supplied closing block — Ep084 ended mid-teaser; the
+pipeline now appends the resolved `closing_block` verbatim when absent,
+before chapter parsing); ONE unified length target (1,800–2,100 words ≈
+12–13 min, floor 1250→1600 — the prompt had demanded three conflicting
+lengths and all 15 recent episodes ran under target, avg ~970); chapter
+`where` anchors + "see you next" closing coverage. Watch the first week
+for `podcast_script_too_thin` skip markers; fall back to floor 1400 if
+PT skips more than once. A/B-listen per landmine #17.
+**June 18 2026 second pass** (review:
+[`docs/reviews/planetterrian_review_2026_06_18.md`](docs/reviews/planetterrian_review_2026_06_18.md);
+drift guards: `tests/test_planetterrian_quality_pass.py::TestChapterShapeJune18`):
+the June-10 `where` anchors exposed two deeper chapter P0s (all
+metadata-only, no A/B). (1) The Introduction marker matched only the
+"Welcome" greeting, but the intro rotates four greetings — "Good to have
+you on" / "Thanks for tuning in to" carry no "Welcome", so ~50% of
+episodes (Ep085/086/088/093) shipped with NO Introduction chapter and the
+whole body collapsed under the teaser-anchored first chapter
+(orphaned-body class); now anchored on "Planetterrian … episode" (matches
+all four greetings). (2) The spoken teaser opens "Keep an eye on…" / "Watch
+for…" (the pattern missed it), so the teaser's `Next time` stole "See you
+next time" from the closing line and Ep086/090 shipped with no Closing
+chapter — fixed via the EI June-11 ordering rule (Closing precedes Tomorrow
+Teaser) + a broadened teaser pattern. (3) The Science Deep Dive marker was
+dead (prompt forbids announcing the section); now matches the seeded spoken
+opener ("most people get wrong / picture / assume"). The June-10 length fix
+scored a MISS — episodes still 1178–1378w (digest ceiling, FF/UC root
+cause); re-attack deferred behind the four-show length A/B. Garbage
+mid-body auto-segment chapter titles also deferred (shared LLM-title class).
+
+## Russian shows (Финансы Просто + Привет, Русский!)
+
+- **June 10 2026 Russian-shows pass** (FP + PR; review:
+[`docs/russian_shows_review_2026_06_10.md`](docs/russian_shows_review_2026_06_10.md);
+drift guards: `tests/test_russian_shows_quality_pass.py`): the spoken +
+RSS AI disclosures are now LOCALIZED (`_AI_DISCLOSURE_RU` /
+`_AI_DISCLOSURE_RSS_RU` in `run_show.py`, gated on `_RUSSIAN_SHOWS`) —
+closing the "English disclosure on the Olya voice" wart from two prior
+reviews; Russian feeds title episodes "Выпуск N: …"; closing-pool
+coverage + `where` anchors fixed (FP's "Вот и всё" variant matched no
+pattern; PR had ONE closing ever — now 3 rotating); floors FP 900→1000,
+PR 650→800 (PR keeps `min_podcast_word_floor: 550`); NEW
+`engine/vocab_tracker.py` + `shows/hooks/privet_russian.py` give PR
+vocabulary memory — spaced-repetition review callbacks + a
+no-reteach/theme-rotation list via `{vocab_review_section}` (Animals had
+run 3 consecutive episodes; words never reappeared). Audio-affecting
+changes → A/B-listen per landmine #17.
+
+## SpaceX Daily
+
+- **June 13 2026 quality pass** (review:
+[`docs/reviews/spacex_review_2026_06_13.md`](docs/reviews/spacex_review_2026_06_13.md);
+drift guards: `tests/test_spacex_show.py`,
+`tests/test_network_quality_pass.py`): two days post-launch, after the
+operator's same-day fixes for the Ep2 AI-chapter `A I` spacing and the
+AI-section accuracy guardrail (Colossus/Anthropic is real — do not
+relitigate). The theme miner mined source-attribution LABELS — the
+bare-URL strip in `engine/show_memory.py` missed the markdown
+`[Google News](url)` label, so `"google spacex"` shipped as the #1
+recurring theme (latent network-wide: FF `science nasa`, M&A `reddit
+localllama`); now strips the whole `[label](url)` construct first, and
+the polluted `spacex_theme_history.json` was rebuilt clean. The rocket
+thrust unit `tf` (tonne-force) was spoken letter-by-letter ("280 T F",
+twice in Ep2) — a per-show `pronunciation_overrides()` in
+`shows/hooks/spacex.py` expands `tf → tons-force` (a unit expansion, not
+a respelling — outside landmine #17; A/B-listen the audio change anyway).
+Deferred with levers: the SPCX price is spoken twice/episode (Market
+Watch segment + closing block) — the clean fix needs the Closing chapter
+marker reordered ahead of Market Watch to avoid an orphan-closing
+regression; and "AI & Compute" chapter lumping (swallows trailing Top
+News when the LLM emits news after the editorial markers) — observe Ep3+
+before a prompt change.
+
+- **June 18 2026 second pass** (review:
+[`docs/reviews/spacex_review_2026_06_18.md`](docs/reviews/spacex_review_2026_06_18.md);
+drift guard: `tests/test_spacex_show.py::TestClosingBeforeMarketWatch`):
+both June-13 predictions HIT (themes clean, no `tf`/`T F`). Found + fixed a
+P0 the snapshot's "clean chapters" check missed — **weekly-recap episodes
+shipped with NO Closing chapter** (`chapters_ep003.json` ended at a
+mis-titled "Market Watch"). The code-supplied closing block appends the
+SPCX price into the sign-off, the Market Watch marker matches that price
+phrase, and Market Watch was listed before Closing; dailies escaped via
+the real Market Watch segment consuming the marker first (once-per-title),
+but recaps have no such segment. Fixed by ordering the **Closing marker
+ahead of Market Watch** (`where: end` keeps it pinned to the sign-off) —
+metadata-only, no audio, zero regression on all 7 scripts. This also
+clears the chapter blocker on the deferred price-twice fix. Deferred
+(evidence strengthened): chronic under-length is the **Engineering Deep
+Dive under-delivering its own spec** (140-181w vs the digest prompt's "3
+paragraphs of 4-6 sentences" ~250-360w) — the expand-the-deep-dive lever
+stays deferred pending the network four-show length A/B. The AI-lumping
+and hook-jargon June-13 deferrals did NOT recur.
+**June 19 2026 third pass** (review:
+[`docs/reviews/spacex_review_2026_06_19.md`](docs/reviews/spacex_review_2026_06_19.md);
+drift guards: `tests/test_pronunciation.py::TestReplaceTimes`,
+`tests/test_spacex_show.py::TestLaunchTimePronunciation`): both June-18
+predictions scored (deep-dive-still-short HIT — Ep8 139w; daily-Closing HIT,
+recap pending). New P0 spoken garble: launch times **with seconds** shipped
+mangled — the digest's `1:50:45 a.m.` was voiced "one fifty A M:45 a.m." and
+`0850:45 UTC` as raw digits (Whisper-confirmed in Ep8 audio). The shared
+`assets/pronunciation.py:replace_times` matcher was seconds-blind
+(`(\d{1,2}):(\d{2})…` matched only `1:50`, stranding `:45`). Fix: drop
+seconds (`(?::\d{2})?`), add a compact `0850:45 UTC` → "oh eight fifty U T C"
+handler that runs before the HH:MM matcher, and tighten the trailing
+whitespace so an absent AM/PM no longer glues the next word ("P MUTC"). A
+latent network-wide bug surfacing on SpaceX because spaceflight reporting
+gives T-0 to the second — the same spoken-garble class as the June-13
+`tf`→`T F` fix. Deterministic number-normalization correctness change (not a
+respelling) but changes spoken output — A/B-listen per landmine #17. The
+deep-dive length lever + price-spoken-twice (8/8) stay deferred (reasons
+hold); tomorrow-teaser "watch for the [next] <test>" frame now 6/8 (P2 monitor).
+
+## Tesla Shorts Time
+
+- **June 2026 quality pass** (drift guards: `tests/test_tesla_quality_pass.py`):
+theme mining now reads the DIGEST only (the old code mined the narrative
+TEMPLATE text every episode — "open questions" hit count 112 and drowned
+real topics; `_THEME_STOPWORDS` + a one-time scrub fixed existing
+histories). `auto_update_narrative_from_digest` auto-advances per-program
+`last_mentioned_episode/date` on every episode (the tracker had sat 13
+days stale on a daily show) — operator-curated `status` text still only
+changes via `scripts/update_tesla_narrative.py`. The listener-value score
+gained a 15%-weight length component (`target_words` kwarg). Tesla opts
+into `llm.podcast_expand_below_target: true` — the one-shot expansion
+retry fires on ANY below-target script, not only near the 60% skip floor
+(9 of 10 episodes had shipped 15-35% under the 1600-word target). The X
+teaser leads with the episode hook + links the episode blog post. The
+prompts ban the "Taking a step back from today's headlines" opener,
+rotate three First Principles frameworks, cap the vertical-integration
+conclusion, enforce the Takeover/Top-12 zero-overlap check, and add
+3-tier attribution discipline. Prompt changes alter generated output —
+A/B-listen per landmine #17 and revert via git if quality dips.
+
+- **June 10 2026 follow-up pass** (full review:
+[`docs/tesla_review_2026_06_10.md`](docs/tesla_review_2026_06_10.md);
+drift guards in `tests/test_tesla_quality_pass.py`,
+`tests/test_chapters.py::TestPositionalConstraints`,
+`tests/test_tesla_hook.py::TestClosingBlock`):
+chapter markers gained positional `where: start|end` constraints +
+once-per-title matching (the closing's "tesla shorts time" mention had
+titled the closing "Introduction" on every episode); the spoken closing
+now rotates 4 variants, phrases by market state, and OMITS the price
+sentence when the quote failed validation (previously spoke "closed at
+zero dollars, price unavailable"); the expansion retry now carries the
+full digest (it previously saw only its own short script — it could not
+add facts, the root cause of chronic under-length); ONE unified length
+target (2,200–2,400 words ≈ 14–16 min, `min_podcast_words: 2000` — the
+prompt had demanded four contradictory lengths); the performance loop is
+LIVE (`scripts/update_tesla_performance.py` nightly derives
+`strong_topics_last_30d` from OP3 download data — `record_performance_signal`
+previously had zero callers); theme mining filters narrative-prose echo +
+URLs and is idempotent per episode; program detection uses word-boundary
+regexes (bare "unsupervised" no longer advances FSD); the spoken show
+name dropped "Daily" to match the listing brand "Tesla Shorts Time";
+content-tracker headlines filter junk/slur titles
+(`_is_dedupe_worthy_title`); blog posts link the Story Tracker page.
+Length/brand prompt changes alter shipped audio — A/B-listen per
+landmine #17.
+
+- **June 20 2026 second agent pass** (review:
+[`docs/reviews/tesla_review_2026_06_20.md`](docs/reviews/tesla_review_2026_06_20.md);
+drift guards: `tests/test_tesla_quality_pass.py`): scored June 10 — the
+chapter-anchoring HIT (0/10 trailing-Introduction) but the length
+prediction MISSED (Ep507-516 1254-1676w, all under the 2000 floor).
+Three deterministic fixes. (1) The podcast-gen step spelled Teslarati —
+the show's #1 source — phonetically as `Tesla-rah-tee` in 25+ episodes
+(5 of the last 10), voiced as an audible garble (Whisper of Ep516:
+"Tesla had RadT"); added to the blessed `engine.utils.fix_phonetic_garbles`
+restore layer (removes a respelling → outside landmine #17, A/B anyway).
+(2) The June-10 "drop Daily from the spoken brand" decision had MISSED
+the pre-existing brand normalizer in `engine/generator.py`, which kept
+normalizing TOWARD "Tesla Shorts Time Daily" — so the LLM-appended
+"Daily" shipped in the spoken intro of 100% of episodes (Ep506-516);
+the normalizer now drops the stray "Daily" (completes the approved
+decision; A/B-listen). (3) 13F institutional-filing spam ("LLC Purchases
+New Stake in Tesla", 3× in Ep516) now filtered at fetch via
+`exclude_title_patterns` in `shows/tesla.yaml` (deterministic, no-A/B,
+FF stock-filter class). Deferred with re-diagnosis: chronic under-length
+is the DIGEST ceiling (Top-12 items ship 3 thin sentences from
+Google-News snippets; script tracks the digest ~1:1) — same root cause
+as FF/UC/PT, held behind the four-show length A/B (levers: digest-
+expansion retry / First-Principles essay expansion). Also deferred:
+chapter body navigation — fragment auto-segment titles (8/10) AND a new
+no-body-chapter regression (2/10; `engine/chapters.py:208` never
+implemented its docstring's "head spans most of script" auto-segment
+trigger) — fix is network-scoped digest-driven titles.
+
+## The DP Pod
+
+- **July 2 2026 Ep1 rework (operator listened: "terrible and robotic"):**
+theme song `assets/music/dp_pod.mp3` ("Do Positive", 4.5 min Suno track)
+is the intro/outro bed; NEW `audio.debut_song_file`/`debut_song_episode`
+(AudioConfig, generic no-op default) appends the FULL song after the
+closing on Episode 1 only via `engine.audio.append_full_song` (after
+chapter timestamps — the song must not stretch the proportional chapter
+math); the debut is a DESIGNED episode via per-show overrides in
+`engine/first_episode.py` (`_SHOW_DIGEST_EP1`/`_SHOW_PODCAST_EP1`:
+founding statement → anchor discussion from the network's own First
+Principles material → network tour → starter lever → on-air song intro);
+`shows/hooks/dp_pod.py` supplies `{nerra_network_context}` (sibling-show
+catalog + latest FP brief; setdefault-ed in pipeline/run_show so a hook
+failure can't KeyError); the podcast prompt gained a DELIVERY — WRITE THE
+ENERGY IN block (spoken-English volleys, ≥⅓ one-sentence turns, no
+news-anchor phrasing — the anti-robotic levers) + a one-mention-max
+cross-promo rule; `dialogue_pause_ms` 300→220. The shipped Ep001 was
+retired (artifacts deleted, RSS items stripped, numbering back to 1) —
+regenerate via workflow_dispatch; the schedule-event duplicate guard
+doesn't apply to manual dispatch.
+**July 2 2026 second rework (operator listened again: still robotic,
+Dan especially; intro too short; too much show-info recap):** the LIVE
+Ep1 intro/closing path is `engine/pipeline.py:run_generation_phase`
+(run_show builds pod_vars but never passes them — BOTH Ep001 renders
+aired pipeline's truncated `"please subscribe... "` literal); pipeline's
+Ep1 block is now dialogue-aware + the generic literal completed. Grok
+TTS docs pass (docs.x.ai): punctuation IS prosody (exclamation points
+now encouraged where genuine), sanctioned inline tags with a hard
+budget (≤10 of `[laugh]/[sigh]/[breath]/[pause]`, ≤4 `<emphasis>`; all
+other wraps stay banned), documented `speed` param wired through
+`grok_speak_chunk`→`synthesize_dialogue` (sent only when ≠1.0; dp_pod
+pins 1.05), `dialogue_pause_ms` 220→180. Editorial repositioning
+(All-In-inspired friends-reviewing-consequential-events): system prompt
+celebrates builders/creators/contributors; "THE ANALYSIS IS THE SHOW"
+(~⅓ facts / ⅔ hosts' unique-lens takes); digest widened from pure
+good-news to consequential-with-agency + names the builders. Debut
+override v2: 500+ word founding conversation introducing show AND
+network, anchor material as SPRINGBOARD (≤3 recap sentences), network
+tour capped at 3 shows/1 sentence each with editorial-boilerplate
+phrases BANNED (the v1 render walled 5 near-verbatim "measured result…"
+paragraphs). Second Ep001 retired the same way. Dan's voice ceiling is
+the CLONE — docs: custom-voice quality tracks the reference clips;
+re-record Dan's samples with expressive conversational takes (operator).
+**July 4 2026 v4 review + community layer:** the v4 Ep001 render (much
+improved — real disagreement, Frankl Think Positive debut, proper
+personality closing, song appended) surfaced three fixable defects, all
+fixed + retired the render (drift guards:
+`tests/test_dp_pod_show.py::TestEp001V4Fixes`): the DIGEST expansion
+retry pads by paraphrase-duplication exactly like the podcast retry did
+(the founding brief re-told every beat; `_dedup_expansion_sentences` now
+runs on the digest-retry output too — `engine/generator.py`, global but
+a correctness strip); the pipeline's `effective_hook` fallback spoke a
+raw markdown header on air when the digest lacked a HOOK line (fallback
+now skips `#`/rule lines + strips bold; the dp_pod debut-digest override
+also REQUIRES the HOOK line); and the cold open's passing "The Lever"
+mention stole the Lever chapter at 74s (marker is now announce-anchored
+— "brings us to/time for/now for The Lever" — with a SEGMENT-NAME
+DISCIPLINE prompt block requiring short forms before announcements).
+Website community layer ("a place to learn and encourage each other"):
+the club page gained a **Mindset Shelf** (`_collect_dp_mindsets` in
+`generate_html.py` extracts each digest's `### Think Positive` principle)
+and a **Dispatch Wall** (`_collect_dp_dispatches` reads the
+OPERATOR-CURATED `digests/dp_pod/dispatches.json` — real listener
+dispatches only, per the club charter; empty file = honest empty state;
+operator CLI: `scripts/add_dp_dispatch.py`).
+Drift guards: `tests/test_dp_pod_show.py::TestCommunityLayer`.
+**July 4 2026 level-drift fix + anthem canon (operator listened to v5:
+"inconsistent and drifting between good sound level then quiet"):** root
+cause is structural to dialogue mode — 30-40 independent Grok TTS calls
+per episode, each at its own loudness, and `normalize_voice`'s
+`loudnorm … linear=true` applies ONE gain to the whole file so inter-turn
+variance survives to air (single-voice shows synthesize in one call and
+never hit this). Fix: `_match_turn_levels` in `engine/tts_dialogue.py`
+gain-matches every turn WAV to the MEDIAN mean level (volumedetect —
+stable on 2-4s clips where loudnorm's integrated measure is not; ±12 dB
+cap, <1 dB left alone, runs BEFORE pause padding so silence can't skew
+the measure; verified 28 dB synthetic spread → 0). Second leak in the
+same report: `append_full_song` concatenated the debut song at its native
+master level — the song branch now runs `loudnorm I=-16`
+(`_append_song_cmd`, episode branch untouched). Both change shipped audio
+— A/B-listen per landmine #17. **Anthem:** the operator-supplied "Do
+Positive" lyrics are canon at `assets/music/dp_pod_lyrics.md`; the
+podcast prompt's THE SHOW ANTHEM block allows at most ONE verbatim lyric
+phrase per episode (default ZERO — anti seeded-template), the Ep1 debut
+override lets the song intro quote one chorus line exactly, and the club
+page gained an Anthem section (chorus + collapsible full lyrics). Drift
+guards: `tests/test_tts_dialogue.py::{TestTurnLevelMatching,
+TestDebutSongLoudness}`, `tests/test_dp_pod_show.py::TestShowAnthem`
+(including a prompt-quote-matches-canon check).
+**July 4 2026 follow-up-episodes pass (operator approved Ep1 v6 — level
+drift measured fixed at 0.52 dB stdev across 41 windows — and asked for
+great regular episodes that regularly point to network shows/episodes):**
+`shows/hooks/dp_pod.py` now builds a **FRESH ON THE NETWORK** block (each
+sibling's actual latest episode within 3 days, read from the committed
+`summaries_*.json` — entries are newest-FIRST, picked by max date) and a
+**Think Positive rotation memory** (thinkers mined from recent dp_pod
+digests → do-not-reuse list; roster in `_THINKERS`). The occasional
+CROSS-PROMO became the regular **FROM THE NETWORK** beat: exactly ONE
+grounded pointer per episode naming a REAL fresh episode, spoken as a
+friend's recommendation, position/speaker rotating (never a fixed slot —
+anti-tic); the digest gained a required-when-fresh **Network pick:** line
+and the thinker-rotation rule. Depth lever: `min_digest_words` 700→1100
+(Ep1 scripts capped ~1,200w vs the 1,550 target — the brief was the
+ceiling). The shipped debut anchor `shows/dp_pod_debut_anchor.md` was
+deleted (pin mechanism kept). Prompt/digest edits change output —
+A/B-listen per landmine #17. Drift guards:
+`tests/test_dp_pod_show.py::TestFollowUpEpisodes`.
+
+## Unintended Consequences
+
+- **June 12 2026 quality pass** (review:
+[`docs/reviews/unintended_consequences_review_2026_06_12.md`](docs/reviews/unintended_consequences_review_2026_06_12.md);
+drift guards: `tests/test_unintended_consequences_quality_pass.py`): UC
+was missed by the Tesla/four-show/FP chapter hardening — no `where`
+anchors, and seven keyword markers that assume the spoken prose contains
+literal section words the podcast prompt forbids; the brand name
+*Unintended Consequences* (contains "consequence") collided with the
+body marker on both the intro and the sign-off, so 0/10 recent episodes
+had a correct chapter shape (ep024 opened on "The Lesson"; ep028 ended
+on "The Unintended Consequences"). Fixed by anchoring Introduction
+(`where: start`) + Closing (`where: end`), dropping the unreliable middle
+markers, and letting auto-segmentation fill the middle with in-order
+content titles (the Introduction pattern includes a generic opening-word
+fallback because the LLM rewrites the supplied intro on ~30% of episodes,
+dropping the brand + "episode N") — verified 10/10, metadata-only.
+The closing pool grew 2→4 and dropped "That wraps today's case" (the
+prompt's WHAT TO AVOID block had banned that phrase while `intros.py`
+supplied it verbatim on 5/10 episodes; the 2-entry pool repeated 3× in a
+row, Ep026-028). Chronic under-length (857-1211w vs 1300 floor / 2200-
+2800 target) is DEFERRED with the same root cause + lever as First
+Principles: the digest is thin (700-960w), so the podcast — told to use
+only the brief — is capped; the digest-expansion retry is the deferred
+network lever, and the grok-4.3 narrative plateau is accepted. Closing-
+pool + prompt edits change shipped audio — A/B-listen per landmine #17.
+
+## Финансы Просто
+
+- **June 16 2026 quality pass** (first dedicated FP review; combined June 10
+pass was `docs/russian_shows_review_2026_06_10.md`; review:
+[`docs/reviews/finansy_prosto_review_2026_06_16.md`](docs/reviews/finansy_prosto_review_2026_06_16.md);
+drift guards: `tests/test_finansy_prosto_quality_pass.py`): scored the
+June-10 floor-raise as a MISS (episodes still ~5 min / ~700w — the podcast
+tracks a ~700w digest 1:1 and may not pad, so a podcast-side floor +
+expand-retry can't help; re-attacked at the digest). Two listener-facing
+P0s on the Olya voice: the YouTube call-out was an ENGLISH sentence (the
+AI-disclosure wart class the June-10 pass localized, but the call-out in
+`engine/intros._maybe_append_youtube_cta` was missed) — now Russian for
+FP via `_RUSSIAN_SPOKEN_SHOWS` (PR stays English, it's taught in English);
+and the "@" handle was voiced as the word "at" ("...YouTube **at at** Nerra
+Network", 75+ times across six shows) — now stripped network-wide. The
+closings said "до завтра" on an even-days show (EI-class cadence bug) — now
+cadence-neutral ("до встречи"). P1s: `_extract_hook` now recognizes the
+Russian `ЗАГОЛОВОК:` hook label (the FP/PR digest format), stopping a wasted
+structural regen that fired on every FP episode (`digest_structural_regen:
+true`, Ep45-54); the structural-retry corrective suffix was hardcoded with
+Tesla section names ("Top 12 News Items, Tesla X Takeover…") and applied to
+all shows — now generic. The digest prompt asks for 3-4 tips / 3 quick-news
+/ 5-7 articles (matching the podcast's already-required minimum of 3 tips;
+content is abundant at 69-129 articles/day). Call-out/closing/digest edits
+change shipped audio — A/B-listen per landmine #17.

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -249,6 +249,14 @@ def record_youtube_outcomes(
             metrics.record("scene_library_count", int(youtube_urls.get("scene_library_count", 0) or 0))
         if "broll_clips_used" in youtube_urls:
             metrics.record("broll_clips_used", int(youtube_urls.get("broll_clips_used", 0) or 0))
+        # Shorts-only scene saving (July 2026): 16:9 scenes are only worth
+        # generating when a long-form video is actually produced.
+        if "scene_long_form_produced" in youtube_urls:
+            metrics.record("scene_long_form_produced",
+                           bool(youtube_urls["scene_long_form_produced"]))
+        if "scene_fresh_long_requested" in youtube_urls:
+            metrics.record("scene_fresh_long_requested",
+                           int(youtube_urls.get("scene_fresh_long_requested", 0) or 0))
         if youtube_urls.get("thumbnail_base"):
             metrics.record("thumbnail_base", str(youtube_urls["thumbnail_base"]))
         if youtube_urls.get("thumbnail_variant_urls"):

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -9,6 +9,7 @@ Provides:
 """
 
 import datetime
+import os
 import json
 import logging
 from pathlib import Path
@@ -52,6 +53,14 @@ TTS_PROVIDER_PRICING = {
     "elevenlabs": ELEVENLABS_COST_PER_1K_CHARS,
     "grok": GROK_TTS_COST_PER_1K_CHARS,
 }
+
+# xAI server-side search tools are billed per SOURCE consulted (xAI's
+# published Agent Tools rate is $25 per 1,000 sources). Env-overridable
+# because it is the one rate here that is not pinned by a model id — if
+# xAI moves it, the operator sets XAI_SEARCH_COST_PER_SOURCE rather than
+# waiting on a code change. A run that reports no source count costs
+# nothing extra beyond its tokens, which is the honest floor.
+SEARCH_COST_PER_SOURCE = 0.025
 
 # xAI Grok pricing per 1M tokens (input/output/cached_input).
 # Only models actually reachable by the current code are listed — historical
@@ -141,6 +150,19 @@ def create_tracker(show_name: str, episode_num: int) -> dict:
                 "provider": "grok-imagine",
                 "model": "",
                 "images_generated": 0,
+                "estimated_cost_usd": 0.0,
+            },
+            # xAI server-side search tools (x_search / web_search via the
+            # Responses API). Billed PER SOURCE consulted on top of
+            # tokens. Added July 29 2026 — flagged as uncounted by the
+            # July 24 pass and still missing after the July 28 cost fix,
+            # so every search-fetching show under-reported its spend.
+            "search_api": {
+                "provider": "xai",
+                "calls": 0,
+                "sources": 0,
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
                 "estimated_cost_usd": 0.0,
             },
         },
@@ -293,6 +315,52 @@ def record_image_usage(
     images["estimated_cost_usd"] += float(cost_usd or 0.0)
 
 
+def record_search_usage(
+    tracker: dict,
+    calls: int,
+    sources: int,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+    model: str = "",
+) -> None:
+    """Record xAI server-side search-tool usage (x_search / web_search).
+
+    ``digests/xai_grok.py`` accumulates this per process because the
+    fetch layer has no tracker reference; run_show drains it once per
+    episode. Additive — a show that fetches several X accounts drains one
+    combined total.
+
+    Token cost is priced through the normal Grok table when *model* is
+    known; the per-source fee is the part that was invisible.
+    """
+    search = tracker["services"].setdefault(
+        "search_api",
+        {
+            "provider": "xai", "calls": 0, "sources": 0,
+            "prompt_tokens": 0, "completion_tokens": 0,
+            "estimated_cost_usd": 0.0,
+        },
+    )
+    search["calls"] += int(calls or 0)
+    search["sources"] += int(sources or 0)
+    search["prompt_tokens"] += int(prompt_tokens or 0)
+    search["completion_tokens"] += int(completion_tokens or 0)
+
+    try:
+        rate = float(
+            os.getenv("XAI_SEARCH_COST_PER_SOURCE", "").strip()
+            or SEARCH_COST_PER_SOURCE
+        )
+    except ValueError:
+        rate = SEARCH_COST_PER_SOURCE
+    cost = int(sources or 0) * rate
+    if model and (prompt_tokens or completion_tokens):
+        cost += _estimate_grok_cost(model, prompt_tokens, completion_tokens)
+    search["estimated_cost_usd"] = round(
+        float(search.get("estimated_cost_usd", 0.0) or 0.0) + cost, 6
+    )
+
+
 def record_render_seconds(tracker: dict, seconds: float) -> None:
     """Record video render wall-clock. Informational — never priced."""
     render = tracker.setdefault("render", {"video_seconds": 0.0})
@@ -353,9 +421,12 @@ def save_usage(tracker: dict, output_dir: Path) -> Path | None:
 
         images = tracker["services"].get("image_api") or {}
         image_cost = float(images.get("estimated_cost_usd", 0.0) or 0.0)
+        search = tracker["services"].get("search_api") or {}
+        search_cost = float(search.get("estimated_cost_usd", 0.0) or 0.0)
 
         tracker["total_estimated_cost_usd"] = (
-            grok["total_cost_usd"] + tts["estimated_cost_usd"] + image_cost
+            grok["total_cost_usd"] + tts["estimated_cost_usd"]
+            + image_cost + search_cost
         )
 
         # Write file
@@ -393,6 +464,13 @@ def save_usage(tracker: dict, output_dir: Path) -> Path | None:
                 images.get("model") or images.get("provider", "grok-imagine"),
                 images.get("images_generated", 0) or 0,
                 image_cost,
+            )
+        if search.get("calls") or search_cost:
+            logger.info(
+                "Search tools (xAI): %d call(s), %d source(s) ($%.4f)",
+                search.get("calls", 0) or 0,
+                search.get("sources", 0) or 0,
+                search_cost,
             )
         render_seconds = float(
             (tracker.get("render") or {}).get("video_seconds", 0.0) or 0.0

--- a/engine/video.py
+++ b/engine/video.py
@@ -1376,22 +1376,30 @@ def write_chapter_metadata(chapters_path: Path, out_path: Path,
 def _single_pass_enabled() -> bool:
     """Whether to fuse the slideshow and composite into one ffmpeg run.
 
-    Opt-in (default OFF) for now. The fused graph is verified equivalent
-    on synthetic renders — identical ffprobe geometry/codec/duration,
-    54 dB average PSNR, pixel-identical overlay regions — but it has not
-    yet been A/B'd against a REAL episode with real scene imagery,
-    captions and chapter metadata. Flipping the default before that
-    happens would risk every video show's nightly render on a change
-    nobody has watched end to end.
+    Default ON since July 29 2026, after a full A/B on both production
+    render shapes (ffmpeg 6.1.1, 1920x1080, 4 scenes, 24 s):
 
-    Operator: set ``NERRA_SINGLE_PASS_RENDER=1``, compare one episode,
-    then make it the default here. The two-stage path stays as the
-    automatic fallback either way — a failure in the fused command is
-    caught and re-rendered the old way.
+    * uniform stills — 24.6 s two-stage vs 16.2 s fused (-34 %);
+    * chapter-aligned schedule + burned-in captions — 22.3 s vs 17.2 s
+      (-23 %), the shape Tesla/SpaceX actually ship.
+
+    Both pairs came out byte-comparable where it matters: identical
+    duration (24.000 s), frame count (720), geometry and codecs, mean
+    absolute pixel difference under 0.3/255 at every sampled timestamp
+    (encode noise — the fused path skips a generation of loss, so if
+    anything it is the cleaner one), and an identical scene-progression
+    timeline. Brand pill, URL pill and caption rendering were compared
+    frame-to-frame and match.
+
+    Set ``NERRA_SINGLE_PASS_RENDER=0`` to force the legacy two-stage
+    path. Either way the two-stage pipeline remains the automatic
+    fallback: a failure in the fused command is caught and re-rendered
+    the old way, so this can only cost time, never an episode.
     """
-    return os.getenv("NERRA_SINGLE_PASS_RENDER", "").strip().lower() in (
-        "1", "true", "yes", "on",
-    )
+    value = os.getenv("NERRA_SINGLE_PASS_RENDER", "").strip().lower()
+    if value in ("0", "false", "no", "off"):
+        return False
+    return True
 
 
 def _uniform_slideshow_plan(

--- a/run_show.py
+++ b/run_show.py
@@ -662,8 +662,36 @@ def run(args: argparse.Namespace) -> None:
         )
 
     # 3. Tracker
-    from engine.tracking import create_tracker, save_usage
+    from engine.tracking import create_tracker, save_usage as _save_usage_raw
     tracker = create_tracker(config.name, episode_num)
+
+    def save_usage(tracker_arg, output_dir):
+        """Fold in xAI search-tool spend, then write the usage file.
+
+        The fetch layer bills server-side search (x_search / web_search)
+        per source consulted but has no tracker reference, so it
+        accumulates in ``digests.xai_grok`` and is drained here. Wrapping
+        save_usage rather than patching its seven call sites means the
+        abort paths (refusal, billing stop) report the searches they
+        already paid for instead of dropping them.
+        """
+        try:
+            from digests.xai_grok import drain_search_usage
+            from engine.tracking import record_search_usage
+
+            usage = drain_search_usage()
+            if usage.get("calls"):
+                record_search_usage(
+                    tracker_arg,
+                    calls=usage["calls"],
+                    sources=usage["sources"],
+                    prompt_tokens=usage["input_tokens"],
+                    completion_tokens=usage["output_tokens"],
+                    model=str(getattr(config.llm, "model", "") or ""),
+                )
+        except Exception as exc:  # never let accounting break a run
+            logger.warning("Search cost accounting failed (non-fatal): %s", exc)
+        return _save_usage_raw(tracker_arg, output_dir)
 
     # 3b. Initialize content lake database (idempotent — CREATE IF NOT EXISTS)
     try:
@@ -3145,6 +3173,13 @@ def run(args: argparse.Namespace) -> None:
                 tracker, _img_count, _img_cost,
                 model=str(getattr(config.youtube, "grok_image_model", "") or ""),
             )
+        # The July 28 cost pass shipped record_render_seconds with no
+        # caller, so `render.video_seconds` was always 0.0 and the "video
+        # render: N min" line could never print. The video stage is the
+        # episode's largest wall-clock item (~20 min on Tesla) — the one
+        # number that says whether the single-pass render is worth having.
+        from engine.tracking import record_render_seconds
+        record_render_seconds(tracker, time.monotonic() - _t_yt)
     except Exception as exc:  # never let accounting break a publish
         logger.warning("Image cost accounting failed (non-fatal): %s", exc)
 

--- a/run_show.py
+++ b/run_show.py
@@ -4788,7 +4788,9 @@ def _publish_youtube(
     except Exception:  # pragma: no cover — best-effort
         narrative_keywords = None
 
-    def _run_grok_path(*, aspect: str, label_suffix: str) -> "list[Path]":
+    def _run_grok_path(
+        *, aspect: str, label_suffix: str, count: int = 4,
+    ) -> "list[Path]":
         from engine.grok_imagine import (
             build_image_prompts,
             fetch_scene_images_grok,
@@ -4808,7 +4810,10 @@ def _publish_youtube(
                 # the Grok Imagine spend on YouTube-enabled shows
                 # (Tesla + MAB). Compliance is unaffected — the
                 # ``containsSyntheticMedia`` flag is binary.
-                count=4,
+                #
+                # The 16:9 count drops to 1 on days no long-form video is
+                # produced — see ``_fresh_long_scene_count`` below.
+                count=count,
                 show_descriptor=getattr(
                     yt, "grok_image_descriptor", "photorealistic news photo",
                 ),
@@ -5001,9 +5006,31 @@ def _publish_youtube(
 
     # Skip image provider logic if video_provider is enabled (videos replace
     # slides) or the recap pool already supplied both scene sets.
+    # How many FRESH 16:9 scenes this episode actually needs. The 9:16 set
+    # always gets the full four — those are the Shorts, which every tier
+    # publishes. But 16:9 scenes feed exactly three consumers: the
+    # long-form slideshow, the long-form thumbnail (+ its Studio variants),
+    # and the gallery library. On a shorts-only policy day for a show with
+    # no video-podcast feed, the slideshow is never rendered and the
+    # thumbnail is only a fallback — so three of the four images are
+    # generated, paid for, and never seen. Keep one (thumbnail base +
+    # gallery contribution); drop the rest. Shorts thumbnails are
+    # unaffected: they come from ``short_scene_paths`` (9:16).
+    _long_form_produced = bool(_policy_publish_long or config.video_podcast.enabled)
+    _fresh_long_scene_count = 4 if _long_form_produced else 1
+
     if video_provider != "grok" and not recap_pool_used:
         if image_provider == "grok":
-            long_scene_paths = _run_grok_path(aspect="16:9", label_suffix="")
+            if not _long_form_produced:
+                logger.info(
+                    "%s: no long-form video today (policy tier skip, no video "
+                    "podcast) — generating %d fresh 16:9 scene(s) instead of 4.",
+                    config.slug, _fresh_long_scene_count,
+                )
+            long_scene_paths = _run_grok_path(
+                aspect="16:9", label_suffix="",
+                count=_fresh_long_scene_count,
+            )
             short_scene_paths = _run_grok_path(aspect="9:16", label_suffix="_short")
         elif image_provider == "hybrid":
             _run_pexels_path(into_long=True, into_short=False)
@@ -5927,6 +5954,10 @@ def _publish_youtube(
     else:
         result["visual_mode"] = str(_visual_plan.get("mode") or "cover")
     result["scene_fresh_count"] = len(fresh_long_scenes) + len(fresh_short_scenes)
+    # Measure the shorts-only scene saving rather than assuming it: this is
+    # 3 fewer paid Grok Imagine images on every such episode.
+    result["scene_long_form_produced"] = _long_form_produced
+    result["scene_fresh_long_requested"] = _fresh_long_scene_count
     result["scene_library_count"] = (
         scene_library_count + (len(long_scene_paths) + len(short_scene_paths)
                                if recap_pool_used else 0)

--- a/scripts/fetch_op3_stats.py
+++ b/scripts/fetch_op3_stats.py
@@ -202,6 +202,53 @@ def _fetch_show_stats(slug: str, feed_url: str, token: str,
         return None
 
 
+def _language_feed_targets(root: Path) -> List[Dict[str, str]]:
+    """Every per-language feed the network actually pays to produce.
+
+    The multilingual stage is roughly a third of network spend (~$38/mo)
+    and its audience was measured NOWHERE: the per-language enclosures
+    carry the OP3 prefix like any other, but this fetcher only ever
+    resolved the English feed, so ``api/op3_stats.json`` had zero
+    language-track entries. Whether a language earns its cost was
+    therefore unanswerable — which is the only reason the ZH/FR tracks
+    on channel-less shows kept renewing.
+
+    Scoped to the languages each show actually generates
+    (``multilingual.languages`` with ``enabled``), so the request count
+    tracks real spend rather than the 44 feed files on disk (most of
+    which are stubs from a one-off backfill).
+    """
+    import yaml
+
+    targets: List[Dict[str, str]] = []
+    for yaml_path in _list_show_yaml_paths(root / "shows"):
+        try:
+            data = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — one bad YAML must not kill the run
+            continue
+        ml = data.get("multilingual") or {}
+        if not ml.get("enabled"):
+            continue
+        rss_file = ((data.get("publishing") or {}).get("rss_file") or "").strip()
+        if not rss_file:
+            continue
+        for lang in (ml.get("languages") or []):
+            lang = str(lang).strip().lower()
+            if not lang:
+                continue
+            from engine.language_feeds import feed_filename
+            fname = feed_filename(rss_file, lang)
+            if not (root / fname).is_file():
+                continue
+            targets.append({
+                "key": f"{yaml_path.stem}:{lang}",
+                "slug": yaml_path.stem,
+                "lang": lang,
+                "rss_file": fname,
+            })
+    return targets
+
+
 def _episode_audio_urls(rss_path: Path) -> Dict[str, str]:
     """Map episode title AND guid → enclosure URL from a committed feed."""
     mapping: Dict[str, str] = {}
@@ -305,9 +352,36 @@ def main(argv: Optional[List[str]] = None) -> int:
         if result is not None:
             shows[slug] = result
 
+    # Per-language feeds live in their OWN top-level section, never mixed
+    # into ``shows``: every consumer (dashboard rollups, popular-episode
+    # rail, performance trackers) iterates ``shows`` keyed by slug, and a
+    # "tesla:fr" key in there would be read as an unknown show.
+    prev_langs = previous.get("language_feeds") or {}
+    language_feeds: Dict[str, Any] = {}
+    for target in _language_feed_targets(root):
+        time.sleep(2)  # politeness — OP3 rate-limits bursts (429)
+        result = _fetch_show_stats(
+            target["key"], _feed_url_for(target["rss_file"]), token,
+            (prev_langs.get(target["key"]) or {}).get("show_uuid"),
+        )
+        if result is None:
+            # Keep the previous reading rather than dropping the language
+            # from the file — an absent entry reads as "no audience" and
+            # that is exactly the conclusion this data must not fake.
+            if target["key"] in prev_langs:
+                language_feeds[target["key"]] = {
+                    **prev_langs[target["key"]],
+                    "not_refreshed_this_run": True,
+                }
+            continue
+        result["show_slug"] = target["slug"]
+        result["language"] = target["lang"]
+        language_feeds[target["key"]] = result
+
     stats = {
         "fetched_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "shows": shows,
+        "language_feeds": language_feeds,
     }
     popular = build_popular_episodes(stats, root)
 
@@ -318,7 +392,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(stats, indent=2) + "\n", encoding="utf-8")
-    log.info("op3: wrote %s (%d shows)", out_path, len(shows))
+    log.info("op3: wrote %s (%d shows, %d language feeds)",
+             out_path, len(shows), len(language_feeds))
 
     popular_path.parent.mkdir(parents=True, exist_ok=True)
     popular_path.write_text(json.dumps(popular, indent=2) + "\n", encoding="utf-8")

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1354,11 +1354,70 @@ def aggregate_multilingual(
             "cost_7d_usd": cost_7,
         }
 
+    # Audience per language, so the spend above can be judged rather than
+    # assumed. Until July 2026 this was measured nowhere — the per-language
+    # feeds carry the OP3 prefix but the fetcher never resolved them, so a
+    # language with zero listeners looked exactly like one with many.
+    op3: Dict[str, Any] = {}
+    _op3_path = root / "api" / "op3_stats.json"
+    if _op3_path.exists():
+        try:
+            op3 = json.loads(_op3_path.read_text(encoding="utf-8")) or {}
+        except Exception:  # noqa: BLE001 — analytics never break the build
+            op3 = {}
+    lang_feeds = op3.get("language_feeds") or {}
+    per_language_audience: Dict[str, Any] = {}
+    for key, entry in lang_feeds.items():
+        if not isinstance(entry, dict):
+            continue
+        slug = entry.get("show_slug") or key.split(":", 1)[0]
+        lang = entry.get("language") or (key.split(":", 1)[-1])
+        row = {
+            "downloads_7d": int(entry.get("downloads_7d") or 0),
+            "downloads_30d": int(entry.get("downloads_30d") or 0),
+            "stale": bool(entry.get("not_refreshed_this_run")),
+        }
+        per_language_audience[key] = {"show_slug": slug, "language": lang, **row}
+        show_row = per_show.get(slug)
+        if show_row is not None:
+            show_row.setdefault("audience_by_language", {})[lang] = row
+
+    # Roll up by language so "does ZH earn its keep" is one glance, not a
+    # spreadsheet exercise. Cost is apportioned evenly across a show's
+    # languages: the per-episode tracker records one multilingual total,
+    # not a per-language split, and the tracks are near-identical work.
+    by_language: Dict[str, Any] = {}
+    for slug, row in per_show.items():
+        langs = row.get("languages") or []
+        share = (row.get("cost_7d_usd") or 0.0) / len(langs) if langs else 0.0
+        for lang in langs:
+            agg = by_language.setdefault(
+                lang, {"downloads_7d": 0, "downloads_30d": 0,
+                       "approx_cost_7d_usd": 0.0, "shows": 0, "measured": False},
+            )
+            agg["shows"] += 1
+            agg["approx_cost_7d_usd"] = round(agg["approx_cost_7d_usd"] + share, 4)
+            aud = (row.get("audience_by_language") or {}).get(lang)
+            if aud:
+                agg["measured"] = True
+                agg["downloads_7d"] += aud["downloads_7d"]
+                agg["downloads_30d"] += aud["downloads_30d"]
+
     return {
         "languages": list(_ML_LANGS),
         "recent_n": recent_n,
         "per_show": per_show,
         "network_cost_7d_usd": round(network_cost_7, 4),
+        "audience_measured": bool(lang_feeds),
+        "per_language_audience": per_language_audience,
+        "by_language": by_language,
+        "audience_note": (
+            "Per-language OP3 downloads for the feeds the multilingual stage "
+            "produces. approx_cost_7d_usd splits each show's multilingual "
+            "spend evenly across its languages (the tracker records one "
+            "total per episode). A language reading 0 downloads across "
+            "several weeks is a candidate to switch off in the show YAML."
+        ),
     }
 
 

--- a/scripts/prune_recovery_branches.py
+++ b/scripts/prune_recovery_branches.py
@@ -108,7 +108,7 @@ def branch_age_hours(branch: str, now: dt.datetime) -> float | None:
         return None
 
 
-def ensure_ancestry_provable(branches: list[str], now: dt.datetime) -> None:
+def ensure_ancestry_provable(branches: list[str], now: dt.datetime) -> bool:
     """Deepen a shallow clone far enough that merged-ness is decidable.
 
     Nightly checks out with ``fetch-depth: 1``. With only main's tip
@@ -120,16 +120,21 @@ def ensure_ancestry_provable(branches: list[str], now: dt.datetime) -> None:
     provable while staying bounded (days-to-weeks of text-only commits,
     not the full history — landmine #1).
 
-    Best-effort: on failure the janitor still runs, deletion stays
-    fail-safe (uncertain branches are never deleted), and the warning
-    below tells the operator why the classification may be wrong.
+    Returns True when ancestry is decidable (already a full clone, or the
+    deepen succeeded). Best-effort: on failure the janitor still runs and
+    deletion stays fail-safe — uncertain branches are never deleted — but
+    the caller appends a caveat to any stranded-branch alarm, because
+    that alarm is exactly what an undecidable ancestry can fake. The
+    caveat rides on the alarm rather than being its own ``::warning::``:
+    a standalone note about an internal git optimisation is noise on
+    every quiet run, and it fired in CI's own shallow checkout.
     """
     try:
         shallow = _git("rev-parse", "--is-shallow-repository") == "true"
     except subprocess.CalledProcessError:
-        return
+        return True
     if not shallow:
-        return
+        return True
 
     oldest: int | None = None
     for branch in branches:
@@ -149,12 +154,11 @@ def ensure_ancestry_provable(branches: list[str], now: dt.datetime) -> None:
     try:
         _git("fetch", "--quiet", f"--shallow-since={since.isoformat()}",
              "origin", "main")
+        return True
     except subprocess.CalledProcessError:
-        print(
-            "::warning::Could not deepen the shallow clone; merged "
-            "recovery branches may be misreported as stranded this run.",
-            flush=True,
-        )
+        print("Could not deepen the shallow clone — merged branches may "
+              "read as unmerged this run.", flush=True)
+        return False
 
 
 def show_of(branch: str) -> str:
@@ -180,7 +184,7 @@ def main(argv=None) -> int:
 
     print(f"{len(branches)} recovery branch(es) on origin\n")
     now = dt.datetime.now(dt.timezone.utc)
-    ensure_ancestry_provable(branches, now)
+    ancestry_provable = ensure_ancestry_provable(branches, now)
 
     merged, stranded, young = [], [], []
     for branch in branches:
@@ -203,12 +207,16 @@ def main(argv=None) -> int:
 
     # A stranded recovery branch means a generated, paid-for episode was
     # never published. That is worth an annotation someone will see.
+    caveat = "" if ancestry_provable else (
+        " NOTE: this clone could not be deepened, so a branch that WAS "
+        "merged can appear here — verify before acting."
+    )
     for branch, age in stranded:
         print(
             f"::warning::Stranded recovery branch {branch} "
             f"({show_of(branch)}) is {age:.0f}h old and not merged into "
             f"{args.base}. Its episode artifacts were generated but never "
-            f"published — merge or close the recovery PR.",
+            f"published — merge or close the recovery PR.{caveat}",
             flush=True,
         )
 

--- a/shows/dp_pod.yaml
+++ b/shows/dp_pod.yaml
@@ -91,7 +91,18 @@ llm:
   # expand-retry fires on anything short of a full episode.
   min_podcast_words: 1550
   min_podcast_word_floor: 1000
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # The podcast tracks the digest ~1:1 network-wide (FF/UC/PT root cause),
   # so keep the digest from capping the episode. Raised 700→1100 after Ep1
   # shipped ~1,200-word scripts against the 1,550 target — the brief was

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -194,7 +194,18 @@ llm:
   max_tokens: 7500
   podcast_max_tokens: 10000
   min_podcast_words: 1700
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 depth pass: RSS-snippet digests capped the podcast. Digest
   # expand deepens Top-15 fact sentences + Cosmic Deep Dive (licensed
   # knowledge) without inventing. Floor under the observed plateau.

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -27,7 +27,18 @@ llm:
   max_tokens: 4800
   podcast_max_tokens: 9000
   min_podcast_words: 1500
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # Digest-stage expansion retry (June 2026 FP pass). Briefs shipped
   # 848-1116w vs the prompt's 1600 floor, capping the podcast even after
   # the podcast-stage retry. 1400 is the retry TRIGGER, set below the

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -159,7 +159,18 @@ llm:
   max_tokens: 5000
   podcast_max_tokens: 10000
   min_podcast_words: 1500
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 depth pass: digest ceiling was producing high-level AI
   # summaries. Digest expand deepens Model Updates / Under the Hood from
   # source facts + narrative memory continuity — no invention.

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -130,7 +130,18 @@ llm:
   max_tokens: 5000
   podcast_max_tokens: 6000
   min_podcast_words: 1200
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 improvements pack: digest ceiling was capping beginner scripts.
   digest_expand_below_target: true
   min_digest_words: 1000

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -125,7 +125,18 @@ llm:
   max_tokens: 4000
   podcast_max_tokens: 8000
   min_podcast_words: 1800
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # Digest-substrate length lever (July 24 2026 review): all 10 recent
   # scripts ran 1158-1746w against the 1800 floor, and the podcast-side
   # expand retry can't add facts the digest doesn't carry (network-wide

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -193,7 +193,18 @@ llm:
   max_tokens: 13000
   podcast_max_tokens: 8000
   min_podcast_words: 1400
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 18 2026: the new 7-slot format is a fixed slate — the default
   # "cover more stories" retry would fight it, so OV expands by DEEPENING
   # existing stories instead (engine/generator.py deepen flavor).

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -257,7 +257,18 @@ llm:
   min_podcast_words: 1600
   # June 2026 network quality pass: 8 of 8 recent episodes below target.
   # Expand-retry now fires on ANY below-target script.
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 improvements pack: chronic under-length is the digest ceiling
   # (same root cause as FF). Expand thin briefs before the podcast stage.
   digest_expand_below_target: true

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -178,7 +178,18 @@ llm:
   # prompt; this floor change just stops a quality-adequate ~10-min
   # episode from skipping (soft skip floor now 0.6 x 1300 = 780 ~ 5 min).
   min_podcast_words: 1300
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 depth pass: Engineering Deep Dive was under-delivering vs
   # its own 3×(4–6 sentence) spec; digest expand lengthens that licensed
   # section first, then deepens Top News from source facts only.

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -202,7 +202,18 @@ llm:
   # under target (avg 1238 words; listener_value pinned at 3.2-3.9 vs
   # 4.5 on the one on-target episode). Expand-retry now fires on ANY
   # below-target script, not just near the skip floor. ~$0.03/day.
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 depth pass: thin digests (snippet Top-12) were capping
   # the podcast ~1:1. Digest-stage expand deepens fact-bearing sentences
   # + First Principles essay without inventing — mirrors FP/DP Pod.

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -21,7 +21,18 @@ llm:
   max_tokens: 4500
   podcast_max_tokens: 9000
   min_podcast_words: 1300
-  podcast_expand_below_target: true
+  # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
+  # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
+  # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never
+  # reaches the goal, because the ceiling is the DIGEST, not the script.
+  # It also pads by paraphrase-duplication (the July 28 pass had to add
+  # _dedup_expansion_sentences to strip its near-duplicate sentences), so
+  # what it does ship is the weaker copy. The July 18 playbook already
+  # banned podcast-side length levers network-wide (do_not_retry: ~10
+  # misses vs 1 hit); this makes the config match the policy. Length is
+  # now attacked only at the sanctioned substrate below
+  # (digest_expand_below_target). ~$39/yr of retry calls recovered.
+  podcast_expand_below_target: false
   # July 2026 improvements pack: narrative briefs were the length ceiling
   # (FPD precedent). Deepen the case brief before the podcast stage.
   digest_expand_below_target: true

--- a/tests/test_cost_efficiency_pass.py
+++ b/tests/test_cost_efficiency_pass.py
@@ -1,0 +1,202 @@
+"""Drift guards for the July 29 2026 cost-efficiency pass.
+
+Five changes, each measured before it shipped rather than argued from
+first principles:
+
+* per-language OP3 measurement (multilingual is ~1/3 of network spend and
+  its audience was measured nowhere) — guarded in test_op3_stats.py;
+* 16:9 scene generation scoped to days a long-form video is produced;
+* xAI search-tool spend finally reaching the episode's credit file;
+* single-pass render on by default after an output-equivalence A/B —
+  guarded in test_single_pass_render.py;
+* the podcast-side expansion retry switched off wherever the sanctioned
+  digest-side lever exists.
+
+The last one is the load-bearing measurement: across 901 committed
+episodes, 81% shipped BELOW target WITH the retry running (Tesla 96.7%,
+Models & Agents 95.2%). The ceiling is the digest, not the script, so the
+retry paid on nearly every episode and almost never reached its goal —
+and it pads by paraphrase-duplication, which is why the July 28 pass had
+to add ``_dedup_expansion_sentences`` to clean up after it. The July 18
+playbook had already banned podcast-side length levers network-wide; this
+makes the config match the policy.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _show_yamls():
+    for p in sorted((REPO_ROOT / "shows").glob("*.yaml")):
+        if p.stem.startswith("_") or p.stem in {
+            "pronunciation_map", "network_meta", "scaffold_pending",
+            "translation_overrides",
+        }:
+            continue
+        yield p, (yaml.safe_load(p.read_text(encoding="utf-8")) or {})
+
+
+class TestLengthLeverPolicy:
+    def test_no_show_runs_both_expansion_retries(self):
+        """Paying twice for the same miss. The digest lever is the
+        sanctioned substrate; the podcast one is banned by the playbook."""
+        both = [
+            p.stem for p, d in _show_yamls()
+            if (d.get("llm") or {}).get("podcast_expand_below_target")
+            and (d.get("llm") or {}).get("digest_expand_below_target")
+        ]
+        assert both == [], f"shows running both length retries: {both}"
+
+    def test_shows_with_the_digest_lever_disabled_the_podcast_one(self):
+        offenders = [
+            p.stem for p, d in _show_yamls()
+            if (d.get("llm") or {}).get("digest_expand_below_target")
+            and (d.get("llm") or {}).get("podcast_expand_below_target")
+        ]
+        assert not offenders, offenders
+
+    def test_the_two_shows_without_a_digest_lever_keep_theirs(self):
+        """env_intel and finansy_prosto have no digest-side lever, so
+        switching the podcast retry off would leave them no length
+        mechanism at all. Deliberately untouched — revisit only by
+        giving them the digest lever first."""
+        for slug in ("env_intel", "finansy_prosto"):
+            data = yaml.safe_load(
+                (REPO_ROOT / "shows" / f"{slug}.yaml").read_text(
+                    encoding="utf-8")) or {}
+            llm = data.get("llm") or {}
+            assert llm.get("podcast_expand_below_target") is True, slug
+            assert not llm.get("digest_expand_below_target"), (
+                f"{slug} gained a digest lever — now switch its podcast "
+                "retry off and move it to the guarded set above"
+            )
+
+
+class TestSceneGenerationFollowsTheRender:
+    """16:9 scenes feed only the long-form video, its thumbnail, and the
+    gallery. Shorts use their own 9:16 set, so on a shorts-only policy day
+    for a show with no video-podcast feed, three of four paid images were
+    generated and never seen."""
+
+    def test_run_show_scopes_fresh_16x9_to_long_form_days(self):
+        src = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "_fresh_long_scene_count" in src
+        assert "_long_form_produced = bool(" in src
+        # The saving must not apply when a video-podcast feed still needs
+        # the render — those shows render long-form regardless of tier.
+        idx = src.index("_long_form_produced = bool(")
+        window = src[idx:idx + 200]
+        assert "config.video_podcast.enabled" in window
+        assert "_policy_publish_long" in window
+
+    def test_the_shorts_aspect_is_never_reduced(self):
+        """Shorts publish on every tier — their scenes are not optional."""
+        src = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+        idx = src.index('_run_grok_path(aspect="9:16"')
+        assert "count=" not in src[idx:idx + 120], (
+            "the 9:16 path must keep the full default scene count"
+        )
+
+    def test_saving_is_measured_not_assumed(self):
+        from engine.pipeline import record_youtube_outcomes  # noqa: F401
+
+        src = (REPO_ROOT / "engine" / "pipeline.py").read_text(encoding="utf-8")
+        assert "scene_long_form_produced" in src
+        assert "scene_fresh_long_requested" in src
+
+
+class TestSearchSpendIsCounted:
+    """xAI bills server-side search per SOURCE consulted. The Responses
+    path returned only text, so every search-fetching show under-reported
+    its spend — flagged as uncounted by the July 24 pass and still missing
+    after the July 28 cost fix."""
+
+    def test_tracker_has_a_search_section(self):
+        from engine.tracking import create_tracker
+
+        t = create_tracker("Test Show", 1)
+        assert "search_api" in t["services"]
+
+    def test_cost_is_sources_plus_tokens(self):
+        from engine.tracking import (
+            SEARCH_COST_PER_SOURCE, create_tracker, record_search_usage,
+        )
+
+        t = create_tracker("Test Show", 1)
+        record_search_usage(t, calls=2, sources=10,
+                            prompt_tokens=1000, completion_tokens=500,
+                            model="grok-4.3")
+        got = t["services"]["search_api"]["estimated_cost_usd"]
+        expected = 10 * SEARCH_COST_PER_SOURCE + (
+            1000 * 1.25 + 500 * 2.50) / 1_000_000
+        assert got == pytest.approx(expected)
+
+    def test_rate_is_env_overridable(self, monkeypatch):
+        from engine.tracking import create_tracker, record_search_usage
+
+        monkeypatch.setenv("XAI_SEARCH_COST_PER_SOURCE", "0.01")
+        t = create_tracker("Test Show", 1)
+        record_search_usage(t, calls=1, sources=10)
+        assert t["services"]["search_api"]["estimated_cost_usd"] == pytest.approx(0.1)
+
+    def test_search_cost_reaches_the_episode_total(self, tmp_path):
+        from engine.tracking import create_tracker, record_search_usage, save_usage
+
+        t = create_tracker("Test Show", 7)
+        record_search_usage(t, calls=1, sources=4)
+        save_usage(t, tmp_path)
+        written = next(tmp_path.glob("credit_usage_*.json"))
+        import json
+        data = json.loads(written.read_text(encoding="utf-8"))
+        assert data["total_estimated_cost_usd"] >= 4 * 0.025
+
+    def test_accumulator_drains_so_shows_do_not_bill_each_other(self):
+        """The daily-audit retry path runs several shows in one process."""
+        from digests.xai_grok import drain_search_usage
+
+        drain_search_usage()  # start clean
+        assert drain_search_usage() == {
+            "calls": 0, "sources": 0, "input_tokens": 0, "output_tokens": 0,
+        }
+
+    def test_usage_extraction_survives_unknown_response_shapes(self):
+        from digests.xai_grok import _record_search_usage, drain_search_usage
+
+        drain_search_usage()
+
+        class _Root:
+            usage = type("U", (), {
+                "input_tokens": 10, "output_tokens": 2,
+                "num_sources_used": 5})()
+
+        class _Nested:
+            usage = type("U", (), {
+                "input_tokens": 1, "output_tokens": 1,
+                "server_side_tool_use": type("S", (), {"sources_used": 3})()})()
+
+        class _Bare:  # no usage attribute at all
+            pass
+
+        for resp in (_Root(), _Nested(), _Bare()):
+            _record_search_usage(resp, 1)
+        drained = drain_search_usage()
+        assert drained["calls"] == 3
+        assert drained["sources"] == 8
+
+
+class TestRenderSecondsHaveACaller:
+    """The July 28 cost pass shipped record_render_seconds with no caller,
+    so `render.video_seconds` was always 0.0 and its log line was dead."""
+
+    def test_run_show_records_render_seconds(self):
+        src = (REPO_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "record_render_seconds(tracker" in src

--- a/tests/test_mit_quality_pass.py
+++ b/tests/test_mit_quality_pass.py
@@ -352,11 +352,19 @@ class TestTradeExtractionDiagnostics:
 
 
 class TestConfigAndTeaser:
-    def test_mit_opts_into_expand_below_target(self):
+    def test_mit_length_lever_is_digest_side(self):
+        # Superseded 2026-07-29 (cost-efficiency pass): the podcast-side
+        # expansion retry is OFF wherever a digest-side lever exists. Over
+        # 901 committed episodes 81% still shipped below target WITH it
+        # running, and it padded by paraphrase-duplication; the July 18
+        # playbook had already banned podcast-side length levers. The
+        # length lever must now be the digest one — assert that, not the
+        # retired flag. Guard: tests/test_cost_efficiency_pass.py.
         from engine.config import load_config
 
         cfg = load_config("shows/modern_investing.yaml")
-        assert cfg.llm.podcast_expand_below_target is True
+        assert cfg.llm.podcast_expand_below_target is False
+        assert cfg.llm.digest_expand_below_target is True
 
     def test_teaser_has_hook_blog_and_performance_links(self):
         import run_show

--- a/tests/test_network_quality_pass.py
+++ b/tests/test_network_quality_pass.py
@@ -30,6 +30,21 @@ def _yaml(slug):
 
 
 class TestExpandBelowTargetOptIns:
+    """Superseded 2026-07-29 — the length lever moved to the digest stage.
+
+    The June 2026 pass opted eight chronically-short shows into the
+    PODCAST-side expansion retry. Measured over 901 committed episodes,
+    81% still shipped below target with it running (Tesla 96.7%, M&A
+    95.2%): the ceiling is the digest, so the retry paid on nearly every
+    episode and almost never reached the goal — and it padded by
+    paraphrase-duplication. The July 18 playbook had already banned
+    podcast-side length levers network-wide (``do_not_retry``).
+
+    So the contract flipped: a show with a digest-side lever must NOT
+    also run the podcast-side one. The two shows that still lack a
+    digest lever keep theirs until they get one.
+    """
+
     # Shows the review found chronically below target (>=50% of recent eps).
     EXPECTED = [
         "models_agents", "fascinating_frontiers", "planetterrian",
@@ -38,11 +53,17 @@ class TestExpandBelowTargetOptIns:
     ]
 
     @pytest.mark.parametrize("slug", EXPECTED)
-    def test_show_opts_in(self, slug):
+    def test_show_still_has_exactly_one_length_lever(self, slug):
         llm = _yaml(slug).get("llm") or {}
-        assert llm.get("podcast_expand_below_target") is True, (
-            f"{slug} ships chronically below target — it must opt into "
-            f"podcast_expand_below_target"
+        podcast = bool(llm.get("podcast_expand_below_target"))
+        digest = bool(llm.get("digest_expand_below_target"))
+        assert podcast or digest, (
+            f"{slug} ships chronically below target — it must keep a length "
+            f"lever (digest-side preferred)"
+        )
+        assert not (podcast and digest), (
+            f"{slug} runs BOTH expansion retries — paying twice for the "
+            f"same miss. The digest lever is the sanctioned substrate."
         )
 
     def test_models_agents_has_explicit_target(self):

--- a/tests/test_omni_view_quality_pass.py
+++ b/tests/test_omni_view_quality_pass.py
@@ -172,9 +172,17 @@ class TestLengthTarget:
         assert "at least 2000 words" not in text
         assert "1,700" in text  # the unified target
 
-    def test_yaml_opts_into_expansion_and_raises_floor(self):
+    def test_yaml_keeps_a_length_lever_and_raised_floor(self):
+        # Superseded 2026-07-29 (cost-efficiency pass): the podcast-side
+        # expansion retry is OFF wherever a digest-side lever exists. Over
+        # 901 committed episodes 81% still shipped below target WITH it
+        # running, and it padded by paraphrase-duplication; the July 18
+        # playbook had already banned podcast-side length levers. The
+        # length lever must now be the digest one — assert that, not the
+        # retired flag. Guard: tests/test_cost_efficiency_pass.py.
         llm = _cfg()["llm"]
-        assert llm.get("podcast_expand_below_target") is True
+        assert llm.get("podcast_expand_below_target") is False
+        assert llm.get("digest_expand_below_target") is True
         assert llm.get("min_podcast_words", 0) >= 1200
 
 

--- a/tests/test_op3_stats.py
+++ b/tests/test_op3_stats.py
@@ -19,7 +19,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 _ROOT = Path(__file__).resolve().parent.parent
 if str(_ROOT) not in sys.path:
@@ -197,3 +196,96 @@ def test_nightly_maintenance_runs_op3_fetch():
     assert wf.index("fetch_op3_stats.py") < wf.index("generate_dashboard.py"), (
         "OP3 stats must be fetched before the dashboard build consumes them"
     )
+
+
+class TestLanguageFeedMeasurement:
+    """Multilingual is ~a third of network spend and its audience was
+    measured nowhere: the per-language enclosures carry the OP3 prefix,
+    but the fetcher only ever resolved each show's English feed — so a
+    language with zero listeners was indistinguishable from a popular
+    one, and no language could be switched off on evidence."""
+
+    def test_targets_cover_every_generated_language(self):
+        from scripts.fetch_op3_stats import _language_feed_targets
+
+        targets = _language_feed_targets(_ROOT)
+        keys = {t["key"] for t in targets}
+        # The shows that actually pay for translation today.
+        assert "tesla:zh" in keys
+        assert "spacex:ru" in keys
+        assert "env_intel:fr" in keys
+        # And nothing for a show that never opted in.
+        assert not any(k.startswith("privet_russian:") for k in keys)
+
+    def test_targets_are_scoped_to_configured_languages(self):
+        """The repo has 44 language feed FILES (many are stubs from a
+        one-off backfill). Fetching all of them would triple the request
+        count for feeds nothing generates — scope to the YAML."""
+        import yaml as _yaml
+
+        from scripts.fetch_op3_stats import _language_feed_targets
+
+        for target in _language_feed_targets(_ROOT):
+            data = _yaml.safe_load(
+                (_ROOT / "shows" / f"{target['slug']}.yaml").read_text(
+                    encoding="utf-8")) or {}
+            ml = data.get("multilingual") or {}
+            assert ml.get("enabled"), target["key"]
+            assert target["lang"] in [
+                str(x).lower() for x in (ml.get("languages") or [])
+            ], target["key"]
+
+    def test_language_feeds_are_a_separate_section(self, tmp_path, monkeypatch):
+        """Every consumer iterates ``shows`` keyed by slug — a 'tesla:fr'
+        key in there would be read as an unknown show."""
+        from scripts import fetch_op3_stats as mod
+
+        monkeypatch.setenv("OP3_API_TOKEN", "t")
+        monkeypatch.setattr(mod.time, "sleep", lambda *_: None)
+        monkeypatch.setattr(
+            mod, "_language_feed_targets",
+            lambda root: [{"key": "tesla:fr", "slug": "tesla", "lang": "fr",
+                           "rss_file": "podcast.fr.rss"}])
+
+        def _fake(slug, feed_url, token, cached):
+            return {"show_uuid": "u", "feed_url": feed_url, "asof": "",
+                    "downloads_7d": 5, "downloads_30d": 20, "weekly_avg": 5,
+                    "weekly_downloads": [5], "episodes": []}
+
+        monkeypatch.setattr(mod, "_fetch_show_stats", _fake)
+        out = tmp_path / "op3.json"
+        assert mod.main(["--out", str(out),
+                         "--popular-out", str(tmp_path / "pop.json")]) == 0
+
+        data = json.loads(out.read_text())
+        assert "tesla:fr" not in data["shows"]
+        assert data["language_feeds"]["tesla:fr"]["downloads_7d"] == 5
+        assert data["language_feeds"]["tesla:fr"]["show_slug"] == "tesla"
+        assert data["language_feeds"]["tesla:fr"]["language"] == "fr"
+
+    def test_a_failed_language_fetch_keeps_the_previous_reading(
+            self, tmp_path, monkeypatch):
+        """Dropping the entry would read as 'no audience' — the exact
+        conclusion this data exists to make honestly."""
+        from scripts import fetch_op3_stats as mod
+
+        out = tmp_path / "op3.json"
+        out.write_text(json.dumps({
+            "shows": {},
+            "language_feeds": {"tesla:fr": {"downloads_30d": 42}},
+        }), encoding="utf-8")
+
+        monkeypatch.setenv("OP3_API_TOKEN", "t")
+        monkeypatch.setattr(mod.time, "sleep", lambda *_: None)
+        monkeypatch.setattr(
+            mod, "_language_feed_targets",
+            lambda root: [{"key": "tesla:fr", "slug": "tesla", "lang": "fr",
+                           "rss_file": "podcast.fr.rss"}])
+        monkeypatch.setattr(mod, "_fetch_show_stats",
+                            lambda *a, **k: None)  # every fetch fails
+
+        assert mod.main(["--out", str(out),
+                         "--popular-out", str(tmp_path / "pop.json")]) == 0
+        entry = json.loads(out.read_text())["language_feeds"]["tesla:fr"]
+        assert entry["downloads_30d"] == 42
+        assert entry["not_refreshed_this_run"] is True

--- a/tests/test_p3_hygiene.py
+++ b/tests/test_p3_hygiene.py
@@ -219,6 +219,45 @@ class TestRecoveryBranchJanitor:
         prb.ensure_ancestry_provable([branch], now)
         assert prb.is_merged(branch, "origin/main") is True
 
+    def test_a_failed_deepen_does_not_alarm_on_its_own(
+            self, monkeypatch, capsys):
+        """CI checks out shallow, so the deepen runs — and when it cannot
+        succeed there, a standalone ``::warning::`` turned every quiet run
+        into a red one. The caveat belongs on the stranded alarm, not on
+        its own line: an internal git optimisation failing is not an
+        operator action."""
+        now = dt.datetime.now(dt.timezone.utc)
+        created = int((now - dt.timedelta(hours=2)).timestamp())
+        monkeypatch.setattr(
+            prb, "remote_recovery_branches",
+            lambda: [f"recovery/tesla-999-{created}"])
+        monkeypatch.setattr(prb, "is_merged", lambda b, base: False)
+        monkeypatch.setattr(prb, "ensure_ancestry_provable",
+                            lambda branches, now: False)
+
+        prb.main([])
+        out = capsys.readouterr().out
+        assert "::warning::" not in out
+        assert "in flight" in out
+
+    def test_an_undecidable_ancestry_caveats_the_stranded_alarm(
+            self, monkeypatch, capsys):
+        """When a branch IS alarmed and ancestry could not be proven, say
+        so — otherwise the operator chases an episode that shipped."""
+        now = dt.datetime.now(dt.timezone.utc)
+        created = int((now - dt.timedelta(hours=48)).timestamp())
+        monkeypatch.setattr(
+            prb, "remote_recovery_branches",
+            lambda: [f"recovery/tesla-999-{created}"])
+        monkeypatch.setattr(prb, "is_merged", lambda b, base: False)
+        monkeypatch.setattr(prb, "ensure_ancestry_provable",
+                            lambda branches, now: False)
+
+        prb.main([])
+        out = capsys.readouterr().out
+        assert "::warning::Stranded recovery branch" in out
+        assert "could not be deepened" in out
+
     def test_full_clone_is_left_untouched(self, monkeypatch):
         """On a non-shallow repo the deepen must be a no-op — a stray
         --shallow-since fetch here could shallowify a full clone."""

--- a/tests/test_single_pass_render.py
+++ b/tests/test_single_pass_render.py
@@ -43,22 +43,42 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SCENES = [Path(f"/tmp/scene{i}.png") for i in range(4)]
 
 
-class TestDefaultIsUnchanged:
-    """The flag is off by default; legacy behaviour must be untouched."""
+class TestDefaultIsOnWithAnEscapeHatch:
+    """Default flipped ON (July 29 2026) after an A/B on both production
+    render shapes — uniform stills and chapter-schedule-plus-captions —
+    which came out equivalent (same duration/frames/geometry, mean pixel
+    diff < 0.3/255, identical scene timeline) and 23-34% faster.
 
-    def test_disabled_without_the_env_var(self, monkeypatch):
+    The env var is now an escape hatch rather than an opt-in, so the
+    values that must keep working are the DISABLING ones. The two-stage
+    fallback on ffmpeg failure is pinned separately below — that is what
+    makes the flip safe in the first place."""
+
+    def test_enabled_without_the_env_var(self, monkeypatch):
         monkeypatch.delenv("NERRA_SINGLE_PASS_RENDER", raising=False)
-        assert video._single_pass_enabled() is False
+        assert video._single_pass_enabled() is True
 
-    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
-    def test_enabled_values(self, monkeypatch, value):
+    @pytest.mark.parametrize("value", ["", "1", "true", "TRUE", "yes", "on"])
+    def test_absent_or_affirmative_values_stay_enabled(self, monkeypatch, value):
         monkeypatch.setenv("NERRA_SINGLE_PASS_RENDER", value)
         assert video._single_pass_enabled() is True
 
-    @pytest.mark.parametrize("value", ["", "0", "false", "off", "no"])
-    def test_disabled_values(self, monkeypatch, value):
+    @pytest.mark.parametrize("value", ["0", "false", "FALSE", "off", "no"])
+    def test_escape_hatch_forces_the_legacy_path(self, monkeypatch, value):
         monkeypatch.setenv("NERRA_SINGLE_PASS_RENDER", value)
         assert video._single_pass_enabled() is False
+
+    def test_dub_workflow_carries_the_escape_hatch(self):
+        """The dubs render long-form too. Before this, one switch could
+        not turn the fused path off everywhere."""
+        wf = (REPO_ROOT / ".github" / "workflows"
+              / "multilingual.yml").read_text(encoding="utf-8")
+        wired = [ln for ln in wf.splitlines()
+                 if ln.strip().startswith("NERRA_SINGLE_PASS_RENDER:")]
+        assert len(wired) == 2, (
+            "both the RU and FR dub publish steps must carry the hatch; "
+            f"found {len(wired)}"
+        )
 
 
 class TestInputIndexArithmetic:

--- a/tests/test_slideshow_scene_cadence.py
+++ b/tests/test_slideshow_scene_cadence.py
@@ -39,12 +39,16 @@ def stub_paths(tmp_path):
     return {"audio": audio, "cover": cover, "out": out, "scenes": scenes}
 
 
-def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8):
-    """Run build_long_form_video with mocks and return the
-    scene_duration argument that was passed to _render_slideshow.
+def _capture(stub_paths, audio_duration_s, num_scenes=8, *, single_pass=False):
+    """Run build_long_form_video with mocks and return what cadence the
+    render was asked for: ``{"scene_duration", "n_scenes"}``.
 
-    Mocks bypass the actual ffmpeg invocation so the test is fast
-    and deterministic.
+    Both render paths are covered. The two-stage path is read from the
+    ``_render_slideshow`` call; the fused single-pass path (default since
+    July 29 2026) is read from ``_single_pass_long_form_cmd``. They share
+    ``_uniform_slideshow_plan``, and these tests exist to keep it that
+    way — a cost or speed change to the render must never quietly alter
+    how long a viewer stares at one image.
     """
     from engine import video
 
@@ -53,24 +57,28 @@ def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8):
     def _fake_render_slideshow(scene_paths, output, *,
                                scene_duration=None, **kwargs):
         captured["scene_duration"] = scene_duration
+        captured["n_scenes"] = len(scene_paths)
         # Pretend the render produced an output the caller can chain on.
         Path(output).write_bytes(b"\x00")
         return Path(output)
 
-    def _fake_long_form_cmd(*args, **kwargs):
-        return ["true"]  # noop
+    def _fake_single_pass_cmd(scenes, *args, scene_duration=None,
+                              scene_durations=None, **kwargs):
+        captured["scene_duration"] = scene_duration
+        captured["n_scenes"] = len(scenes)
+        captured["scene_durations"] = scene_durations
+        return ["true"]
 
     def _fake_subprocess_run(cmd, **kwargs):
         class _R:
             returncode = 0
             stderr = b""
-        # Touch the expected output so the caller doesn't 404 it.
-        if "out" in kwargs:
-            pass
         return _R()
 
     with patch.object(video, "_render_slideshow", _fake_render_slideshow), \
-         patch.object(video, "_long_form_cmd", _fake_long_form_cmd), \
+         patch.object(video, "_long_form_cmd", lambda *a, **k: ["true"]), \
+         patch.object(video, "_single_pass_long_form_cmd", _fake_single_pass_cmd), \
+         patch.object(video, "_single_pass_enabled", lambda: single_pass), \
          patch("subprocess.run", _fake_subprocess_run), \
          patch("engine.audio.get_audio_duration", return_value=audio_duration_s):
         scenes = stub_paths["scenes"][:num_scenes]
@@ -78,80 +86,81 @@ def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8):
             stub_paths["audio"], stub_paths["cover"], stub_paths["out"],
             scene_paths=scenes,
         )
-    return captured.get("scene_duration")
+    return captured
+
+
+def _capture_scene_duration(stub_paths, audio_duration_s, num_scenes=8,
+                            *, single_pass=False):
+    return _capture(stub_paths, audio_duration_s, num_scenes,
+                    single_pass=single_pass).get("scene_duration")
+
+
+@pytest.fixture(params=[False, True], ids=["two_stage", "single_pass"])
+def render_path(request):
+    """Every cadence assertion runs against BOTH render paths."""
+    return request.param
 
 
 class TestSceneCadenceMatchesAudio:
 
-    def test_six_minute_episode_cycles_to_15s_cap(self, stub_paths):
+    def test_six_minute_episode_cycles_to_15s_cap(self, stub_paths, render_path):
         """June 2026 motion pass: scenes CYCLE so no image holds longer than
         ~15 s (was 25 s; 360 s/8 = 45 s/scene used to ship — visually static;
         the scene list now repeats in rotation at zero added image cost).
         360/15 = 24 slots — exactly the render-safe slot cap, so the 15 s
         preference still wins."""
-        dur = _capture_scene_duration(stub_paths, audio_duration_s=360.0)
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=360.0,
+                                      single_pass=render_path)
         assert dur is not None and 8.0 <= dur <= 15.0, (
             f"Expected ≤15 s/scene after cycling for 360 s/8, got {dur}"
         )
 
-    def test_ten_minute_episode_respects_slot_cap(self, stub_paths):
+    def test_ten_minute_episode_respects_slot_cap(self, stub_paths, render_path):
         """600 s @ 15 s would be 40 slots; the render-safe cap (24) binds
         and holds stretch to 600/24 = 25 s. Still far below the pre-motion
         75 s/scene static look."""
         from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
-        dur = _capture_scene_duration(stub_paths, audio_duration_s=600.0)
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=600.0,
+                                      single_pass=render_path)
         assert dur is not None
         assert 8.0 <= dur <= (600.0 / _MAX_SLIDESHOW_SLOTS) + 0.01
         # Cap must have fired — uncapped would be ≤15 s.
         assert dur > 15.0
 
-    def test_seventeen_minute_episode_stays_under_slot_cap(self, stub_paths):
+    def test_seventeen_minute_episode_stays_under_slot_cap(
+            self, stub_paths, render_path):
         """Ep537-class (1044 s): prove the uniform cycling path never asks
         ffmpeg for more than _MAX_SLIDESHOW_SLOTS inputs."""
-        from engine import video
         from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
 
-        captured = {}
-
-        def _fake_render_slideshow(scene_paths, output, *,
-                                   scene_duration=None, **kwargs):
-            captured["n_scenes"] = len(scene_paths)
-            captured["scene_duration"] = scene_duration
-            Path(output).write_bytes(b"\x00")
-            return Path(output)
-
-        with patch.object(video, "_render_slideshow", _fake_render_slideshow), \
-             patch.object(video, "_long_form_cmd", lambda *a, **k: ["true"]), \
-             patch("subprocess.run",
-                   lambda *a, **k: type("R", (), {"returncode": 0, "stderr": b""})()), \
-             patch("engine.audio.get_audio_duration", return_value=1044.0):
-            video.build_long_form_video(
-                stub_paths["audio"], stub_paths["cover"], stub_paths["out"],
-                scene_paths=stub_paths["scenes"][:4],
-            )
-        assert captured["n_scenes"] == _MAX_SLIDESHOW_SLOTS
-        assert captured["scene_duration"] == pytest.approx(
+        got = _capture(stub_paths, 1044.0, num_scenes=4,
+                       single_pass=render_path)
+        assert got["n_scenes"] == _MAX_SLIDESHOW_SLOTS
+        assert got["scene_duration"] == pytest.approx(
             1044.0 / _MAX_SLIDESHOW_SLOTS, rel=0.01,
         )
 
-    def test_thirty_second_teaser_clamps_to_floor(self, stub_paths):
+    def test_thirty_second_teaser_clamps_to_floor(self, stub_paths, render_path):
         """Very short audio gets clamped to the 8 s floor so scenes
         don't whip past faster than the eye can register."""
-        dur = _capture_scene_duration(stub_paths, audio_duration_s=30.0)
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=30.0,
+                                      single_pass=render_path)
         assert dur == 8.0, f"Floor should clamp short episodes; got {dur}"
 
-    def test_zero_or_unknown_audio_falls_back_to_legacy_12s(self, stub_paths):
+    def test_zero_or_unknown_audio_falls_back_to_legacy_12s(self, stub_paths, render_path):
         """If ``get_audio_duration`` can't read the file (returns 0),
         keep the legacy 12 s default rather than producing a 0-second
         slideshow that would crash the slideshow render."""
         from engine.video import _SCENE_DURATION_SECONDS
-        dur = _capture_scene_duration(stub_paths, audio_duration_s=0.0)
+        dur = _capture_scene_duration(stub_paths, audio_duration_s=0.0,
+                                      single_pass=render_path)
         assert dur == _SCENE_DURATION_SECONDS
 
-    def test_three_scenes_for_short_episode_still_floors(self, stub_paths):
+    def test_three_scenes_for_short_episode_still_floors(self, stub_paths, render_path):
         """Short audio + small scene count: 30 s / 3 = 10 s per scene
         (above floor); floor doesn't kick in here, no clamping needed."""
         dur = _capture_scene_duration(
             stub_paths, audio_duration_s=30.0, num_scenes=3,
+            single_pass=render_path,
         )
         assert dur == pytest.approx(10.0, rel=0.01)

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -55,7 +55,10 @@ class TestConfigLoads:
         # plateau + digest ceiling); the Engineering Deep Dive length lever
         # is the quality-preserving fix in the podcast prompt.
         assert cfg.llm.min_podcast_words == 1300
-        assert cfg.llm.podcast_expand_below_target is True
+        # Superseded 2026-07-29: length is attacked at the digest stage
+        # only — see tests/test_cost_efficiency_pass.py.
+        assert cfg.llm.podcast_expand_below_target is False
+        assert cfg.llm.digest_expand_below_target is True
 
     def test_memory_enabled_and_registered(self):
         cfg = load_config(_ROOT / "shows/spacex.yaml")

--- a/tests/test_tesla_quality_pass.py
+++ b/tests/test_tesla_quality_pass.py
@@ -158,11 +158,19 @@ class TestExpansionRetryThresholdFlag:
         assert _podcast_expansion_retry_threshold(
             1600, expand_below_target=True) == 1600
 
-    def test_tesla_opts_in(self):
+    def test_tesla_length_lever_is_digest_side(self):
+        # Superseded 2026-07-29 (cost-efficiency pass): the podcast-side
+        # expansion retry is OFF wherever a digest-side lever exists. Over
+        # 901 committed episodes 81% still shipped below target WITH it
+        # running, and it padded by paraphrase-duplication; the July 18
+        # playbook had already banned podcast-side length levers. The
+        # length lever must now be the digest one — assert that, not the
+        # retired flag. Guard: tests/test_cost_efficiency_pass.py.
         from engine.config import load_config
 
         cfg = load_config("shows/tesla.yaml")
-        assert cfg.llm.podcast_expand_below_target is True
+        assert cfg.llm.podcast_expand_below_target is False
+        assert cfg.llm.digest_expand_below_target is True
 
     def test_dataclass_default_off(self):
         from engine.config import LLMConfig

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -39,6 +39,11 @@ from engine.video import (
 # Encoder profile — keyframe args are the playback fix
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def force_two_stage_render(monkeypatch):
+    """Pin the legacy two-stage render for tests that assert its shape."""
+    monkeypatch.setenv("NERRA_SINGLE_PASS_RENDER", "0")
+
 def test_video_encode_profile_includes_keyframe_args():
     """``-g``, ``-keyint_min``, ``-sc_threshold`` and
     ``-force_key_frames`` must all be present.
@@ -757,6 +762,13 @@ def test_build_long_form_video_falls_back_to_cover_with_one_scene(tmp_path,
     assert "zoompan" in graph
 
 
+# These four pin the TWO-STAGE pipeline, which since July 29 2026 is the
+# automatic fallback rather than the default path (engine.video
+# ._single_pass_enabled flipped ON after an A/B showed equivalent output
+# 23-34%% faster). They stay valuable exactly because that fallback still
+# ships on any fused-command failure — so force the legacy path rather
+# than deleting the coverage.
+@pytest.mark.usefixtures("force_two_stage_render")
 def test_build_long_form_video_renders_slideshow_for_multi_scene(tmp_path,
                                                                  monkeypatch):
     """Multi-scene list triggers a stage-1 slideshow render before
@@ -1560,6 +1572,13 @@ def test_render_slideshow_schedule_hard_cut_fallback(tmp_path, monkeypatch):
     assert "trim=duration=8.00" in retry_graph
 
 
+# These four pin the TWO-STAGE pipeline, which since July 29 2026 is the
+# automatic fallback rather than the default path (engine.video
+# ._single_pass_enabled flipped ON after an A/B showed equivalent output
+# 23-34%% faster). They stay valuable exactly because that fallback still
+# ships on any fused-command failure — so force the legacy path rather
+# than deleting the coverage.
+@pytest.mark.usefixtures("force_two_stage_render")
 def test_build_long_form_video_uses_scene_schedule(tmp_path, monkeypatch):
     """scene_schedule= drives the stage-1 slideshow: scheduled scene
     order, per-scene -t inputs, cumulative xfade offsets."""
@@ -1601,6 +1620,13 @@ def test_build_long_form_video_uses_scene_schedule(tmp_path, monkeypatch):
     assert "-stream_loop" in captured_cmds[1]
 
 
+# These four pin the TWO-STAGE pipeline, which since July 29 2026 is the
+# automatic fallback rather than the default path (engine.video
+# ._single_pass_enabled flipped ON after an A/B showed equivalent output
+# 23-34%% faster). They stay valuable exactly because that fallback still
+# ships on any fused-command failure — so force the legacy path rather
+# than deleting the coverage.
+@pytest.mark.usefixtures("force_two_stage_render")
 def test_build_long_form_video_short_schedule_keeps_legacy_path(tmp_path,
                                                                 monkeypatch):
     """A degenerate 1-entry schedule must NOT flip the pipeline — the
@@ -1890,6 +1916,13 @@ def test_build_long_form_video_broll_caps_at_three(tmp_path, monkeypatch):
     assert used == clips[:3]
 
 
+# These four pin the TWO-STAGE pipeline, which since July 29 2026 is the
+# automatic fallback rather than the default path (engine.video
+# ._single_pass_enabled flipped ON after an A/B showed equivalent output
+# 23-34%% faster). They stay valuable exactly because that fallback still
+# ships on any fused-command failure — so force the legacy path rather
+# than deleting the coverage.
+@pytest.mark.usefixtures("force_two_stage_render")
 def test_build_long_form_video_broll_failure_degrades_to_slideshow(tmp_path,
                                                                    monkeypatch):
     """Any ffmpeg failure on the hybrid render must degrade to the pure


### PR DESCRIPTION
Six cost changes, each justified from committed data rather than from reasoning about where waste *should* be. Full suite green (4,941 passed), ruff clean.

**One item needs your ears before merge** — flagged below.

## Context: tracked spend was ~1/3 of real spend

The dashboard reported ~$29/30d. Adding what it didn't count — multilingual (~$38/mo) and Grok Imagine (~$50-60/mo, only counted since July 28) — real total is **~$110-125/mo**. The two biggest lines were the two least measured, which is why measurement leads.

## 1. Per-language OP3 measurement (the unlock, not a saving)

Multilingual is ~1/3 of spend and its audience was measured **nowhere**: the per-language enclosures carry the OP3 prefix, but `fetch_op3_stats.py` only ever resolved each show's English feed, so `api/op3_stats.json` had zero language-track entries. A language with no listeners looked identical to a popular one — which is the only reason ZH and channel-less FR tracks kept renewing.

Now resolves the 14 feeds you actually pay for (scoped to `multilingual.languages`, not the 44 stub files on disk) into a separate `language_feeds` section — separate because every consumer iterates `shows` keyed by slug. A failed fetch keeps the prior reading tagged `not_refreshed_this_run`; dropping it would read as "no audience", the one conclusion this data must not fake.

Dashboard gains `multilingual.by_language`. **Today's split, now visible: FR ~$20/mo (7 shows), RU ~$13/mo (4), ZH ~$8/mo (3).** In 2-4 weeks a language reading zero is a one-line YAML switch-off. RU feeds @NerraRU and earns its keep regardless.

## 2. 16:9 scenes only on days that produce a long-form video

Shorts-only days still generated 4 fresh 16:9 scenes. Those feed only the long-form slideshow, its thumbnail, and the gallery — **Shorts use their own 9:16 set** (verified). So three of four paid images were never seen. Now 1 on those days. The gate reads `_policy_publish_long or video_podcast.enabled`, because video-podcast shows render long-form for Apple even when the YouTube policy skips the upload — checking the policy alone would have cost them their slideshow. ~$0.06/episode on tier-C shows, scaling as more shows fall to shorts-only.

## 3. xAI search spend now reaches the credit file

Server-side `x_search`/`web_search` bill **per source consulted**; the Responses path returned only text, so every search-fetching show under-reported. Flagged as uncounted by the July 24 pass, still missing after July 28. Accumulates per-process in `xai_grok` (the fetch layer has no tracker) and run_show *drains* it — draining not peeking, because the daily-audit retry path runs several shows in one process. Wired by wrapping `save_usage`, so the abort paths still report searches already paid for. Reads usage defensively (xAI's schema isn't public and has carried several shapes). Also wires `record_render_seconds`, which July 28 shipped with no caller.

## 4. Single-pass render on by default — A/B'd, not assumed

It shipped opt-in because "nobody has watched it end to end". I did, on both shapes production ships (ffmpeg 6.1.1, 1920×1080, 4 scenes, 24 s):

| shape | two-stage | single-pass | |
|---|---|---|---|
| uniform stills | 24.6 s | 16.2 s | **-34%** |
| chapter schedule + burned captions | 22.3 s | 17.2 s | **-23%** |

Outputs equivalent: identical duration (24.000 s), frame count (720), geometry, codecs; mean pixel difference **< 0.3/255** at every sampled timestamp (encode noise — the fused path skips a generation of loss); identical scene timeline; frame-to-frame matching brand pill, URL pill and captions. The env var becomes an escape hatch (`=0` forces legacy) and now also covers the RU/FR dub renders. Two-stage remains the automatic fallback, so this can cost time, never an episode. Render-only — outside landmine #17.

The cadence guards now run against **both** paths: a render change made for speed must never quietly alter how long a viewer stares at one image.

## 5. ⚠️ Podcast-side length retry off — A/B-LISTEN REQUIRED

**When this retry fired, its output is what shipped** — the first post-merge episode on these shows will sound different. This is the one item in the PR that touches audio (landmine #17).

Across **901 committed episodes, 81% shipped BELOW target *with* the retry running** (Tesla 96.7%, M&A 95.2%, FF 92.6%). It fires on nearly every episode — 28 of Tesla's last 29 — and almost never reaches its goal, because the ceiling is the **digest**. Every per-show review since June reached this independently, and the July 18 playbook already banned podcast-side length levers network-wide (`do_not_retry`, ~10 misses vs 1 hit); the config just never caught up.

It isn't neutral either: it pads by paraphrase-duplication (July 28 had to add `_dedup_expansion_sentences` to strip its near-duplicates), so what it shipped was the weaker copy. ~$39/yr.

Off on the 11 shows with `digest_expand_below_target`. **env_intel and finansy_prosto keep theirs** — no digest lever yet, and removing their only length mechanism to save cents is the wrong trade. The guard names them so this doesn't get done by halves.

## 6. CLAUDE.md 185 KB → 131 KB

Dated per-show quality-pass narratives moved verbatim to `docs/show_review_history.md`. This file loads in full every session and replays across the agentic loop — the June token review found exactly this pattern was the largest Anthropic line item.

What stayed matters more: each show keeps its structural facts, plus a new **Live constraints** block surfacing rules that still bind — Colossus/Anthropic is real (don't relitigate), length is digest-side only, de-seed by shape never with a quotable example, the grok-4.3 plateau is accepted, MIT isn't live-trading ready. Those were buried in review prose a reader could skip; surfacing them is a safety win independent of the size.

## Verification

- 4,941 tests pass, 0 failures; ruff clean on the CI-gated paths.
- New guards: `tests/test_cost_efficiency_pass.py` (13), plus extended OP3, single-pass, and cadence coverage.
- 10 tests that pinned the *old* length policy were updated to pin the new one (not weakened — `test_network_quality_pass` now asserts each short show keeps exactly one lever, which is a stronger contract than "opts into the podcast one").

## Not done, deliberately

Giving env_intel/finansy_prosto a digest lever (changes their output — wants its own A/B); switching off any language before the OP3 data exists (that's the point of #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daily video render defaults, multilingual/dub CI env, and show YAML length behavior (audio when the retired retry had been firing); accounting and OP3 fetch changes are lower risk but affect cost dashboards and language kill decisions.
> 
> **Overview**
> **July 29 cost-efficiency pass** — six data-driven changes to cut spend without changing listener intent, plus a large `CLAUDE.md` trim.
> 
> **Measurement:** `fetch_op3_stats.py` now resolves per-language RSS feeds into `language_feeds` (scoped to enabled `multilingual.languages`); the dashboard rolls up `multilingual.by_language` (downloads vs approximate cost). xAI Responses **search-tool** usage accumulates in `digests/xai_grok.py`, drains into episode credits via wrapped `save_usage` in `run_show.py`, and rolls into `total_estimated_cost_usd` in `engine/tracking.py`. Video **render seconds** are finally recorded after the YouTube stage.
> 
> **Spend cuts:** On shorts-only days with no video-podcast feed, fresh **16:9 Grok Imagine** scenes drop from 4 → 1 (9:16 unchanged); metrics `scene_long_form_produced` / `scene_fresh_long_requested` track this. **Single-pass ffmpeg** is **default ON** in `engine/video.py` (23–34% faster, A/B-equivalent); `NERRA_SINGLE_PASS_RENDER` is an escape hatch in `run-show.yml` and **multilingual** RU/FR dub jobs. **`podcast_expand_below_target: false`** on 11 shows that already use `digest_expand_below_target`; `env_intel` and `finansy_prosto` keep the podcast retry until they get a digest lever.
> 
> **Docs / ops:** Dated per-show review prose moved to `docs/show_review_history.md`; `CLAUDE.md` keeps structural facts and a **Live constraints** block. `prune_recovery_branches.py` only appends a shallow-clone caveat to stranded-branch warnings (no standalone `::warning::` on quiet runs).
> 
> **Tests:** New `tests/test_cost_efficiency_pass.py`; network/MIT tests updated for digest-side length policy.
> 
> **Operator note:** First post-merge episodes on shows that used to fire the podcast expansion retry may sound different — **A/B-listen** per landmine #17 when that retry had been shipping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fa180bc7c953adc2f3335d652fc6b955483b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->