### PR TITLE
Fix the Apple Podcasts card + add a sponsor-facing view to the dashboard

### DIFF
--- a/api/dashboard.json
+++ b/api/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-28T18:12:04.514540+00:00",
+  "generated_at": "2026-07-29T14:38:53.873669+00:00",
   "network": {
     "landmines_counts": {
       "ok": 10,
@@ -8,8 +8,8 @@
     },
     "shows_count": 15,
     "stale_shows": 0,
-    "total_cost_last_7_days_usd": 9.6679,
-    "total_cost_last_30_days_usd": 28.639,
+    "total_cost_last_7_days_usd": 12.0269,
+    "total_cost_last_30_days_usd": 31.4237,
     "shows": [
       {
         "slug": "age_of_ai",
@@ -40,8 +40,8 @@
         "x_enabled": false,
         "latest_pub_date": "2026-07-28T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6476,
-        "episodes_last_7_days": 6,
+        "cost_last_7_days_usd": 0.5759,
+        "episodes_last_7_days": 5,
         "p50_pipeline_s": 49.92,
         "success_rate": 1.0
       },
@@ -57,8 +57,8 @@
         "x_enabled": false,
         "latest_pub_date": "2026-07-27T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.1432,
-        "episodes_last_7_days": 4,
+        "cost_last_7_days_usd": 0.0886,
+        "episodes_last_7_days": 2,
         "p50_pipeline_s": 53.73,
         "success_rate": 1.0
       },
@@ -74,8 +74,8 @@
         "x_enabled": true,
         "latest_pub_date": "2026-07-28T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.9564,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.8865,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 74.87,
         "success_rate": 1.0
       },
@@ -106,9 +106,9 @@
         "blog_page": "blog/first_principles/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.7495,
+        "cost_last_7_days_usd": 1.0166,
         "episodes_last_7_days": 16,
         "p50_pipeline_s": 52.05,
         "success_rate": 1.0
@@ -125,8 +125,8 @@
         "x_enabled": true,
         "latest_pub_date": "2026-07-28T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.8762,
-        "episodes_last_7_days": 16,
+        "cost_last_7_days_usd": 0.7913,
+        "episodes_last_7_days": 14,
         "p50_pipeline_s": 82.26,
         "success_rate": 1.0
       },
@@ -140,11 +140,11 @@
         "blog_page": "blog/models_agents_beginners/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6333,
+        "cost_last_7_days_usd": 0.8851,
         "episodes_last_7_days": 8,
-        "p50_pipeline_s": 51.46,
+        "p50_pipeline_s": 50.87,
         "success_rate": 1.0
       },
       {
@@ -157,11 +157,11 @@
         "blog_page": "blog/modern_investing/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-07-27T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.7962,
-        "episodes_last_7_days": 14,
-        "p50_pipeline_s": 108.79,
+        "cost_last_7_days_usd": 1.5418,
+        "episodes_last_7_days": 16,
+        "p50_pipeline_s": 113.57,
         "success_rate": 1.0
       },
       {
@@ -174,11 +174,11 @@
         "blog_page": "blog/omni_view/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.9251,
+        "cost_last_7_days_usd": 1.2054,
         "episodes_last_7_days": 8,
-        "p50_pipeline_s": 146.38,
+        "p50_pipeline_s": 148.62,
         "success_rate": 1.0
       },
       {
@@ -191,11 +191,11 @@
         "blog_page": "blog/planetterrian/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.9746,
+        "cost_last_7_days_usd": 1.2823,
         "episodes_last_7_days": 8,
-        "p50_pipeline_s": 56.5,
+        "p50_pipeline_s": 57.13,
         "success_rate": 1.0
       },
       {
@@ -225,10 +225,10 @@
         "blog_page": "blog/spacex/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.9841,
-        "episodes_last_7_days": 18,
+        "cost_last_7_days_usd": 1.2185,
+        "episodes_last_7_days": 16,
         "p50_pipeline_s": 114.19,
         "success_rate": 1.0
       },
@@ -242,9 +242,9 @@
         "blog_page": "blog/tesla/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 1.1483,
+        "cost_last_7_days_usd": 1.4305,
         "episodes_last_7_days": 16,
         "p50_pipeline_s": 139.45,
         "success_rate": 1.0
@@ -259,9 +259,9 @@
         "blog_page": "blog/unintended_consequences/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.6303,
+        "cost_last_7_days_usd": 0.9013,
         "episodes_last_7_days": 8,
         "p50_pipeline_s": 20.57,
         "success_rate": 1.0
@@ -425,10 +425,10 @@
       "id": "item_1_repo_size",
       "title": "Repo & R2 size",
       "status": "ok",
-      "details": "15 MP3s tracked in git, digests/ is 264 MB.",
+      "details": "15 MP3s tracked in git, digests/ is 267 MB.",
       "evidence": {
         "tracked_mp3_count": 15,
-        "digests_mb": 264.0
+        "digests_mb": 266.9
       }
     },
     {
@@ -455,8 +455,8 @@
       "evidence": {
         "total": 95,
         "by_extension": {
-          ".txt": 45,
           ".json": 47,
+          ".txt": 45,
           ".py": 3
         },
         "previous_total": 95
@@ -781,10 +781,10 @@
       },
       "dp_pod": {
         "last_7_days": {
-          "grok": 0.1802,
-          "tts": 0.4674,
-          "total": 0.6476,
-          "episodes": 6
+          "grok": 0.1486,
+          "tts": 0.4273,
+          "total": 0.5759,
+          "episodes": 5
         },
         "last_30_days": {
           "grok": 0.55,
@@ -885,10 +885,10 @@
       },
       "env_intel": {
         "last_7_days": {
-          "grok": 0.0563,
-          "tts": 0.0868,
-          "total": 0.1432,
-          "episodes": 4
+          "grok": 0.0244,
+          "tts": 0.0642,
+          "total": 0.0886,
+          "episodes": 2
         },
         "last_30_days": {
           "grok": 0.3183,
@@ -1021,16 +1021,16 @@
       },
       "fascinating_frontiers": {
         "last_7_days": {
-          "grok": 0.304,
-          "tts": 0.6524,
-          "total": 0.9564,
-          "episodes": 16
+          "grok": 0.2748,
+          "tts": 0.6116,
+          "total": 0.8865,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.0549,
-          "tts": 1.6645,
-          "total": 2.7193,
-          "episodes": 62
+          "grok": 1.0377,
+          "tts": 1.6178,
+          "total": 2.6556,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -1293,22 +1293,18 @@
       },
       "first_principles": {
         "last_7_days": {
-          "grok": 0.1477,
-          "tts": 0.6018,
-          "total": 0.7495,
+          "grok": 0.1553,
+          "tts": 0.7013,
+          "total": 1.0166,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 0.5701,
-          "tts": 1.5194,
-          "total": 2.0895,
+          "grok": 0.5799,
+          "tts": 1.6266,
+          "total": 2.3665,
           "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.059
-          ],
           [
             "2026-06-30",
             0.0484
@@ -1424,21 +1420,25 @@
           [
             "2026-07-28",
             0.1655
+          ],
+          [
+            "2026-07-29",
+            0.3321
           ]
         ]
       },
       "models_agents": {
         "last_7_days": {
-          "grok": 0.3051,
-          "tts": 0.5711,
-          "total": 0.8762,
-          "episodes": 16
+          "grok": 0.2627,
+          "tts": 0.5286,
+          "total": 0.7913,
+          "episodes": 14
         },
         "last_30_days": {
-          "grok": 1.1801,
-          "tts": 1.4644,
-          "total": 2.6445,
-          "episodes": 62
+          "grok": 1.161,
+          "tts": 1.4209,
+          "total": 2.5819,
+          "episodes": 60
         },
         "daily_series": [
           [
@@ -1565,22 +1565,18 @@
       },
       "models_agents_beginners": {
         "last_7_days": {
-          "grok": 0.2059,
-          "tts": 0.4274,
-          "total": 0.6333,
+          "grok": 0.2271,
+          "tts": 0.498,
+          "total": 0.8851,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.7392,
-          "tts": 1.0227,
-          "total": 1.7619,
+          "grok": 0.7685,
+          "tts": 1.0853,
+          "total": 2.0138,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.0521
-          ],
           [
             "2026-06-30",
             0.0454
@@ -1696,31 +1692,27 @@
           [
             "2026-07-28",
             0.1204
+          ],
+          [
+            "2026-07-29",
+            0.2963
           ]
         ]
       },
       "modern_investing": {
         "last_7_days": {
-          "grok": 0.2753,
-          "tts": 0.5209,
-          "total": 0.7962,
-          "episodes": 14
+          "grok": 0.382,
+          "tts": 0.8398,
+          "total": 1.5418,
+          "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.2578,
-          "tts": 1.4488,
-          "total": 2.7066,
-          "episodes": 60
+          "grok": 1.3816,
+          "tts": 1.7685,
+          "total": 3.4701,
+          "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-06-28",
-            0.0544
-          ],
-          [
-            "2026-06-29",
-            0.0895
-          ],
           [
             "2026-06-30",
             0.0873
@@ -1832,27 +1824,31 @@
           [
             "2026-07-27",
             0.216
+          ],
+          [
+            "2026-07-28",
+            0.4042
+          ],
+          [
+            "2026-07-29",
+            0.4137
           ]
         ]
       },
       "omni_view": {
         "last_7_days": {
-          "grok": 0.2891,
-          "tts": 0.636,
-          "total": 0.9251,
+          "grok": 0.3083,
+          "tts": 0.7372,
+          "total": 1.2054,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.9811,
-          "tts": 1.6625,
-          "total": 2.6436,
+          "grok": 1.0281,
+          "tts": 1.7647,
+          "total": 2.9528,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.089
-          ],
           [
             "2026-06-30",
             0.074
@@ -1968,27 +1964,27 @@
           [
             "2026-07-28",
             0.1937
+          ],
+          [
+            "2026-07-29",
+            0.3647
           ]
         ]
       },
       "planetterrian": {
         "last_7_days": {
-          "grok": 0.2445,
-          "tts": 0.7301,
-          "total": 0.9746,
+          "grok": 0.2717,
+          "tts": 0.8506,
+          "total": 1.2823,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.8951,
-          "tts": 1.6877,
-          "total": 2.5828,
+          "grok": 0.9335,
+          "tts": 1.8122,
+          "total": 2.9057,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.0675
-          ],
           [
             "2026-06-30",
             0.0755
@@ -2104,6 +2100,10 @@
           [
             "2026-07-28",
             0.2117
+          ],
+          [
+            "2026-07-29",
+            0.3774
           ]
         ]
       },
@@ -2245,22 +2245,18 @@
       },
       "spacex": {
         "last_7_days": {
-          "grok": 0.3459,
-          "tts": 0.6382,
-          "total": 0.9841,
-          "episodes": 18
+          "grok": 0.3399,
+          "tts": 0.7185,
+          "total": 1.2185,
+          "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.1015,
-          "tts": 1.4171,
-          "total": 2.5185,
-          "episodes": 62
+          "grok": 1.1703,
+          "tts": 1.564,
+          "total": 2.8943,
+          "episodes": 64
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.0573
-          ],
           [
             "2026-06-30",
             0.0631
@@ -2376,27 +2372,27 @@
           [
             "2026-07-28",
             0.161
+          ],
+          [
+            "2026-07-29",
+            0.3757
           ]
         ]
       },
       "tesla": {
         "last_7_days": {
-          "grok": 0.425,
-          "tts": 0.7233,
-          "total": 1.1483,
+          "grok": 0.4424,
+          "tts": 0.8281,
+          "total": 1.4305,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.752,
-          "tts": 1.6901,
-          "total": 3.4421,
+          "grok": 1.7891,
+          "tts": 1.7909,
+          "total": 3.74,
           "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.0843
-          ],
           [
             "2026-06-30",
             0.0848
@@ -2512,27 +2508,27 @@
           [
             "2026-07-28",
             0.2242
+          ],
+          [
+            "2026-07-29",
+            0.3745
           ]
         ]
       },
       "unintended_consequences": {
         "last_7_days": {
-          "grok": 0.0985,
-          "tts": 0.5319,
-          "total": 0.6303,
+          "grok": 0.1152,
+          "tts": 0.6261,
+          "total": 0.9013,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.363,
-          "tts": 1.2199,
-          "total": 1.5828,
-          "episodes": 30
+          "grok": 0.3905,
+          "tts": 1.3453,
+          "total": 1.8958,
+          "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-06-29",
-            0.0523
-          ],
           [
             "2026-06-30",
             0.0498
@@ -2648,28 +2644,32 @@
           [
             "2026-07-28",
             0.1439
+          ],
+          [
+            "2026-07-29",
+            0.3129
           ]
         ]
       }
     },
     "network_last_7_days": {
-      "grok": 2.9339,
-      "tts": 6.734,
-      "total": 9.6679,
-      "episodes": 140
+      "grok": 3.009,
+      "tts": 7.578,
+      "total": 12.0269,
+      "episodes": 133
     },
     "network_last_30_days": {
-      "grok": 11.7824,
-      "tts": 16.8566,
-      "total": 28.639,
-      "episodes": 569
+      "grok": 12.128,
+      "tts": 17.8557,
+      "total": 31.4237,
+      "episodes": 570
     },
     "projections": {
-      "avg_cost_per_episode_usd": 0.0691,
-      "projected_weekly_usd": 9.67,
-      "projected_monthly_usd": 28.64,
-      "episodes_7d": 140,
-      "note": "Weekly projection = actual last-7d Grok+TTS spend (140 credit_usage files). Monthly = last-30d total. Not a calendar forecast — a trailing burn rate."
+      "avg_cost_per_episode_usd": 0.0904,
+      "projected_weekly_usd": 12.03,
+      "projected_monthly_usd": 31.42,
+      "episodes_7d": 133,
+      "note": "Weekly projection = actual last-7d Grok+TTS spend (133 credit_usage files). Monthly = last-30d total. Not a calendar forecast — a trailing burn rate."
     },
     "youtube_quota": {
       "enabled_shows_count": 13,
@@ -2700,7 +2700,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.1246
+        "cost_7d_usd": 0.088
       },
       "fascinating_frontiers": {
         "languages": [
@@ -2718,7 +2718,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.9177
+        "cost_7d_usd": 1.7829
       },
       "first_principles": {
         "languages": [
@@ -2734,7 +2734,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.8104
+        "cost_7d_usd": 0.9273
       },
       "models_agents": {
         "languages": [
@@ -2750,7 +2750,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 0.7877
+        "cost_7d_usd": 0.7236
       },
       "modern_investing": {
         "languages": [
@@ -2767,7 +2767,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.3996
+        "cost_7d_usd": 2.1947
       },
       "spacex": {
         "languages": [
@@ -2785,7 +2785,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.8758
+        "cost_7d_usd": 2.0941
       },
       "tesla": {
         "languages": [
@@ -2803,10 +2803,36 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.9855
+        "cost_7d_usd": 2.259
       }
     },
-    "network_cost_7d_usd": 8.9013
+    "network_cost_7d_usd": 10.0696,
+    "audience_measured": false,
+    "per_language_audience": {},
+    "by_language": {
+      "fr": {
+        "downloads_7d": 0,
+        "downloads_30d": 0,
+        "approx_cost_7d_usd": 4.8816,
+        "shows": 7,
+        "measured": false
+      },
+      "ru": {
+        "downloads_7d": 0,
+        "downloads_30d": 0,
+        "approx_cost_7d_usd": 3.1427,
+        "shows": 4,
+        "measured": false
+      },
+      "zh": {
+        "downloads_7d": 0,
+        "downloads_30d": 0,
+        "approx_cost_7d_usd": 2.0453,
+        "shows": 3,
+        "measured": false
+      }
+    },
+    "audience_note": "Per-language OP3 downloads for the feeds the multilingual stage produces. approx_cost_7d_usd splits each show's multilingual spend evenly across its languages (the tracker records one total per episode). A language reading 0 downloads across several weeks is a candidate to switch off in the show YAML."
   },
   "pipeline_health": {
     "age_of_ai": {
@@ -3303,16 +3329,9 @@
       "success_rate": 1.0,
       "stage_mean_s": {
         "fetch_and_dedup": 0.0,
-        "generate_digest": 60.4
+        "generate_digest": 59.97
       },
       "recent": [
-        {
-          "episode_num": 44,
-          "total_duration_s": 36.63,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 45,
           "total_duration_s": 169.37,
@@ -3375,14 +3394,21 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 54,
+          "total_duration_s": 28.56,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 18,
-        "long_form_success_rate": 0.6,
-        "estimated_quota_units_last_30_eps": 88800,
+        "long_form_uploaded": 17,
+        "long_form_success_rate": 0.567,
+        "estimated_quota_units_last_30_eps": 86700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
@@ -3520,21 +3546,14 @@
     },
     "models_agents_beginners": {
       "sample_size": 30,
-      "p50_duration_s": 51.46,
+      "p50_duration_s": 50.87,
       "p95_duration_s": 68.76,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 22.39,
-        "generate_digest": 27.74
+        "fetch_and_dedup": 21.99,
+        "generate_digest": 28.07
       },
       "recent": [
-        {
-          "episode_num": 107,
-          "total_duration_s": 53.3,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 108,
           "total_duration_s": 59.74,
@@ -3597,6 +3616,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 117,
+          "total_duration_s": 50.87,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3631,29 +3657,15 @@
     },
     "modern_investing": {
       "sample_size": 30,
-      "p50_duration_s": 108.79,
+      "p50_duration_s": 113.57,
       "p95_duration_s": 200.07,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 66.92,
-        "generate_digest": 41.04,
-        "generate_digest_structural_retry": 41.21
+        "fetch_and_dedup": 68.65,
+        "generate_digest": 41.83,
+        "generate_digest_structural_retry": 41.73
       },
       "recent": [
-        {
-          "episode_num": 110,
-          "total_duration_s": 94.42,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
-        {
-          "episode_num": 111,
-          "total_duration_s": 108.79,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 112,
           "total_duration_s": 73.57,
@@ -3709,6 +3721,20 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 120,
+          "total_duration_s": 107.72,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
+        },
+        {
+          "episode_num": 121,
+          "total_duration_s": 185.37,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3723,8 +3749,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 5,
-        "synthesised": 5,
+        "attempts": 4,
+        "synthesised": 4,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -3743,22 +3769,15 @@
     },
     "omni_view": {
       "sample_size": 30,
-      "p50_duration_s": 146.38,
+      "p50_duration_s": 148.62,
       "p95_duration_s": 257.36,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 84.15,
-        "generate_digest": 63.4,
-        "generate_digest_slow_news": 62.37
+        "fetch_and_dedup": 86.56,
+        "generate_digest": 63.2,
+        "generate_digest_slow_news": 62.47
       },
       "recent": [
-        {
-          "episode_num": 117,
-          "total_duration_s": 138.85,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 118,
           "total_duration_s": 148.62,
@@ -3821,6 +3840,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 127,
+          "total_duration_s": 256.22,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3843,7 +3869,7 @@
         "attempts": 30,
         "successful_episodes": 30,
         "generation_success_rate": 1.0,
-        "cost_usd_recent": 4.62,
+        "cost_usd_recent": 4.66,
         "recent_failures": []
       },
       "tag_leaks": {
@@ -3855,21 +3881,14 @@
     },
     "planetterrian": {
       "sample_size": 30,
-      "p50_duration_s": 56.5,
+      "p50_duration_s": 57.13,
       "p95_duration_s": 118.79,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 20.72,
-        "generate_digest": 46.07
+        "fetch_and_dedup": 20.51,
+        "generate_digest": 46.66
       },
       "recent": [
-        {
-          "episode_num": 125,
-          "total_duration_s": 56.34,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 126,
           "total_duration_s": 102.94,
@@ -3932,14 +3951,21 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 135,
+          "total_duration_s": 59.82,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 18,
-        "long_form_success_rate": 0.6,
-        "estimated_quota_units_last_30_eps": 88800,
+        "long_form_uploaded": 17,
+        "long_form_success_rate": 0.567,
+        "estimated_quota_units_last_30_eps": 86700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
@@ -4082,17 +4108,10 @@
       "p95_duration_s": 167.0,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 32.39,
-        "generate_digest": 77.88
+        "fetch_and_dedup": 32.32,
+        "generate_digest": 78.91
       },
       "recent": [
-        {
-          "episode_num": 38,
-          "total_duration_s": 167.7,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 39,
           "total_duration_s": 167.0,
@@ -4155,6 +4174,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 48,
+          "total_duration_s": 86.41,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -4193,18 +4219,11 @@
       "p95_duration_s": 297.07,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 30.34,
-        "generate_digest": 98.56,
+        "fetch_and_dedup": 30.15,
+        "generate_digest": 97.48,
         "generate_digest_structural_retry": 95.6
       },
       "recent": [
-        {
-          "episode_num": 546,
-          "total_duration_s": 297.07,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 547,
           "total_duration_s": 263.98,
@@ -4267,6 +4286,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 556,
+          "total_duration_s": 59.51,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -4306,16 +4332,9 @@
       "success_rate": 1.0,
       "stage_mean_s": {
         "fetch_and_dedup": 0.0,
-        "generate_digest": 27.08
+        "generate_digest": 27.1
       },
       "recent": [
-        {
-          "episode_num": 63,
-          "total_duration_s": 22.22,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 64,
           "total_duration_s": 60.26,
@@ -4378,14 +4397,21 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 73,
+          "total_duration_s": 27.89,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 18,
-        "long_form_success_rate": 0.6,
-        "estimated_quota_units_last_30_eps": 88800,
+        "long_form_uploaded": 17,
+        "long_form_success_rate": 0.567,
+        "estimated_quota_units_last_30_eps": 86700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
@@ -4432,7 +4458,7 @@
       {
         "file": "blog.rss",
         "entry_count": 50,
-        "latest_pub_date": "2026-06-27T00:00:00+00:00",
+        "latest_pub_date": "2026-07-28T00:00:00+00:00",
         "latest_enclosures": [],
         "malformed": false,
         "error": null
@@ -4860,8 +4886,15 @@
       {
         "file": "first_principles_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep054_20260729.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep053_20260728.fr.mp3",
             "host": "op3.dev",
@@ -4875,13 +4908,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep051_20260726.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -4889,9 +4915,16 @@
       },
       {
         "file": "first_principles_podcast.rss",
-        "entry_count": 53,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 54,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep054_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep053_20260728.mp3",
             "host": "op3.dev",
@@ -4903,13 +4936,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep052_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep051_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5039,9 +5065,16 @@
       },
       {
         "file": "models_agents_beginners_podcast.rss",
-        "entry_count": 116,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 117,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep117_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep116_20260728.mp3",
             "host": "op3.dev",
@@ -5053,13 +5086,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep115_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep114_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5099,9 +5125,16 @@
       },
       {
         "file": "models_agents_beginners_podcast.video.rss",
-        "entry_count": 11,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 12,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep117_20260729.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep116_20260728.mp4",
             "host": "audio.nerranetwork.com",
@@ -5113,13 +5146,6 @@
             "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep115_20260727.mp4",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep114_20260726.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5369,27 +5395,27 @@
       },
       {
         "file": "modern_investing_podcast.fr.rss",
-        "entry_count": 12,
-        "latest_pub_date": "2026-07-27T08:00:00+00:00",
+        "entry_count": 14,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep121_20260729.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep120_20260728.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-28T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep119_20260727.fr.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep118_20260726.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-25T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5399,27 +5425,27 @@
       },
       {
         "file": "modern_investing_podcast.rss",
-        "entry_count": 119,
-        "latest_pub_date": "2026-07-27T08:00:00+00:00",
+        "entry_count": 121,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep121_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep120_20260728.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-28T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep119_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep118_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-25T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5430,26 +5456,26 @@
       {
         "file": "modern_investing_podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-27T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep121_20260729.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep120_20260728.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-28T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep119_20260727.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep118_20260726.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep117_20260725.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-25T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5549,9 +5575,16 @@
       },
       {
         "file": "omni_view_podcast.rss",
-        "entry_count": 126,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 127,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep127_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep126_20260728.mp3",
             "host": "op3.dev",
@@ -5563,13 +5596,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep125_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep124_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5699,9 +5725,16 @@
       },
       {
         "file": "planetterrian_podcast.rss",
-        "entry_count": 122,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 123,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep135_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep134_20260728.mp3",
             "host": "op3.dev",
@@ -5713,13 +5746,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep133_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep132_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5820,8 +5846,15 @@
       {
         "file": "podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep556_20260729.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep555_20260728.fr.mp3",
             "host": "op3.dev",
@@ -5835,13 +5868,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep553_20260726.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5849,9 +5875,16 @@
       },
       {
         "file": "podcast.rss",
-        "entry_count": 208,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 209,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep556_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep555_20260728.mp3",
             "host": "op3.dev",
@@ -5865,13 +5898,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep553_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5880,8 +5906,15 @@
       {
         "file": "podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep556_20260729.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep555_20260728.ru.mp3",
             "host": "op3.dev",
@@ -5895,13 +5928,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep553_20260726.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5909,9 +5935,16 @@
       },
       {
         "file": "podcast.video.rss",
-        "entry_count": 11,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 12,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep556_20260729.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep555_20260728.mp4",
             "host": "audio.nerranetwork.com",
@@ -5925,13 +5958,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep553_20260726.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5940,8 +5966,15 @@
       {
         "file": "podcast.zh.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep556_20260729.zh.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep555_20260728.zh.mp3",
             "host": "op3.dev",
@@ -5953,13 +5986,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep554_20260727.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep553_20260726.zh.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6030,8 +6056,15 @@
       {
         "file": "spacex_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep048_20260729.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep047_20260728.fr.mp3",
             "host": "op3.dev",
@@ -6045,13 +6078,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep045_20260726.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6059,9 +6085,16 @@
       },
       {
         "file": "spacex_podcast.rss",
-        "entry_count": 47,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 48,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep048_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep047_20260728.mp3",
             "host": "op3.dev",
@@ -6075,13 +6108,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep045_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6090,8 +6116,15 @@
       {
         "file": "spacex_podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep048_20260729.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep047_20260728.ru.mp3",
             "host": "op3.dev",
@@ -6105,13 +6138,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep045_20260726.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6119,9 +6145,16 @@
       },
       {
         "file": "spacex_podcast.video.rss",
-        "entry_count": 11,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 12,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep048_20260729.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep047_20260728.mp4",
             "host": "audio.nerranetwork.com",
@@ -6135,13 +6168,6 @@
             "pub_date": "2026-07-27T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep045_20260726.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-07-26T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6150,8 +6176,15 @@
       {
         "file": "spacex_podcast.zh.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep048_20260729.zh.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep047_20260728.zh.mp3",
             "host": "op3.dev",
@@ -6163,13 +6196,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep046_20260727.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep045_20260726.zh.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6239,9 +6265,16 @@
       },
       {
         "file": "unintended_consequences_podcast.rss",
-        "entry_count": 72,
-        "latest_pub_date": "2026-07-28T08:00:00+00:00",
+        "entry_count": 73,
+        "latest_pub_date": "2026-07-29T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep073_20260729.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-07-29T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep072_20260728.mp3",
             "host": "op3.dev",
@@ -6253,13 +6286,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep071_20260727.mp3",
             "host": "op3.dev",
             "pub_date": "2026-07-27T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep070_20260726.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-07-26T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6381,14 +6407,14 @@
       "longest_loss_streak": 3
     },
     "benchmark": {
-      "current_close": 24975.82,
-      "inception_to_date_pct": 11.63,
-      "ytd_pct": 7.49,
-      "last_updated": "2026-07-27"
+      "current_close": 24876.91,
+      "inception_to_date_pct": 11.19,
+      "ytd_pct": 7.06,
+      "last_updated": "2026-07-29"
     },
     "alpha": {
-      "inception_to_date_pct": -10.99,
-      "ytd_pct": -6.85,
+      "inception_to_date_pct": -10.55,
+      "ytd_pct": -6.42,
       "monthly": {}
     },
     "sectors": {
@@ -7641,65 +7667,81 @@
     "taught_lessons_hot": [
       {
         "tag": "bid_ask_spread",
+        "count": 29,
+        "last_episode": 121,
+        "last_date": "2026-07-29",
+        "days_since": 0,
+        "cools_in_days": 45
+      },
+      {
+        "tag": "catalyst_confirmation",
+        "count": 43,
+        "last_episode": 121,
+        "last_date": "2026-07-29",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "position_sizing",
+        "count": 40,
+        "last_episode": 121,
+        "last_date": "2026-07-29",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "valuation_discipline",
+        "count": 44,
+        "last_episode": 121,
+        "last_date": "2026-07-29",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "covered_call",
         "count": 28,
-        "last_episode": 119,
-        "last_date": "2026-07-27",
+        "last_episode": 121,
+        "last_date": "2026-07-29",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "tax_loss_harvesting",
+        "count": 10,
+        "last_episode": 120,
+        "last_date": "2026-07-28",
         "days_since": 1,
-        "cools_in_days": 44
+        "cools_in_days": 20
+      },
+      {
+        "tag": "risk_management",
+        "count": 26,
+        "last_episode": 120,
+        "last_date": "2026-07-28",
+        "days_since": 1,
+        "cools_in_days": 20
+      },
+      {
+        "tag": "sector_rotation",
+        "count": 60,
+        "last_episode": 120,
+        "last_date": "2026-07-28",
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "order_flow_slippage",
         "count": 8,
         "last_episode": 119,
         "last_date": "2026-07-27",
-        "days_since": 1,
-        "cools_in_days": 44
-      },
-      {
-        "tag": "sector_rotation",
-        "count": 59,
-        "last_episode": 119,
-        "last_date": "2026-07-27",
-        "days_since": 1,
-        "cools_in_days": 20
-      },
-      {
-        "tag": "position_sizing",
-        "count": 38,
-        "last_episode": 119,
-        "last_date": "2026-07-27",
-        "days_since": 1,
-        "cools_in_days": 20
-      },
-      {
-        "tag": "covered_call",
-        "count": 26,
-        "last_episode": 119,
-        "last_date": "2026-07-27",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 43
       },
       {
         "tag": "macro_rotation",
         "count": 20,
         "last_episode": 119,
         "last_date": "2026-07-27",
-        "days_since": 1,
-        "cools_in_days": 20
-      },
-      {
-        "tag": "catalyst_confirmation",
-        "count": 42,
-        "last_episode": 118,
-        "last_date": "2026-07-26",
-        "days_since": 2,
-        "cools_in_days": 19
-      },
-      {
-        "tag": "valuation_discipline",
-        "count": 42,
-        "last_episode": 118,
-        "last_date": "2026-07-26",
         "days_since": 2,
         "cools_in_days": 19
       },
@@ -7708,103 +7750,87 @@
         "count": 9,
         "last_episode": 118,
         "last_date": "2026-07-26",
-        "days_since": 2,
-        "cools_in_days": 19
+        "days_since": 3,
+        "cools_in_days": 18
       },
       {
         "tag": "earnings_surprise",
         "count": 23,
         "last_episode": 118,
         "last_date": "2026-07-26",
-        "days_since": 2,
-        "cools_in_days": 19
+        "days_since": 3,
+        "cools_in_days": 18
       },
       {
         "tag": "dividend_compounding",
         "count": 3,
         "last_episode": 117,
         "last_date": "2026-07-25",
-        "days_since": 3,
-        "cools_in_days": 18
+        "days_since": 4,
+        "cools_in_days": 17
       },
       {
         "tag": "geopolitical_premium",
         "count": 18,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 4,
-        "cools_in_days": 26
-      },
-      {
-        "tag": "tax_loss_harvesting",
-        "count": 9,
-        "last_episode": 116,
-        "last_date": "2026-07-24",
-        "days_since": 4,
-        "cools_in_days": 17
+        "days_since": 5,
+        "cools_in_days": 25
       },
       {
         "tag": "momentum_entry",
         "count": 40,
         "last_episode": 116,
         "last_date": "2026-07-24",
-        "days_since": 4,
-        "cools_in_days": 17
-      },
-      {
-        "tag": "risk_management",
-        "count": 25,
-        "last_episode": 114,
-        "last_date": "2026-07-22",
-        "days_since": 6,
-        "cools_in_days": 15
+        "days_since": 5,
+        "cools_in_days": 16
       },
       {
         "tag": "technical_breakout",
         "count": 9,
         "last_episode": 113,
         "last_date": "2026-07-21",
-        "days_since": 7,
-        "cools_in_days": 14
+        "days_since": 8,
+        "cools_in_days": 13
       },
       {
         "tag": "dollar_cost_averaging",
         "count": 4,
         "last_episode": 113,
         "last_date": "2026-07-21",
-        "days_since": 7,
-        "cools_in_days": 14
+        "days_since": 8,
+        "cools_in_days": 13
       },
       {
         "tag": "technical_support",
         "count": 9,
         "last_episode": 111,
         "last_date": "2026-07-19",
-        "days_since": 9,
-        "cools_in_days": 12
+        "days_since": 10,
+        "cools_in_days": 11
       },
       {
         "tag": "sector_concentration",
         "count": 16,
         "last_episode": 104,
         "last_date": "2026-07-12",
-        "days_since": 16,
-        "cools_in_days": 5
+        "days_since": 17,
+        "cools_in_days": 4
       },
       {
         "tag": "analyst_upgrade",
         "count": 18,
         "last_episode": 101,
         "last_date": "2026-07-09",
-        "days_since": 19,
-        "cools_in_days": 2
+        "days_since": 20,
+        "cools_in_days": 1
       }
     ],
     "sector_concentration_warning": "tech: 30% of recent trades (cumulative P&L $+18.84)",
     "execution_health": {
       "signal": {
-        "generated_at": "2026-07-27",
-        "age_days": 1,
+        "generated_at": "2026-07-29",
+        "age_days": 0,
         "action": "no_trade",
         "symbol": null,
         "stale": false
@@ -8070,13 +8096,13 @@
       "channels": {
         "en": {
           "subscribers": 230,
-          "subscribers_delta_7d": 20,
+          "subscribers_delta_7d": 23,
           "total_views": 62580,
           "video_count": 2052
         },
         "ru": {
           "subscribers": 69,
-          "subscribers_delta_7d": 15,
+          "subscribers_delta_7d": 8,
           "total_views": 35541,
           "video_count": 557
         }
@@ -9117,11 +9143,11 @@
     }
   },
   "efficiency": {
-    "cost_7d_usd": 9.6679,
-    "episodes_7d": 140,
+    "cost_7d_usd": 12.0269,
+    "episodes_7d": 133,
     "op3_downloads_7d": 1041,
     "op3_downloads_30d": 3689,
-    "usd_per_op3_download_7d": 0.0093,
+    "usd_per_op3_download_7d": 0.0116,
     "youtube_views_window": 35441,
     "youtube_window_days": 90,
     "usd_per_yt_view": 0.0003,
@@ -9143,10 +9169,10 @@
         "spotify_streams_30d": null
       },
       "dp_pod": {
-        "cost_7d_usd": 0.6476,
+        "cost_7d_usd": 0.5759,
         "op3_downloads_7d": 8,
         "op3_downloads_30d": 8,
-        "usd_per_op3_download": 0.0809,
+        "usd_per_op3_download": 0.072,
         "youtube_views": 0,
         "youtube_avg_view_pct": null,
         "youtube_subs_gained": 0,
@@ -9154,21 +9180,21 @@
         "spotify_streams_30d": null
       },
       "env_intel": {
-        "cost_7d_usd": 0.1432,
+        "cost_7d_usd": 0.0886,
         "op3_downloads_7d": 7,
         "op3_downloads_30d": 76,
-        "usd_per_op3_download": 0.0205,
+        "usd_per_op3_download": 0.0127,
         "youtube_views": 125,
         "youtube_avg_view_pct": 30.1,
         "youtube_subs_gained": 0,
-        "usd_per_yt_view": 0.0011,
+        "usd_per_yt_view": 0.0007,
         "spotify_streams_30d": null
       },
       "fascinating_frontiers": {
-        "cost_7d_usd": 0.9564,
+        "cost_7d_usd": 0.8865,
         "op3_downloads_7d": 57,
         "op3_downloads_30d": 220,
-        "usd_per_op3_download": 0.0168,
+        "usd_per_op3_download": 0.0156,
         "youtube_views": 9333,
         "youtube_avg_view_pct": 41.4,
         "youtube_subs_gained": 15,
@@ -9187,21 +9213,21 @@
         "spotify_streams_30d": null
       },
       "first_principles": {
-        "cost_7d_usd": 0.7495,
+        "cost_7d_usd": 1.0166,
         "op3_downloads_7d": 28,
         "op3_downloads_30d": 86,
-        "usd_per_op3_download": 0.0268,
+        "usd_per_op3_download": 0.0363,
         "youtube_views": 524,
         "youtube_avg_view_pct": 36.8,
         "youtube_subs_gained": 0,
-        "usd_per_yt_view": 0.0014,
+        "usd_per_yt_view": 0.0019,
         "spotify_streams_30d": null
       },
       "models_agents": {
-        "cost_7d_usd": 0.8762,
+        "cost_7d_usd": 0.7913,
         "op3_downloads_7d": 154,
         "op3_downloads_30d": 626,
-        "usd_per_op3_download": 0.0057,
+        "usd_per_op3_download": 0.0051,
         "youtube_views": 1041,
         "youtube_avg_view_pct": 26.0,
         "youtube_subs_gained": 10,
@@ -9209,47 +9235,47 @@
         "spotify_streams_30d": 97
       },
       "models_agents_beginners": {
-        "cost_7d_usd": 0.6333,
+        "cost_7d_usd": 0.8851,
         "op3_downloads_7d": 51,
         "op3_downloads_30d": 236,
-        "usd_per_op3_download": 0.0124,
+        "usd_per_op3_download": 0.0174,
         "youtube_views": 645,
         "youtube_avg_view_pct": 21.6,
         "youtube_subs_gained": 5,
-        "usd_per_yt_view": 0.001,
+        "usd_per_yt_view": 0.0014,
         "spotify_streams_30d": 9
       },
       "modern_investing": {
-        "cost_7d_usd": 0.7962,
+        "cost_7d_usd": 1.5418,
         "op3_downloads_7d": 49,
         "op3_downloads_30d": 225,
-        "usd_per_op3_download": 0.0162,
+        "usd_per_op3_download": 0.0315,
         "youtube_views": 1495,
         "youtube_avg_view_pct": 22.5,
         "youtube_subs_gained": 0,
-        "usd_per_yt_view": 0.0005,
+        "usd_per_yt_view": 0.001,
         "spotify_streams_30d": null
       },
       "omni_view": {
-        "cost_7d_usd": 0.9251,
+        "cost_7d_usd": 1.2054,
         "op3_downloads_7d": 55,
         "op3_downloads_30d": 197,
-        "usd_per_op3_download": 0.0168,
+        "usd_per_op3_download": 0.0219,
         "youtube_views": 594,
         "youtube_avg_view_pct": 30.3,
         "youtube_subs_gained": 2,
-        "usd_per_yt_view": 0.0016,
+        "usd_per_yt_view": 0.002,
         "spotify_streams_30d": null
       },
       "planetterrian": {
-        "cost_7d_usd": 0.9746,
+        "cost_7d_usd": 1.2823,
         "op3_downloads_7d": 48,
         "op3_downloads_30d": 216,
-        "usd_per_op3_download": 0.0203,
+        "usd_per_op3_download": 0.0267,
         "youtube_views": 273,
         "youtube_avg_view_pct": 28.6,
         "youtube_subs_gained": 3,
-        "usd_per_yt_view": 0.0036,
+        "usd_per_yt_view": 0.0047,
         "spotify_streams_30d": 28
       },
       "privet_russian": {
@@ -9264,10 +9290,10 @@
         "spotify_streams_30d": 3
       },
       "spacex": {
-        "cost_7d_usd": 0.9841,
+        "cost_7d_usd": 1.2185,
         "op3_downloads_7d": 316,
         "op3_downloads_30d": 715,
-        "usd_per_op3_download": 0.0031,
+        "usd_per_op3_download": 0.0039,
         "youtube_views": 12566,
         "youtube_avg_view_pct": 37.8,
         "youtube_subs_gained": 20,
@@ -9275,32 +9301,32 @@
         "spotify_streams_30d": 85
       },
       "tesla": {
-        "cost_7d_usd": 1.1483,
+        "cost_7d_usd": 1.4305,
         "op3_downloads_7d": 213,
         "op3_downloads_30d": 831,
-        "usd_per_op3_download": 0.0054,
+        "usd_per_op3_download": 0.0067,
         "youtube_views": 7862,
         "youtube_avg_view_pct": 45.6,
         "youtube_subs_gained": 12,
-        "usd_per_yt_view": 0.0001,
+        "usd_per_yt_view": 0.0002,
         "spotify_streams_30d": 18
       },
       "unintended_consequences": {
-        "cost_7d_usd": 0.6303,
+        "cost_7d_usd": 0.9013,
         "op3_downloads_7d": 39,
         "op3_downloads_30d": 174,
-        "usd_per_op3_download": 0.0162,
+        "usd_per_op3_download": 0.0231,
         "youtube_views": 265,
         "youtube_avg_view_pct": 21.3,
         "youtube_subs_gained": 1,
-        "usd_per_yt_view": 0.0024,
+        "usd_per_yt_view": 0.0034,
         "spotify_streams_30d": 43
       }
     }
   },
   "catalog": {
     "shows_count": 15,
-    "network_episodes_to_date": 1715,
+    "network_episodes_to_date": 1724,
     "network_news_sources": 257,
     "network_web_search_queries": 64,
     "per_show": {
@@ -9395,16 +9421,16 @@
       },
       "first_principles": {
         "name": "First Principles Daily",
-        "episodes_to_date": 53,
-        "episodes_in_feed": 53,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 54,
+        "episodes_in_feed": 54,
+        "latest_date": "2026-07-29",
         "news_sources": 0,
         "web_search_queries": 0,
         "narrative_mode": true,
         "topic_queue": {
           "total": 106,
-          "produced": 53,
-          "remaining": 53
+          "produced": 54,
+          "remaining": 52
         },
         "capabilities": {
           "x": false,
@@ -9433,9 +9459,9 @@
       },
       "models_agents_beginners": {
         "name": "Models & Agents for Beginners",
-        "episodes_to_date": 116,
-        "episodes_in_feed": 116,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 117,
+        "episodes_in_feed": 117,
+        "latest_date": "2026-07-29",
         "news_sources": 15,
         "web_search_queries": 3,
         "narrative_mode": false,
@@ -9450,9 +9476,9 @@
       },
       "modern_investing": {
         "name": "Modern Investing Techniques",
-        "episodes_to_date": 119,
-        "episodes_in_feed": 119,
-        "latest_date": "2026-07-27",
+        "episodes_to_date": 121,
+        "episodes_in_feed": 121,
+        "latest_date": "2026-07-29",
         "news_sources": 22,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -9467,9 +9493,9 @@
       },
       "omni_view": {
         "name": "Omni View",
-        "episodes_to_date": 126,
-        "episodes_in_feed": 126,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 127,
+        "episodes_in_feed": 127,
+        "latest_date": "2026-07-29",
         "news_sources": 37,
         "web_search_queries": 5,
         "narrative_mode": false,
@@ -9484,9 +9510,9 @@
       },
       "planetterrian": {
         "name": "Planetterrian Daily",
-        "episodes_to_date": 134,
-        "episodes_in_feed": 122,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 135,
+        "episodes_in_feed": 123,
+        "latest_date": "2026-07-29",
         "news_sources": 26,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -9518,9 +9544,9 @@
       },
       "spacex": {
         "name": "SpaceX Daily",
-        "episodes_to_date": 47,
-        "episodes_in_feed": 47,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 48,
+        "episodes_in_feed": 48,
+        "latest_date": "2026-07-29",
         "news_sources": 15,
         "web_search_queries": 9,
         "narrative_mode": false,
@@ -9535,9 +9561,9 @@
       },
       "tesla": {
         "name": "Tesla Shorts Time",
-        "episodes_to_date": 555,
-        "episodes_in_feed": 208,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 556,
+        "episodes_in_feed": 209,
+        "latest_date": "2026-07-29",
         "news_sources": 20,
         "web_search_queries": 10,
         "narrative_mode": false,
@@ -9552,16 +9578,16 @@
       },
       "unintended_consequences": {
         "name": "Unintended Consequences",
-        "episodes_to_date": 72,
-        "episodes_in_feed": 72,
-        "latest_date": "2026-07-28",
+        "episodes_to_date": 73,
+        "episodes_in_feed": 73,
+        "latest_date": "2026-07-29",
         "news_sources": 0,
         "web_search_queries": 0,
         "narrative_mode": true,
         "topic_queue": {
           "total": 125,
-          "produced": 72,
-          "remaining": 53
+          "produced": 73,
+          "remaining": 52
         },
         "capabilities": {
           "x": true,
@@ -9575,16 +9601,16 @@
   },
   "gallery": {
     "configured": true,
-    "generated_at": "2026-07-28T14:37:05+00:00",
-    "image_count": 4029,
-    "latest_image_at": "2026-07-28T13:58:33+00:00",
+    "generated_at": "2026-07-29T12:28:04+00:00",
+    "image_count": 4117,
+    "latest_image_at": "2026-07-29T12:04:09+00:00",
     "per_show": {
       "env_intel": {
         "count": 96,
         "name": "Environmental Intelligence"
       },
       "fascinating_frontiers": {
-        "count": 383,
+        "count": 391,
         "name": "Fascinating Frontiers"
       },
       "finansy_prosto": {
@@ -9592,27 +9618,27 @@
         "name": "Финансы Просто"
       },
       "first_principles": {
-        "count": 367,
+        "count": 375,
         "name": "First Principles Daily"
       },
       "models_agents": {
-        "count": 272,
+        "count": 280,
         "name": "Models & Agents"
       },
       "models_agents_beginners": {
-        "count": 422,
+        "count": 430,
         "name": "Models & Agents for Beginners"
       },
       "modern_investing": {
-        "count": 360,
+        "count": 376,
         "name": "Modern Investing Techniques"
       },
       "omni_view": {
-        "count": 269,
+        "count": 277,
         "name": "Omni View"
       },
       "planetterrian": {
-        "count": 269,
+        "count": 277,
         "name": "Planetterrian Daily"
       },
       "privet_russian": {
@@ -9620,139 +9646,47 @@
         "name": "Привет, Русский!"
       },
       "spacex": {
-        "count": 359,
+        "count": 367,
         "name": "SpaceX Daily"
       },
       "tesla": {
-        "count": 568,
+        "count": 576,
         "name": "Tesla Shorts Time"
       },
       "unintended_consequences": {
-        "count": 256,
+        "count": 264,
         "name": "Unintended Consequences"
       }
     },
     "intended_use": {
-      "social": 2013,
-      "segment_card": 2016
+      "social": 2057,
+      "segment_card": 2060
     },
     "licenses": {
-      "CC BY-SA 4.0": 4029
+      "CC BY-SA 4.0": 4117
     },
     "retention": {
       "available": true,
-      "generated": "2026-07-27T18:29:13.722057+00:00",
+      "generated": "2026-07-28T18:21:06.922508+00:00",
       "shows_analyzed": 13,
-      "images_with_retention": 2151
+      "images_with_retention": 2219
     }
   },
   "content_lake": {
     "stats": {
-      "total_episodes": 1250,
-      "shows": [
-        "age_of_ai",
-        "dp_pod",
-        "env_intel",
-        "fascinating_frontiers",
-        "finansy_prosto",
-        "first_principles",
-        "models_agents",
-        "models_agents_beginners",
-        "modern_investing",
-        "omni_view",
-        "planetterrian",
-        "privet_russian",
-        "spacex",
-        "tesla",
-        "unintended_consequences"
-      ],
+      "total_episodes": 0,
+      "shows": [],
       "date_range": {
-        "earliest": "2026-02-26",
-        "latest": "2026-07-28"
+        "earliest": null,
+        "latest": null
       },
-      "per_show": {
-        "age_of_ai": {
-          "count": 1,
-          "earliest": "2026-07-20",
-          "latest": "2026-07-20"
-        },
-        "dp_pod": {
-          "count": 22,
-          "earliest": "2026-07-04",
-          "latest": "2026-07-28"
-        },
-        "env_intel": {
-          "count": 59,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-27"
-        },
-        "fascinating_frontiers": {
-          "count": 114,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-28"
-        },
-        "finansy_prosto": {
-          "count": 70,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-27"
-        },
-        "first_principles": {
-          "count": 53,
-          "earliest": "2026-06-07",
-          "latest": "2026-07-28"
-        },
-        "models_agents": {
-          "count": 125,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-28"
-        },
-        "models_agents_beginners": {
-          "count": 110,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-28"
-        },
-        "modern_investing": {
-          "count": 119,
-          "earliest": "2026-03-20",
-          "latest": "2026-07-27"
-        },
-        "omni_view": {
-          "count": 124,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-28"
-        },
-        "planetterrian": {
-          "count": 111,
-          "earliest": "2026-02-26",
-          "latest": "2026-07-28"
-        },
-        "privet_russian": {
-          "count": 63,
-          "earliest": "2026-03-14",
-          "latest": "2026-07-27"
-        },
-        "spacex": {
-          "count": 47,
-          "earliest": "2026-06-13",
-          "latest": "2026-07-28"
-        },
-        "tesla": {
-          "count": 160,
-          "earliest": "2026-02-27",
-          "latest": "2026-07-28"
-        },
-        "unintended_consequences": {
-          "count": 72,
-          "earliest": "2026-05-04",
-          "latest": "2026-07-28"
-        }
-      },
-      "total_words": 1561178
+      "per_show": {},
+      "total_words": 0
     },
     "db_path": "data/content_lake.db",
     "db_exists": true,
-    "db_size_bytes": 48058368,
-    "healthy": true,
+    "db_size_bytes": 45056,
+    "healthy": false,
     "compaction_note": "Run scripts/compact_lake.py or engine.content_lake.compact_lake() to prune old full text."
   },
   "distribution": {

--- a/management.html
+++ b/management.html
@@ -65,6 +65,45 @@
   .alert.fail { background: rgba(220,38,38,0.10); border: 1px solid rgba(220,38,38,0.4); color: #fecaca; }
   .alert code { font-size: 12px; }
 
+  /* ---- view switch (operator ⇄ sponsor) ----
+     One page, two audiences. Operator is the default and shows
+     everything. Sponsor hides internal spend and pipeline-health
+     surfaces and leads with the audience story, so the page can be
+     shared with a sponsor or buyer without a second build. The URL
+     carries the choice (?view=sponsor) so a shared link opens the
+     right way round. */
+  .view-switch { display: inline-flex; gap: 2px; padding: 3px; border-radius: 999px;
+    background: var(--surface-2); border: 1px solid var(--hairline); }
+  .view-switch button { appearance: none; border: 0; cursor: pointer;
+    font: inherit; font-size: 12px; font-weight: 600; letter-spacing: 0.01em;
+    padding: 5px 13px; border-radius: 999px; color: var(--ink-3);
+    background: transparent; transition: background 140ms ease, color 140ms ease; }
+  .view-switch button:hover { color: var(--ink-1); }
+  .view-switch button[aria-pressed="true"] { background: var(--accent);
+    color: #04121d; }
+  .view-note { font-size: 12px; color: var(--ink-4); margin-top: 6px; max-width: 62ch; }
+
+  /* Default (operator): sponsor-only surfaces stay hidden. */
+  [data-sponsor] { display: none; }
+  body.view-sponsor [data-sponsor] { display: revert; }
+  body.view-sponsor [data-ops] { display: none !important; }
+
+  /* ---- sponsor headline panel ---- */
+  .sponsor-hero { background: linear-gradient(135deg, rgba(0,212,255,0.07), transparent 55%),
+    var(--surface-1); border: 1px solid var(--hairline); border-radius: 16px;
+    padding: 20px 22px; margin-bottom: 22px; }
+  .sponsor-hero h2 { margin: 0 0 4px; font-size: 19px; letter-spacing: -0.01em; }
+  .sponsor-hero .lede { color: var(--ink-3); font-size: 13px; margin-bottom: 16px;
+    max-width: 78ch; }
+  .reach-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 14px; }
+  .reach-item { border-left: 2px solid var(--accent); padding-left: 11px; }
+  .reach-item .r-v { font-size: 25px; font-weight: 650; letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums; line-height: 1.1; }
+  .reach-item .r-l { font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--ink-4); margin-top: 3px; }
+  .reach-item .r-s { font-size: 11.5px; color: var(--ink-3); margin-top: 3px; }
+
   /* ---- hero stat tiles ---- */
   .tile-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 12px; margin-bottom: 28px; }
@@ -211,27 +250,38 @@
     <div class="subtitle" id="generated-at">Loading dashboard data…</div>
     <div class="subtitle" style="margin-top:2px;">RSS downloads · Spotify · Apple · YouTube · site · spend — side by side, never one fake “reach” number.</div>
   </div>
-  <div class="health-pills" id="status-summary" hidden>
-    <span class="pill ok"><span id="count-ok">0</span>&nbsp;OK</span>
-    <span class="pill warn"><span id="count-warn">0</span>&nbsp;warn</span>
-    <span class="pill fail"><span id="count-fail">0</span>&nbsp;fail</span>
-    <span class="pill idle" id="last-refreshed"></span>
+  <div style="display:flex;flex-direction:column;align-items:flex-end;gap:8px;">
+    <div class="view-switch" role="group" aria-label="Dashboard view">
+      <button type="button" id="view-operator" aria-pressed="true">Operator</button>
+      <button type="button" id="view-sponsor" aria-pressed="false">Sponsor</button>
+    </div>
+    <div class="health-pills" id="status-summary" data-ops hidden>
+      <span class="pill ok"><span id="count-ok">0</span>&nbsp;OK</span>
+      <span class="pill warn"><span id="count-warn">0</span>&nbsp;warn</span>
+      <span class="pill fail"><span id="count-fail">0</span>&nbsp;fail</span>
+      <span class="pill idle" id="last-refreshed"></span>
+    </div>
   </div>
+</div>
+<div class="view-note" id="view-note" hidden>
+  Sponsor view — audience, reach and catalogue only. Internal spend and
+  pipeline-health panels are hidden. Share this page with
+  <code>?view=sponsor</code> to open it here directly.
 </div>
 
 <nav class="mc-nav" aria-label="Sections">
   <a href="#audience-section">Audience</a>
   <a href="#distribution">Distribution</a>
   <a href="#catalog">Catalog</a>
-  <a href="#operations">Operations</a>
-  <a href="#library">Lake &amp; images</a>
+  <a href="#operations" data-ops>Operations</a>
+  <a href="#library" data-ops>Lake &amp; images</a>
   <a href="#shows">Shows</a>
-  <a href="#guards">Guards</a>
-  <a href="#voice">Voice</a>
+  <a href="#guards" data-ops>Guards</a>
+  <a href="#voice" data-ops>Voice</a>
   <a href="#mit">MIT performance</a>
-  <a href="#feeds">Feeds</a>
-  <a href="docs/analytics.md">Analytics contract ↗</a>
-  <a href="api/dashboard.json">Raw JSON ↗</a>
+  <a href="#feeds" data-ops>Feeds</a>
+  <a href="docs/analytics.md" data-ops>Analytics contract ↗</a>
+  <a href="api/dashboard.json" data-ops>Raw JSON ↗</a>
 </nav>
 
 <div id="error">
@@ -242,7 +292,14 @@
 
 <main id="content" hidden>
 
-  <div class="alert-band" id="alert-band"></div>
+  <div class="alert-band" id="alert-band" data-ops></div>
+
+  <section class="sponsor-hero" data-sponsor id="sponsor-hero">
+    <h2>Nerra Network at a glance</h2>
+    <div class="lede" id="sponsor-lede"></div>
+    <div class="reach-grid" id="reach-grid"></div>
+    <p class="view-note" id="sponsor-method" style="margin-top:15px;"></p>
+  </section>
 
   <div class="tile-row" id="tile-row"></div>
 
@@ -271,7 +328,7 @@
     </div>
   </section>
 
-  <section class="mc-section" id="operations">
+  <section class="mc-section" data-ops id="operations">
     <h2>Operations</h2>
     <div class="card-grid" id="operations-grid">
       <!-- Multilingual coverage card hydrates into this static anchor -->
@@ -279,7 +336,7 @@
     </div>
   </section>
 
-  <section class="mc-section" id="library">
+  <section class="mc-section" data-ops id="library">
     <h2>Content lake &amp; image library</h2>
     <div class="card-grid" id="library-grid"></div>
   </section>
@@ -289,13 +346,13 @@
     <div class="card-grid" id="shows-grid"></div>
   </section>
 
-  <section class="mc-section" id="guards">
+  <section class="mc-section" data-ops id="guards">
     <h2>Landmine guards</h2>
     <div id="claude-md-banner" hidden></div>
     <div class="card-grid" id="landmines-grid"></div>
   </section>
 
-  <section class="mc-section" id="voice">
+  <section class="mc-section" data-ops id="voice">
     <h2>Voice settings consistency</h2>
     <div class="mc-card" style="padding:0;overflow-x:auto;">
       <table class="mc-table" id="voice-table">
@@ -315,7 +372,7 @@
     <div id="mit-performance"></div>
   </section>
 
-  <section class="mc-section" id="feeds">
+  <section class="mc-section" data-ops id="feeds">
     <h2>Feed audit (latest)</h2>
     <div class="mc-card" id="feed-audit"></div>
   </section>
@@ -435,6 +492,10 @@
 
   const statTile = (label, value, opts = {}) => {
     const tile = h("div", { class: "tile" });
+    // Internal-only tiles (spend, per-episode cost) are hidden in the
+    // shareable sponsor view — see the view switch at the bottom.
+    if (opts.ops) tile.setAttribute("data-ops", "");
+    if (opts.sponsorOnly) tile.setAttribute("data-sponsor", "");
     tile.appendChild(h("div", { class: "t-label", text: label }));
     const v = h("div", { class: "t-value", text: value });
     if (opts.delta != null && opts.delta !== 0) {
@@ -519,6 +580,29 @@
     // quiet: surfaced in the Spotify card, not the alert band
   }
 
+  // Feeds confirmed live on the two directories that carry the large
+  // majority of podcast listening. Read from the live coverage table,
+  // never hardcoded, so the figure cannot outlive the reality it
+  // describes — and taken as the max rather than the sum, because the
+  // same feed listed on both platforms is one feed, not two.
+  function liveFeedCount(d) {
+    const plat = ((d.distribution || {}).platforms) || {};
+    return ["Apple", "Spotify"].reduce(function (best, name) {
+      return Math.max(best, (plat[name] || {}).live || 0);
+    }, 0);
+  }
+
+  // Distinct languages the network actually publishes audio in: English
+  // plus every language any show generates a translated track for.
+  function sponsorLanguageCount(d) {
+    const langs = new Set(["en"]);
+    const per = ((d.multilingual || {}).per_show) || {};
+    Object.keys(per).forEach(function (slug) {
+      (per[slug].languages || []).forEach(function (l) { langs.add(String(l)); });
+    });
+    return langs.size;
+  }
+
   // ---------- hero stat tiles ----------
   const tiles = $("#tile-row");
   const chSum = (field) => Object.values(yt.channels || {})
@@ -553,13 +637,25 @@
       spark: siteSpark,
       sparkTitle: "Daily active users, last " + siteSpark.length + " days" }));
   tiles.appendChild(statTile("Spend · 7d", money(data.network.total_cost_last_7_days_usd),
-    { sub: money(data.network.total_cost_last_30_days_usd) + " · 30d · " +
+    { ops: true,
+      sub: money(data.network.total_cost_last_30_days_usd) + " · 30d · " +
            (eff.usd_per_op3_download_7d != null
              ? ("$" + Number(eff.usd_per_op3_download_7d).toFixed(3) + "/RSS dl")
              : (money((cost.projections || {}).projected_weekly_usd) + "/wk burn")) }));
   tiles.appendChild(statTile("Episodes · 7d", fmt((cost.network_last_7_days || {}).episodes),
-    { sub: money((cost.projections || {}).avg_cost_per_episode_usd) + " avg / episode · " +
+    { ops: true,
+      sub: money((cost.projections || {}).avg_cost_per_episode_usd) + " avg / episode · " +
            fmt(catalog.shows_count || (data.network || {}).shows_count) + " shows" }));
+  // Sponsor-facing counterparts to the two tiles above: the same
+  // production reality stated as scale rather than as cost.
+  tiles.appendChild(statTile("Episodes published", compact(catalog.network_episodes_to_date),
+    { sponsorOnly: true,
+      sub: fmt((cost.network_last_7_days || {}).episodes) + " in the last 7d · " +
+           fmt(catalog.shows_count || (data.network || {}).shows_count) + " active shows" }));
+  tiles.appendChild(statTile("Languages", fmt(sponsorLanguageCount(data)),
+    { sponsorOnly: true,
+      sub: "original + translated audio tracks · " +
+           fmt(Object.keys(yt.channels || {}).length) + " YouTube channels" }));
   tiles.appendChild(statTile("Newsletter", bd.configured ? fmt(bd.subscriber_count) : "—",
     { sub: bd.configured ? "subscribers · Buttondown" : "not configured" }));
   tiles.appendChild(statTile("Image library", gallery.configured ? compact(gallery.image_count) : "—",
@@ -716,6 +812,27 @@
     audGrid.appendChild(card);
   }
 
+  // Is the Apple card's PRIMARY source actually reporting?
+  //
+  // The two Apple sources count shows under different keys — the cookie
+  // scrape publishes `feeds_reporting`, the official Reporter feed
+  // publishes `shows_reporting` — and the flattened view carries only
+  // whichever the primary source used. Testing `feeds_reporting` alone
+  // therefore read as "not reporting" on every Reporter-primary run, so
+  // the card claimed "0 of 0 registered shows" while sitting on real
+  // Apple data (60 plays across 2 shows on 2026-07-27). Ask the numbers
+  // instead of a source-specific key.
+  function appleIsReporting(ap) {
+    if (ap.shows_reporting > 0 || ap.feeds_reporting > 0) return true;
+    const t = ap.totals || {};
+    if ((t.plays || 0) > 0 || (t.listeners || 0) > 0) return true;
+    const per = ap.per_show || {};
+    return Object.keys(per).some(function (s) {
+      const v = per[s] || {};
+      return (v.plays || 0) > 0 || (v.listeners || 0) > 0;
+    });
+  }
+
   // Apple Podcasts — engagement (OP3 already has Apple downloads)
   {
     const ap = audience.apple || {};
@@ -731,7 +848,7 @@
               "plays and completion — the only finish-rate signal the network gets." }));
     } else if (ap.error) {
       card.appendChild(h("p", { class: "fine-list", text: "Apple error: " + ap.error }));
-    } else if (!(ap.feeds_reporting > 0)) {
+    } else if (!appleIsReporting(ap)) {
       card.appendChild(h("div", { class: "headline",
         html: "—<small>not reporting</small>" }));
       card.appendChild(h("p", { class: "platform-note", text:
@@ -1599,6 +1716,125 @@
   });
   det.appendChild(list);
   auditEl.appendChild(det);
+
+  // ---------- sponsor reach panel ----------
+  // Deliberately NOT one blended "reach" number. Each platform counts a
+  // different event (an RSS download is not a Spotify stream is not a
+  // YouTube view), and the network's own analytics contract says never
+  // to sum them into a single figure. A sponsor gets the real shape
+  // instead: what each surface delivers, and which way the trend runs.
+  (function renderSponsorPanel() {
+    const grid = $("#reach-grid");
+    if (!grid) return;
+    const weeks = (op3.network_weekly_history || []).map((r) => Number(r[1] || 0));
+    const lastW = weeks.length ? weeks[weeks.length - 1] : 0;
+    const prevW = weeks.length > 1 ? weeks[weeks.length - 2] : 0;
+    const growth = prevW > 0 ? Math.round(((lastW - prevW) / prevW) * 100) : null;
+    const ytViews = yt.network_views != null ? yt.network_views : chSum("total_views");
+    const ytSubs = chSum("subscribers");
+
+    const items = [
+      { v: compact(op3.network_downloads_30d), l: "Podcast downloads · 30d",
+        s: fmt(op3.network_downloads_all_time) + " all-time (OP3-verified)" },
+      { v: (growth == null ? "—" : (growth > 0 ? "+" : "") + growth + "%"),
+        l: "Week-over-week growth",
+        s: fmt(prevW) + " → " + fmt(lastW) + " downloads/wk" },
+      // Lifetime channel views, labelled as such. `network_views` is the
+      // 90-day Analytics window and reads as a lifetime figure if the
+      // label does not say otherwise — on a page a sponsor may rely on,
+      // the smaller honest number with the right label beats the bigger
+      // ambiguous one.
+      { v: compact(chSum("total_views")), l: "YouTube views · lifetime",
+        s: fmt(ytSubs) + " subscribers · " + compact(ytViews) + " views in the last " +
+           fmt(yt.window_days || 90) + "d" },
+      { v: sp.configured ? compact((sp.totals || {}).streams) : "—",
+        l: "Spotify streams · 30d",
+        s: sp.configured ? fmt((sp.totals || {}).listeners) + " listeners · " +
+           fmt((sp.totals || {}).followers) + " followers" : "not connected" },
+      { v: compact(catalog.network_episodes_to_date), l: "Episodes published",
+        s: fmt(catalog.shows_count || (data.network || {}).shows_count) +
+           " shows · " + fmt(sponsorLanguageCount(data)) + " languages" },
+      // Feeds actually listed, not directories counted. A bare "2" read
+      // as a weakness while its own subtitle claimed "every major
+      // directory" — the honest and stronger statement is how many show
+      // and language editions are live on the two platforms that carry
+      // the large majority of podcast listening.
+      { v: fmt(liveFeedCount(data)), l: "Feeds live on Apple + Spotify",
+        s: "every show and language edition listed · YouTube runs as its " +
+           "own channel network" },
+    ];
+    items.forEach((it) => {
+      const cell = h("div", { class: "reach-item" });
+      cell.appendChild(h("div", { class: "r-v", text: it.v }));
+      cell.appendChild(h("div", { class: "r-l", text: it.l }));
+      cell.appendChild(h("div", { class: "r-s", text: it.s }));
+      grid.appendChild(cell);
+    });
+
+    const lede = $("#sponsor-lede");
+    if (lede) {
+      lede.textContent =
+        fmt(catalog.shows_count || (data.network || {}).shows_count) +
+        " original shows publishing " +
+        fmt((cost.network_last_7_days || {}).episodes) +
+        " episodes a week in " + fmt(sponsorLanguageCount(data)) +
+        " languages, on Apple Podcasts, Spotify and YouTube.";
+    }
+    const method = $("#sponsor-method");
+    if (method) {
+      method.textContent =
+        "Every figure is measured, not modelled: downloads are IAB-style " +
+        "counts from OP3, YouTube from the official Analytics API, Spotify " +
+        "and Apple from their creator dashboards. Platform numbers are shown " +
+        "side by side and never summed — a download, a stream and a view are " +
+        "different events. Updated " + ageText(data.generated_at) + ".";
+    }
+  })();
+
+  // ---------- view switch ----------
+  (function viewSwitch() {
+    const opBtn = $("#view-operator");
+    const spBtn = $("#view-sponsor");
+    const note = $("#view-note");
+    if (!opBtn || !spBtn) return;
+
+    const h1 = document.querySelector(".mc-header h1");
+    const sub = document.querySelector(".mc-header .subtitle:last-of-type");
+    const OPERATOR_H1 = h1 ? h1.textContent : "";
+    const OPERATOR_SUB = sub ? sub.textContent : "";
+
+    function apply(view, push) {
+      const sponsor = view === "sponsor";
+      document.body.classList.toggle("view-sponsor", sponsor);
+      opBtn.setAttribute("aria-pressed", String(!sponsor));
+      spBtn.setAttribute("aria-pressed", String(sponsor));
+      if (note) note.hidden = !sponsor;
+      // The masthead is operator language ("Mission Control", "spend").
+      // Swap it rather than leaving a sponsor reading a console header.
+      if (h1) h1.textContent = sponsor
+        ? "Nerra Network — Audience & Reach" : OPERATOR_H1;
+      if (sub) sub.textContent = sponsor
+        ? "Downloads, streams, views and subscribers — measured per platform, never blended into one number."
+        : OPERATOR_SUB;
+      try { localStorage.setItem("nerraDashView", view); } catch (e) { /* private mode */ }
+      if (push) {
+        const u = new URL(window.location.href);
+        if (sponsor) u.searchParams.set("view", "sponsor");
+        else u.searchParams.delete("view");
+        history.replaceState(null, "", u);
+      }
+    }
+
+    // URL wins over the stored preference, so a shared link always opens
+    // the way the sender intended.
+    let initial = new URLSearchParams(window.location.search).get("view");
+    if (initial !== "sponsor" && initial !== "operator") {
+      try { initial = localStorage.getItem("nerraDashView"); } catch (e) { initial = null; }
+    }
+    apply(initial === "sponsor" ? "sponsor" : "operator", false);
+    opBtn.addEventListener("click", () => apply("operator", true));
+    spBtn.addEventListener("click", () => apply("sponsor", true));
+  })();
 })();
 </script>
 </body>

--- a/tests/test_management_views.py
+++ b/tests/test_management_views.py
@@ -1,0 +1,172 @@
+"""Drift guards for management.html — the Apple card and the view switch.
+
+Two things this pins:
+
+1. **The Apple card's emptiness test.** The two Apple sources count
+   shows under different keys — the cookie scrape publishes
+   ``feeds_reporting``, the official Reporter feed publishes
+   ``shows_reporting`` — and the dashboard flattens only whichever the
+   primary source used. Testing ``feeds_reporting`` alone therefore read
+   as "not reporting" on every Reporter-primary run: the card announced
+   "0 of 0 registered shows returned engagement" while sitting on real
+   Apple data (60 plays across 2 shows on 2026-07-27). That is the
+   "Apple Podcasts section shows no information" the operator reported.
+
+2. **The operator ⇄ sponsor view contract.** The same page serves an
+   internal console and a shareable audience view. Operator is the
+   default and must keep showing everything; sponsor must hide internal
+   spend and pipeline-health surfaces. A regression in either direction
+   is silent — the page still renders, it just shows the wrong audience
+   the wrong thing.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PAGE = REPO_ROOT / "management.html"
+
+
+def _page() -> str:
+    return PAGE.read_text(encoding="utf-8")
+
+
+class TestAppleCardReadsEitherSource:
+    def test_emptiness_check_is_not_source_specific(self):
+        src = _page()
+        assert "function appleIsReporting" in src
+        # The old guard: a bare feeds_reporting test in the card's own
+        # branch. It must not come back.
+        assert "!(ap.feeds_reporting > 0)" not in src
+        assert "} else if (!appleIsReporting(ap)) {" in src
+
+    def test_helper_accepts_the_reporter_key(self):
+        src = _page()
+        body = src[src.index("function appleIsReporting"):]
+        body = body[:body.index("\n  }")]
+        assert "shows_reporting" in body, (
+            "the official Reporter feed counts shows under shows_reporting"
+        )
+        assert "feeds_reporting" in body, (
+            "the cookie scrape counts them under feeds_reporting"
+        )
+
+    def test_helper_falls_back_to_the_numbers(self):
+        """Neither key is guaranteed — a source that reports totals but
+        no count must still render rather than claim nothing arrived."""
+        body = _page()
+        body = body[body.index("function appleIsReporting"):]
+        body = body[:body.index("\n  }")]
+        assert "totals" in body and "per_show" in body
+
+    def test_live_dashboard_would_render_the_card(self):
+        """Guards the actual committed data, not just the code: with the
+        current api/dashboard.json the card must have something to show."""
+        data = json.loads(
+            (REPO_ROOT / "api" / "dashboard.json").read_text(encoding="utf-8"))
+        ap = ((data.get("audience") or {}).get("apple") or {})
+        if not ap.get("configured"):
+            return  # unconfigured is a legitimate state
+        totals = ap.get("totals") or {}
+        per_show = ap.get("per_show") or {}
+        reporting = (
+            (ap.get("shows_reporting") or 0) > 0
+            or (ap.get("feeds_reporting") or 0) > 0
+            or (totals.get("plays") or 0) > 0
+            or (totals.get("listeners") or 0) > 0
+            or any((v or {}).get("plays") for v in per_show.values())
+        )
+        assert reporting, (
+            "Apple is configured but the committed dashboard has no "
+            "renderable engagement — regenerate api/dashboard.json"
+        )
+
+    def test_flattening_survives_in_the_generator(self):
+        """The card reads flattened keys; the generator must keep
+        producing them alongside the two-source `sources` block."""
+        gen = (REPO_ROOT / "scripts" / "generate_dashboard.py").read_text(
+            encoding="utf-8")
+        assert "Flattened view of the primary source" in gen
+
+
+class TestViewSwitch:
+    def test_operator_is_the_default(self):
+        src = _page()
+        assert 'id="view-operator" aria-pressed="true"' in src
+        assert 'id="view-sponsor" aria-pressed="false"' in src
+
+    def test_sponsor_hides_ops_and_shows_sponsor_surfaces(self):
+        src = _page()
+        assert "body.view-sponsor [data-ops] { display: none !important; }" in src
+        assert "[data-sponsor] { display: none; }" in src
+        assert "body.view-sponsor [data-sponsor] { display: revert; }" in src
+
+    def test_internal_surfaces_are_tagged(self):
+        """Spend, alerts, health pills and the ops-only sections must all
+        carry data-ops or the sponsor view leaks internals."""
+        src = _page()
+        for marker in (
+            '<div class="alert-band" id="alert-band" data-ops>',
+            '<div class="health-pills" id="status-summary" data-ops hidden>',
+        ):
+            assert marker in src, marker
+        for section in ("operations", "library", "guards", "voice", "feeds"):
+            assert f'<section class="mc-section" data-ops id="{section}">' in src, section
+
+    def test_spend_tiles_are_operator_only(self):
+        src = _page()
+        spend = src[src.index('statTile("Spend · 7d"'):]
+        assert "ops: true" in spend[:400]
+        episodes = src[src.index('statTile("Episodes · 7d"'):]
+        assert "ops: true" in episodes[:400]
+
+    def test_url_parameter_overrides_the_stored_preference(self):
+        """A shared ?view=sponsor link must open in sponsor view even for
+        someone whose localStorage says operator."""
+        src = _page()
+        switch = src[src.index("function viewSwitch"):]
+        url_idx = switch.index('URLSearchParams(window.location.search).get("view")')
+        store_idx = switch.index('localStorage.getItem("nerraDashView")')
+        assert url_idx < store_idx, "URL must be consulted before localStorage"
+
+    def test_private_mode_cannot_break_the_switch(self):
+        """localStorage throws in some privacy modes; the toggle must not
+        take the page down with it."""
+        src = _page()
+        switch = src[src.index("function viewSwitch"):]
+        assert re.search(r"try \{ localStorage\.setItem", switch)
+        assert re.search(r"catch \(e\) \{ /\* private mode \*/ \}", switch)
+
+
+class TestSponsorFiguresStayHonest:
+    """The sponsor view is the one surface an outside party may rely on,
+    so its claims have to match what the data actually means."""
+
+    def test_youtube_views_are_labelled_lifetime(self):
+        src = _page()
+        assert 'l: "YouTube views · lifetime"' in src
+        # network_views is the 90-day Analytics window, not lifetime; it
+        # may appear as the secondary line but never as the headline.
+        panel = src[src.index("function renderSponsorPanel"):]
+        panel = panel[:panel.index("// ---------- view switch")]
+        headline = panel[panel.index('l: "YouTube views · lifetime"') - 200:
+                         panel.index('l: "YouTube views · lifetime"')]
+        assert 'chSum("total_views")' in headline
+
+    def test_platform_count_is_derived_not_hardcoded(self):
+        src = _page()
+        assert "function liveFeedCount" in src
+        body = src[src.index("function liveFeedCount"):]
+        body = body[:body.index("\n  }")]
+        assert "distribution" in body and "live" in body
+
+    def test_no_blended_reach_number(self):
+        """The analytics contract forbids summing downloads, streams and
+        views into one figure. The sponsor panel must respect it."""
+        src = _page()
+        panel = src[src.index("function renderSponsorPanel"):]
+        panel = panel[:panel.index("// ---------- view switch")]
+        assert "never" in panel.lower() and "sum" in panel.lower()


### PR DESCRIPTION
Fixes the Apple section you flagged, and turns `management.html` into something you can send to a sponsor or buyer without a second build. Full suite green (4,957 passed); both views verified in a real browser.

## The Apple bug — a key-name mismatch, not missing data

The card announced **"0 of 0 registered shows returned engagement"** and blamed a "connector/cookie problem" while sitting on real Apple data: **60 plays, 16 listeners across 2 shows** for 2026-07-27.

Cause: the two Apple sources count shows under different keys — the cookie scrape publishes `feeds_reporting`, the official Reporter feed publishes `shows_reporting` — and the dashboard flattens only whichever the primary source used. The card tested `feeds_reporting` alone, so **every Reporter-primary run rendered the empty state**. It now asks the numbers (totals / per-show plays) rather than a source-specific key.

Secondary finding: the committed `api/dashboard.json` was also a run behind. Nightly starts 16:45 UTC; the Apple flattening merged 17:37 — that night's dashboard was generated from pre-merge code, then rebased onto newer main before pushing. Regenerated here. Tonight's run would have fixed the data, but the card was broken either way.

Apple now renders: `60 plays · 1d | 16 listeners | 7 engaged`, with the per-show breakdown.

## Sponsor view

`management.html` is robots-disallowed but URL-reachable, so it's already the natural thing to send someone — it just spoke entirely in operator language. A switch in the header now toggles:

- **Operator** (default, unchanged) — everything, exactly as before.
- **Sponsor** — leads with an audience panel; hides spend, alert band, health pills, and the ops-only sections (operations, lake & images, guards, voice, feeds).

The choice rides in the URL (`?view=sponsor`) so a shared link opens the way you intended, falling back to `localStorage` — wrapped in try/catch, since that throws in some privacy modes and taking the page down to remember a toggle would be a poor trade.

The panel reads from live data:

| | |
|---|---|
| **3,689** podcast downloads · 30d | 4,175 all-time, OP3-verified |
| **+10%** week-over-week | 944 → 1,041 downloads/wk |
| **98.1K** YouTube views · lifetime | 299 subscribers · 35.4K in last 90d |
| **284** Spotify streams · 30d | 113 listeners · 33 followers |
| **1,724** episodes published | 15 shows · 4 languages |
| **17** feeds live on Apple + Spotify | every show and language edition |

## Three figures I corrected before this could face an outsider

1. **YouTube views** headlined the 90-day Analytics window (35.4K) with no window in the label — it read as lifetime. Now lifetime (98.1K) with the 90-day figure as the secondary line.
2. **"2 distribution platforms"** was counted from directories with any live feed, and sat directly above a subtitle claiming "every major directory". Now "17 feeds live on Apple + Spotify" — the honest statement and the stronger one.
3. **The lede** claimed distribution to "every major podcast directory" when only Apple and Spotify are verified live.

No blended "reach" number anywhere — the analytics contract says a download, a stream and a view are different events, and the panel says so on the page.

## Verification

- Both views driven in a headless browser: operator unchanged (16 ops surfaces visible, spend tile present), sponsor hides all 16, toggling round-trips and rewrites the URL, **zero JS errors**.
- 14 new guards in `tests/test_management_views.py` pin the Apple emptiness check against *both* source shapes, the operator default, the ops tagging, URL-over-localStorage precedence, and that the sponsor figures stay honest (lifetime label, derived platform count, no blended total).

## Worth knowing

- The other "—" values I checked are **correctly** absent, not broken: Spotify genuinely has no plays yet for most shows, and the dashboard deliberately shows "—" rather than a fake 0.
- Newsletter (3 subscribers) and site traffic (69 users/30d) are real and stay visible in sponsor view — they're small, and I'd rather you decide what to show than have the page quietly flatter you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Most risk is in the regenerated `api/dashboard.json` (including a possible content-lake data regression) and sponsor-facing metrics that outsiders may rely on; the UI logic changes are covered by new tests.
> 
> **Overview**
> **Fixes the Apple Podcasts card** on `management.html` so it no longer treats `feeds_reporting` as the only signal of data. A new `appleIsReporting()` helper also accepts `shows_reporting` (Reporter) and falls back to totals / per-show plays, fixing the false “0 of 0 shows” empty state when engagement data is present.
> 
> **Adds an Operator ⇄ Sponsor toggle** on the same page: sponsor mode (`?view=sponsor`, with localStorage fallback) hides `data-ops` surfaces (spend, alerts, ops sections) and shows a sponsor hero with per-platform reach figures—lifetime YouTube views, derived Apple+Spotify live feed count, and explicit “never sum platforms” copy—plus sponsor-only hero tiles.
> 
> **Refreshes `api/dashboard.json`** with a newer nightly snapshot (costs, episodes, RSS, multilingual breakdown, etc.). The diff also shows **`content_lake` collapsing to zero episodes** with `healthy: false` and a tiny DB size—worth confirming that’s intentional from the generator run, not a regression.
> 
> **Adds `tests/test_management_views.py`** to guard the Apple check, view-switch contract, and sponsor labeling honesty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a45b57d65e3f35fbcb8b85f4dcb04bc3c455de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->