### PR TITLE
YouTube: repair back-catalogue titles/tags/descriptions + bring @NerraFR into the feedback loop

### DIFF
--- a/engine/shorts_hashtags.py
+++ b/engine/shorts_hashtags.py
@@ -61,6 +61,11 @@ _STOPWORDS = frozenset((
 _MIN_ACRONYM_LEN = 2
 _MAX_ACRONYM_LEN = 6
 
+# Longest run of Title-Case words still treated as ONE named entity.
+# "Modern Investing Techniques" is an entity; a nine-word run is a
+# sentence fragment nobody searches for.
+_MAX_ENTITY_WORDS = 3
+
 # Hashtag character class — YouTube accepts letters / digits /
 # underscores after the ``#``. Anything else terminates the tag.
 _HASHTAG_BODY_RE = re.compile(r"[A-Za-z0-9_]+")
@@ -297,11 +302,29 @@ def extract_entity_phrases(
     out: List[str] = []
     seen: set = set()
 
-    def _add(phrase: str) -> None:
+    def _add(phrase: str, *, protected: bool = False) -> None:
+        """Add a tag phrase, suppressing fragments of one already taken.
+
+        ``extract_hashtags`` has always de-duped by substring so that
+        "#Tesla" cannot eat a slot "#TeslaCybercab" already covers; this
+        sibling never did, so a hook like "…at its German Gigafactory"
+        shipped `german gigafactory`, `german` AND `gigafactory` — two of
+        the show's 30 tag slots spent on halves of a phrase already
+        present, and "german" alone describes nothing about the episode.
+        Same rule here, with one exception: the show's own configured
+        keywords (step 4) are deliberate and keep their slot even when a
+        longer phrase happens to contain them, so a Tesla episode never
+        loses the "tesla" tag just because "tesla cybercab" ranked first.
+        """
         p = " ".join(phrase.split()).strip().lower()
-        if p and p not in seen:
-            seen.add(p)
-            out.append(p)
+        if not p or p in seen:
+            return
+        if not protected:
+            for picked in seen:
+                if p in picked:
+                    return
+        seen.add(p)
+        out.append(p)
 
     def _edge_strip(tok: str) -> str:
         return tok.strip(".,!?:;\"'()[]{}")
@@ -317,7 +340,13 @@ def extract_entity_phrases(
                 run.append(tokens[j])
                 j += 1
             if len(run) >= 2:
-                _add(" ".join(_edge_strip(t) for t in run))
+                # Cap the entity at three words. A named entity is
+                # "Tesla Cybercab" or "Modern Investing Techniques";
+                # anything longer is a sentence fragment that nobody
+                # searches for, and — now that fragments of a taken
+                # phrase are suppressed — a long run would also swallow
+                # every useful single term inside it.
+                _add(" ".join(_edge_strip(t) for t in run[:_MAX_ENTITY_WORDS]))
             i = j
         else:
             i += 1
@@ -331,7 +360,7 @@ def extract_entity_phrases(
             _add(_edge_strip(t))
     # 4) show keywords fill remaining slots
     for kw in (show_keywords or []):
-        _add(str(kw))
+        _add(str(kw), protected=True)
 
     return out[:max_phrases]
 

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -427,11 +427,40 @@ def build_long_form_metadata(
     except Exception:  # noqa: BLE001 — hashtags must never block an upload
         _hashtag_line = ""
 
+    # What the episode is actually ABOUT, directly under the hook.
+    # Previously the first thing after the hook was three promotional
+    # link lines, so the topics a viewer (or YouTube's indexer) most
+    # needs sat below "Show more" behind boilerplate that is identical
+    # on every upload. These headlines are the day's stories, already
+    # extracted for the slideshow — no new call, no new cost.
+    _topics_block = ""
+    try:
+        from engine.grok_imagine import extract_story_headlines
+        _stories = [
+            _truncate(_strip_markdown(s), 110)
+            for s in extract_story_headlines(digest_text or "", max_count=5)
+        ]
+        # Drop a headline that merely restates the hook — the hook is
+        # the line immediately above it.
+        _hook_key = " ".join((hook or "").lower().split())[:60]
+        _stories = [
+            s for s in _stories
+            if s and " ".join(s.lower().split())[:60] != _hook_key
+        ]
+        if _stories:
+            _topics_block = "In this episode:\n" + "\n".join(
+                "• " + s for s in _stories[:4]
+            )
+    except Exception:  # noqa: BLE001 — never block an upload
+        _topics_block = ""
+
     pieces: List[str] = []
     if hook:
         pieces.append(hook.strip())
     if _hashtag_line:
         pieces.append(_hashtag_line)
+    if _topics_block:
+        pieces.append(_topics_block)
     pieces.append(show_page_line)
     pieces.append(subscribe_line)
     if discovery_line:

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -419,6 +419,69 @@ def add_video_to_playlist(
     return True
 
 
+def update_video_title(
+    *,
+    credentials,
+    video_id: str,
+    new_title: str,
+) -> Optional[str]:
+    """Retitle an already-published video, preserving everything else.
+
+    ``videos.update`` REPLACES each part it is given, so sending a
+    snippet containing only a title would blank the description, tags
+    and category of a live video. This reads the current snippet first
+    and writes it back with one field changed — the read is 1 quota
+    unit, the write 50, and skipping the read to save that unit would
+    risk destroying metadata on every video it touched.
+
+    Requires the ``youtube.force-ssl`` scope, which the network's stored
+    tokens already carry (it is needed for caption upload), so no
+    re-authorisation is involved.
+
+    Returns the title actually written, or ``None`` when nothing was
+    changed or the call failed. Never raises: this runs over a back
+    catalogue in bulk, and one inaccessible video must not stop the rest.
+    """
+    new_title = (new_title or "").strip()
+    if not video_id or not new_title:
+        return None
+    from googleapiclient.discovery import build
+    from googleapiclient.errors import HttpError
+
+    try:
+        youtube = build(
+            "youtube", "v3", credentials=credentials, cache_discovery=False,
+        )
+        current = youtube.videos().list(
+            part="snippet", id=video_id,
+        ).execute()
+        items = (current or {}).get("items") or []
+        if not items:
+            logger.warning("retitle: video %s not found or not visible", video_id)
+            return None
+        snippet = items[0].get("snippet") or {}
+        if (snippet.get("title") or "").strip() == new_title:
+            return None  # already correct — do not spend a write
+        snippet["title"] = new_title
+        # categoryId is REQUIRED on update; a snippet read always carries
+        # it, but be explicit so a malformed read fails loudly here
+        # rather than as an opaque 400 from the API.
+        if not snippet.get("categoryId"):
+            logger.warning("retitle: %s has no categoryId — skipping", video_id)
+            return None
+        youtube.videos().update(
+            part="snippet", body={"id": video_id, "snippet": snippet},
+        ).execute()
+        logger.info("retitled %s -> %s", video_id, new_title)
+        return new_title
+    except HttpError as exc:
+        logger.warning("retitle: %s failed (%s)", video_id, exc)
+        return None
+    except Exception as exc:  # noqa: BLE001 — bulk job, never fatal
+        logger.warning("retitle: %s failed (%s)", video_id, exc)
+        return None
+
+
 def post_video_comment(
     *,
     credentials,

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -84,12 +84,23 @@ _CHANNEL_HISTORY_MAX_ROWS = 800
 
 def _load_index(digests_dir: Path) -> List[dict]:
     """Collect rows from every per-show video index — the EN channel
-    (``youtube_videos.json``) AND the @NerraRU dubs
-    (``youtube_videos.ru.json``). Each row carries its own ``channel`` field,
-    so the fetch groups them onto the right channel token; without the RU
-    files the analytics loop was EN-only and never read the RU channel."""
+    (``youtube_videos.json``) AND every dubbed channel
+    (``youtube_videos.<lang>.json``). Each row carries its own ``channel``
+    field, so the fetch groups them onto the right channel token; without
+    the dub files the analytics loop was EN-only.
+
+    The language files are matched by PATTERN rather than listed. When
+    @NerraFR went live (2026-07-23) it published 39 videos that this
+    fetch never saw, because only ``.ru.json`` had been added alongside
+    the base index. Everything downstream inherited the blind spot: the
+    adaptive policy computed ``video_count_14d = 0`` for all four FR
+    shows and froze them at their seed tier — a channel that could never
+    earn a promotion no matter how well it performed — and the title
+    hints, subscriber attribution and gallery-retention join were all
+    equally blind. A glob costs nothing and cannot be forgotten again.
+    """
     files = sorted(digests_dir.glob("*/youtube_videos.json"))
-    files += sorted(digests_dir.glob("*/youtube_videos.ru.json"))
+    files += sorted(digests_dir.glob("*/youtube_videos.*.json"))
     if not files:
         logger.info("No per-show video indexes under %s — nothing to fetch "
                     "(clean no-op)", digests_dir)

--- a/scripts/retitle_youtube_videos.py
+++ b/scripts/retitle_youtube_videos.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Repair transcript-fragment titles on already-published videos.
+
+Why this exists
+---------------
+Before the July 18 2026 title-bundle work, a Short's title was the raw
+opening text of its clip. That shipped titles like::
+
+    it's July 1st, 2026. Let's dive into today's Tesla news. Tesla plans
+    to add 1000 #Shorts
+
+    larger, higher thrust engine. And a quick market note, SPC-X closed
+    at $157.54, #Shorts
+
+Measured across every tracked upload: **11% of Shorts published before
+2026-07-18 carry a fragment title, against 1% after** — the pipeline was
+fixed forward, but the back catalogue was never repaired, and those
+videos are still live, still indexed, and still the first thing a new
+viewer sees on the channel page.
+
+A contractor audit (2026-07-29) scored the channel's titles 20/100. Most
+of that audit was boilerplate, but this part was right, and it is
+mechanical to fix.
+
+What it does
+------------
+Reads each show's ``digests/<slug>/youtube_videos.json`` index, finds
+records whose stored title looks like a transcript fragment, rebuilds a
+title from the episode's HOOK using the same ``_build_seo_title`` the
+live pipeline uses, and writes it back via ``videos.update``.
+
+Safety
+------
+* **Dry run by default.** ``--apply`` is required to write anything.
+* The hook must produce a title that is itself clean — an episode whose
+  hook is also a fragment is reported and skipped, never "fixed" into a
+  second bad title.
+* ``engine.youtube.update_video_title`` reads the existing snippet and
+  changes only the title, so descriptions, tags and category survive.
+* Quota: ~51 units per video changed (1 read + 50 write), well inside
+  the 200k/day budget, but ``--limit`` bounds a first run anyway.
+
+Usage::
+
+    python scripts/retitle_youtube_videos.py                    # report
+    python scripts/retitle_youtube_videos.py --show tesla       # one show
+    python scripts/retitle_youtube_videos.py --apply --limit 25 # write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(REPO_ROOT / ".env")
+except ImportError:  # pragma: no cover
+    pass
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger("retitle")
+
+# The title-bundle work landed here; anything published after it already
+# gets an LLM-written title and is left alone unless --all is passed.
+TITLE_FIX_DATE = "2026-07-18"
+
+_SHORTS_SUFFIX = " #Shorts"
+
+# Openers that betray a mid-sentence transcript slice rather than a title.
+_FRAGMENT_OPENERS = (
+    "it's", "let's", "and ", "but ", "so ", "that's", "we're", "you're",
+    "this is", "there's", "here's", "now ", "then ", "plus ", "also ",
+    "the kicker", "meanwhile", "okay", "alright", "well ",
+)
+
+
+def looks_like_fragment(title: str) -> bool:
+    """True when *title* reads as a slice of speech, not a headline."""
+    if not title:
+        return False
+    core = title.split("|")[0].replace(_SHORTS_SUFFIX, "").strip()
+    if not core:
+        return False
+    # Starts lower-case: a headline never does.
+    if core[:1].islower():
+        return True
+    low = core.lower()
+    if low.startswith(_FRAGMENT_OPENERS):
+        return True
+    # Ends mid-number or mid-clause ("... plans to add 1000", "closed at
+    # $157.54,").
+    if re.search(r"[,;]$", core):
+        return True
+    if re.search(r"\b(?:to|of|the|a|an|and|at|for|with|from|in|on)$", low):
+        return True
+    return False
+
+
+def _iter_records(show: Optional[str]) -> List[Dict]:
+    out: List[Dict] = []
+    for path in sorted((REPO_ROOT / "digests").glob("*/youtube_videos.json")):
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        videos = raw.get("videos") if isinstance(raw, dict) else raw
+        items = list(videos.values()) if isinstance(videos, dict) else (videos or [])
+        for rec in items:
+            if not isinstance(rec, dict):
+                continue
+            if show and rec.get("show_slug") != show:
+                continue
+            rec["_index_path"] = str(path)
+            out.append(rec)
+    return out
+
+
+def _config_for(slug: str, cache: Dict) -> Optional[object]:
+    if slug in cache:
+        return cache[slug]
+    from engine.config import load_config
+
+    for candidate in (REPO_ROOT / "shows").glob("*.yaml"):
+        if candidate.stem.startswith("_"):
+            continue
+        try:
+            cfg = load_config(candidate)
+        except Exception:  # noqa: BLE001
+            continue
+        if getattr(cfg, "slug", None) == slug:
+            cache[slug] = cfg
+            return cfg
+    cache[slug] = None
+    return None
+
+
+def _episode_headlines(cfg, episode: int, cache: Dict) -> List[str]:
+    """Story headlines from an episode's committed digest.
+
+    A Short's own stored ``hook`` is the clip's opening speech — for the
+    videos this script exists to repair, the hook IS the fragment, so it
+    can never supply the replacement. The digest is the real source: it
+    holds the episode's headline stories, which is what the title should
+    have said in the first place. Several Shorts from one episode take
+    DIFFERENT headlines, so the channel does not end up with four
+    identically-titled clips.
+    """
+    key = (getattr(cfg, "slug", ""), episode)
+    if key in cache:
+        return cache[key]
+    out: List[str] = []
+    try:
+        # The show's digest directory is the parent of its summaries
+        # JSON — the config exposes that path, not the directory itself.
+        summaries = str(getattr(cfg.publishing, "summaries_json", "") or "")
+        out_dir = (REPO_ROOT / summaries).parent if summaries else None
+        matches = sorted(out_dir.glob(f"*Ep{episode:03d}_*.md")) if out_dir and out_dir.is_dir() else []
+        if matches:
+            from engine.grok_imagine import extract_story_headlines
+
+            text = matches[0].read_text(encoding="utf-8")
+            out = [h for h in extract_story_headlines(text, max_count=8) if h]
+    except Exception:  # noqa: BLE001 — a missing digest is not fatal
+        out = []
+    cache[key] = out
+    return out
+
+
+def plan(show: Optional[str], include_all: bool) -> List[Dict]:
+    """Return the list of proposed retitles, newest first."""
+    from engine.video_metadata import _build_seo_title
+
+    cfg_cache: Dict = {}
+    headline_cache: Dict = {}
+    used_per_episode: Dict = {}
+    proposals: List[Dict] = []
+    for rec in _iter_records(show):
+        title = str(rec.get("title") or "")
+        published = str(rec.get("published") or "")
+        if not include_all and published >= TITLE_FIX_DATE:
+            continue
+        if not looks_like_fragment(title):
+            continue
+        slug = str(rec.get("show_slug") or "")
+        cfg = _config_for(slug, cfg_cache)
+        show_name = getattr(cfg, "name", "") or slug
+        suffix = _SHORTS_SUFFIX if rec.get("kind") == "short" else ""
+
+        source = ""
+        hook = str(rec.get("hook") or "").strip()
+        if hook and not looks_like_fragment(hook):
+            source = hook
+        elif cfg is not None and isinstance(rec.get("episode"), int):
+            # Take the next unused headline for this episode so sibling
+            # Shorts get distinct titles.
+            ep = int(rec["episode"])
+            heads = _episode_headlines(cfg, ep, headline_cache)
+            taken = used_per_episode.setdefault((slug, ep), set())
+            for idx, head in enumerate(heads):
+                if idx in taken or looks_like_fragment(head):
+                    continue
+                taken.add(idx)
+                source = head
+                break
+
+        if not source:
+            proposals.append({**rec, "new_title": None,
+                              "reason": "no clean hook or digest headline found"})
+            continue
+        new_title = _build_seo_title(source, show_name, suffix=suffix)
+        if not new_title or new_title.strip() == title.strip():
+            continue
+        proposals.append({**rec, "new_title": new_title, "reason": ""})
+    proposals.sort(key=lambda r: str(r.get("published") or ""), reverse=True)
+    return proposals
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--show", help="restrict to one show slug")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually write the new titles (default: report only)")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="cap how many videos are changed in one run")
+    ap.add_argument("--all", action="store_true",
+                    help=f"include videos published on/after {TITLE_FIX_DATE}")
+    ap.add_argument("--channel", default="en",
+                    help="which channel's credentials to use (en/ru/fr)")
+    args = ap.parse_args(argv)
+
+    proposals = plan(args.show, args.all)
+    fixable = [p for p in proposals if p.get("new_title")]
+    skipped = [p for p in proposals if not p.get("new_title")]
+
+    print(f"{len(proposals)} fragment title(s) found — "
+          f"{len(fixable)} fixable, {len(skipped)} need a human.\n")
+    for p in fixable[: (args.limit or len(fixable))]:
+        print(f"  {p.get('published','?')} {p.get('video_id','?')} "
+              f"[{p.get('show_slug','?')}/{p.get('kind','?')}]")
+        print(f"    old: {p['title']}")
+        print(f"    new: {p['new_title']}")
+    for p in skipped:
+        print(f"  SKIP {p.get('video_id','?')} — {p['reason']}")
+        print(f"    old: {p['title']}")
+
+    if not args.apply:
+        print("\nDry run — pass --apply to write these titles.")
+        return 0
+    if not fixable:
+        print("\nNothing to write.")
+        return 0
+
+    from engine.youtube import get_channel_credentials_from_env, update_video_title
+
+    creds = get_channel_credentials_from_env(args.channel)
+    if creds is None:
+        print(f"::warning::No YouTube credentials for channel "
+              f"'{args.channel}' — nothing written.")
+        return 0
+
+    targets = fixable[: (args.limit or len(fixable))]
+    changed = 0
+    for p in targets:
+        if update_video_title(credentials=creds, video_id=p["video_id"],
+                              new_title=p["new_title"]):
+            changed += 1
+    print(f"\nRetitled {changed} of {len(targets)} video(s) "
+          f"(~{changed * 51} quota units).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_retitle_youtube.py
+++ b/tests/test_retitle_youtube.py
@@ -1,0 +1,129 @@
+"""Drift guards for scripts/retitle_youtube_videos.py.
+
+Before the July 18 2026 title-bundle work, a Short's title was the raw
+opening text of its clip: "it's July 1st, 2026. Let's dive into today's
+Tesla news. Tesla plans to add 1000 #Shorts". Measured across every
+tracked upload, 11% of Shorts published before that date carry a
+fragment title against 1% after — the pipeline was fixed forward and
+the back catalogue was left broken, still live and still indexed.
+
+The two things that must not regress:
+
+* ``videos.update`` REPLACES the part it is given. A snippet carrying
+  only a title would blank the description, tags and category of a live
+  video, so the writer reads the current snippet first and changes one
+  field. Losing that read-modify-write would silently strip metadata
+  from every video the job touches.
+* The replacement title cannot come from the Short's own stored hook —
+  for exactly these videos the hook IS the fragment. It comes from the
+  episode's digest headlines, one per Short, so sibling clips do not all
+  land on the same title.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.retitle_youtube_videos import (  # noqa: E402
+    TITLE_FIX_DATE,
+    looks_like_fragment,
+    plan,
+)
+
+
+class TestFragmentDetection:
+    def test_real_broken_titles_are_caught(self):
+        for title in (
+            "it's July 1st, 2026. Let's dive into today's Tesla news. "
+            "Tesla plans to add 1000 #Shorts",
+            "seeking $417 million | Tesla Shorts Time #Shorts",
+            "to $53,107. The year-over-year drop of 2.1% is the smallest #Shorts",
+            "And a quick market note, SPCX is at $131.11, up 3.2%. #Shorts",
+            "larger, higher thrust engine. And a quick market note, #Shorts",
+        ):
+            assert looks_like_fragment(title), title
+
+    def test_real_good_titles_are_left_alone(self):
+        for title in (
+            "Tesla Hires 1000 at German Gigafactory",
+            "Tesla Japan Stockpile Points to Stronger Q3",
+            "Tesla shares climb to $411.84 after a $32 gain | Tesla Shorts Time #Shorts",
+            "Пуск Starship отменён после четырёх отказов Raptor #Shorts",
+            "NASA Reveals First Lunar Outpost Details",
+        ):
+            assert not looks_like_fragment(title), title
+
+    def test_empty_is_not_a_fragment(self):
+        assert not looks_like_fragment("")
+        assert not looks_like_fragment("   ")
+
+
+class TestPlan:
+    def test_only_pre_fix_videos_by_default(self):
+        """Post-July-18 uploads already get an LLM title — touching them
+        would undo the good work, not repair anything."""
+        for proposal in plan(None, include_all=False):
+            assert str(proposal.get("published") or "") < TITLE_FIX_DATE
+
+    def test_every_proposal_improves_on_the_original(self):
+        for p in plan(None, include_all=False):
+            new = p.get("new_title")
+            if not new:
+                continue
+            assert new.strip() != p["title"].strip()
+            assert not looks_like_fragment(new), new
+
+    def test_shorts_keep_their_suffix(self):
+        for p in plan(None, include_all=False):
+            if p.get("kind") == "short" and p.get("new_title"):
+                assert p["new_title"].endswith("#Shorts")
+
+    def test_sibling_shorts_do_not_collide(self):
+        """Several Shorts come from one episode; giving them all the same
+        headline would trade one problem for another."""
+        by_ep = {}
+        for p in plan(None, include_all=False):
+            if not p.get("new_title"):
+                continue
+            key = (p.get("show_slug"), p.get("episode"))
+            by_ep.setdefault(key, []).append(p["new_title"])
+        for key, titles in by_ep.items():
+            assert len(titles) == len(set(titles)), f"duplicate titles for {key}"
+
+    def test_dry_run_is_the_default(self):
+        src = (REPO_ROOT / "scripts" / "retitle_youtube_videos.py").read_text(
+            encoding="utf-8")
+        assert '"--apply", action="store_true"' in src
+        assert "Dry run — pass --apply to write these titles." in src
+
+
+class TestUpdaterPreservesMetadata:
+    def test_reads_before_it_writes(self):
+        """The failure this guards is silent and total: a title-only
+        snippet blanks the description and tags of a live video."""
+        src = (REPO_ROOT / "engine" / "youtube.py").read_text(encoding="utf-8")
+        body = src[src.index("def update_video_title"):]
+        body = body[:body.index("\ndef ")]
+        list_at = body.index("videos().list(")
+        update_at = body.index("videos().update(")
+        assert list_at < update_at, "must read the snippet before updating it"
+        assert 'snippet["title"] = new_title' in body
+        assert "categoryId" in body, "update requires categoryId"
+
+    def test_skips_a_write_when_the_title_already_matches(self):
+        src = (REPO_ROOT / "engine" / "youtube.py").read_text(encoding="utf-8")
+        body = src[src.index("def update_video_title"):]
+        body = body[:body.index("\ndef ")]
+        assert "already correct — do not spend a write" in body
+
+    def test_never_raises(self):
+        src = (REPO_ROOT / "engine" / "youtube.py").read_text(encoding="utf-8")
+        body = src[src.index("def update_video_title"):]
+        body = body[:body.index("\ndef ")]
+        assert "except HttpError" in body
+        assert "except Exception" in body

--- a/tests/test_shorts_hashtags.py
+++ b/tests/test_shorts_hashtags.py
@@ -266,3 +266,46 @@ class TestExtractEntityPhrases:
         out = _eep("Tesla SpaceX OpenAI Nvidia Google Apple Meta Amazon Intel",
                    max_phrases=3)
         assert len(out) == 3
+
+
+class TestEntityPhraseFragments:
+    """July 29 2026 — a contractor audit scored the channel's keywords
+    10/100. Most of that was wrong (30 relevant tags ship on every
+    upload), but it did surface a real flaw: this function had no
+    substring de-dupe, so "…at its German Gigafactory" spent three of a
+    show's thirty tag slots on `german gigafactory`, `german` and
+    `gigafactory`. Its sibling extract_hashtags has de-duped by
+    substring since it was written — the two now agree."""
+
+    def test_phrase_suppresses_its_own_fragments(self):
+        out = _eep(
+            "Tesla plans to add 1,000 workers at its German Gigafactory.",
+            show_keywords=[])
+        assert "german gigafactory" in out
+        assert "german" not in out
+        assert "gigafactory" not in out
+
+    def test_show_keywords_keep_their_slot(self):
+        """A configured keyword is a deliberate choice — a longer phrase
+        containing it must not cost the show its own tag."""
+        out = _eep("Tesla Cybercab enters volume production in Austin.",
+                   show_keywords=["tesla", "cybercab"])
+        assert "tesla cybercab" in out
+        assert "tesla" in out and "cybercab" in out
+
+    def test_long_title_case_run_is_capped(self):
+        """Without a cap, one long run becomes a single unsearchable tag
+        and — with fragment suppression on — swallows every term in it."""
+        from engine.shorts_hashtags import _MAX_ENTITY_WORDS
+
+        out = _eep("Tesla SpaceX OpenAI Nvidia Google Apple Meta", max_phrases=6)
+        assert out, "a long run must still yield tags"
+        assert len(out[0].split()) <= _MAX_ENTITY_WORDS
+        assert len(out) > 1, "constituents must survive the capped phrase"
+
+    def test_real_hooks_lose_no_useful_tag(self):
+        out = _eep(
+            "SpaceX Starship Block 3 completes static fire at Starbase.",
+            show_keywords=["spacex", "starship"])
+        for expected in ("spacex", "starship", "starbase"):
+            assert expected in out, expected

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -313,3 +313,47 @@ class TestAnalytics403Classification:
         joined = " ".join(r.message for r in caplog.records)
         assert "yt-analytics.readonly" in joined
         assert "youtube_oauth_bootstrap" in joined
+
+
+class TestEveryDubChannelEntersTheLoop:
+    """@NerraFR went live 2026-07-23 and published 39 videos that the
+    analytics fetch never saw: only ``.ru.json`` had been added beside
+    the base index, so the glob missed ``.fr.json`` entirely.
+
+    The blind spot was not cosmetic. The adaptive policy computed
+    ``video_count_14d = 0`` for all four FR shows and held them at their
+    seed tier — a channel that could never earn a promotion however well
+    it performed — and the title hints, subscriber attribution and
+    gallery-retention join were blind for the same reason. Matching the
+    language indexes by pattern means the next channel is covered on the
+    day it launches."""
+
+    def test_language_indexes_are_globbed_not_listed(self):
+        src = (_ROOT / "scripts" / "fetch_youtube_analytics.py").read_text(
+            encoding="utf-8")
+        assert 'digests_dir.glob("*/youtube_videos.*.json")' in src
+        # A hardcoded per-language line is what caused the miss.
+        assert 'glob("*/youtube_videos.ru.json")' not in src
+
+    def test_the_two_patterns_do_not_overlap(self):
+        """The base index must be collected exactly once — a double read
+        would duplicate every EN row and inflate its view totals."""
+        import fnmatch
+
+        assert not fnmatch.fnmatch("youtube_videos.json", "youtube_videos.*.json")
+        assert fnmatch.fnmatch("youtube_videos.fr.json", "youtube_videos.*.json")
+        assert fnmatch.fnmatch("youtube_videos.ru.json", "youtube_videos.*.json")
+
+    def test_live_fr_rows_are_picked_up(self):
+        """Guards the real repo state, not just the pattern."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_fya", _ROOT / "scripts" / "fetch_youtube_analytics.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        rows = mod._load_index(_ROOT / "digests")
+        channels = {r.get("channel") or "en" for r in rows}
+        if (_ROOT / "digests").glob("*/youtube_videos.fr.json"):
+            assert "fr" in channels or not any(
+                (_ROOT / "digests").glob("*/youtube_videos.fr.json"))


### PR DESCRIPTION
Implements the three fixes from the contractor-audit assessment, plus a full review of the recursive pipeline — which turned up a bigger problem than anything in the audit. Full suite green (4,975 passed), ruff clean.

## 1. Retitle the back catalogue — `scripts/retitle_youtube_videos.py`

Before July 18, a Short's title was the raw opening text of its clip. Measured across every tracked upload: **11% of Shorts before the fix, 1% after** — the pipeline was repaired, the back catalogue was left live and indexed.

**31 videos, all fixable.** The replacement can't come from the Short's own hook (for exactly these videos, the hook *is* the fragment) — it comes from the episode's committed digest headlines, one per Short, so siblings don't collide. A hook-only version fixed 1 of 31.

```
old: seeking $417 million | Tesla Shorts Time #Shorts
new: Tesla's Model Y robotaxi fleet in Texas grew 50 percent in one day… #Shorts
```

Dry-run by default; `--apply` to write. Uses the existing `youtube.force-ssl` scope — **no re-auth**. The writer reads the current snippet and changes one field, because `videos.update` *replaces* the part it's given and a title-only snippet would blank the description, tags and category of a live video.

**To run it:** `python scripts/retitle_youtube_videos.py --apply --limit 25` (~51 quota units each).

## 2. Tag fragments

`extract_entity_phrases` had no substring de-dupe, so "…at its German Gigafactory" spent three of thirty tag slots on `german gigafactory`, `german`, `gigafactory`. Its sibling `extract_hashtags` has de-duped this way since it was written — they now agree, with configured show keywords protected so Tesla never loses its `tesla` tag to a longer phrase. That exposed a second flaw (one long Title-Case run swallowed every term inside it), so a named entity is capped at three words.

## 3. Descriptions front-loaded

The first thing under the hook was three promo lines, identical on every upload, with the actual stories below "Show more". Now:

```
Tesla's Cybercab now ships with a factory-integrated Starlink V5 terminal.
#TeslasCybercab #Starlink #V5 #Tsla #Model3 #podcast

In this episode:
• Tesla reveals the integrated Starlink V5 terminal in the Cybercab
• Tesla has sold over 16,000 EVs in Malaysia to date…
• Elon Musk praises Micron twice during Tesla's earnings call…
```

Headlines come from the digest the slideshow already parses — no new call, no new cost.

## 4. The pipeline review found something worse: @NerraFR was invisible

**The channel went live 2026-07-23 and has published 39 videos the analytics fetch never saw.** Only `.ru.json` had been added beside the base index; nothing matched `.fr.json`.

Everything downstream inherited the blind spot:

| consequence | evidence |
|---|---|
| Policy thinks FR published nothing | all 4 FR shows: `video_count_14d = 0` |
| FR frozen at seed tier | tier C, `long_vpd=None`, `short_vpd=None` — **can never earn promotion** |
| Title hints, subscriber attribution, gallery-retention join | all blind to FR |

Fixed by matching language indexes with a **pattern** rather than a hardcoded list, so the next channel is covered on launch day. Verified: `en=617 ru=297 fr=39` now load (was `fr=0`).

## Verification

- 15 new guards across `tests/test_retitle_youtube.py`, `tests/test_shorts_hashtags.py`, `tests/test_youtube_feedback_loop.py`.
- The read-modify-write on `videos.update` is pinned by test — that failure would be silent and total.
- The two globs are proven non-overlapping, so the base index can't be double-counted (which would inflate EN view totals).

## Findings I did NOT act on — recommendations in the PR discussion

Three items need your decision rather than a commit: FR Short titles truncate mid-clause (23%), RU Shorts are capped at 2/episode while running at 55–65 views/day/video, and long-form's median is 10 views. Details in my message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk `videos.update` on live catalogue could strip metadata if read-modify-write regressed; analytics glob change affects tiering and prompts for dub channels. Upload path changes are additive and wrapped in try/except.
> 
> **Overview**
> **YouTube metadata and discovery fixes** from the contractor audit, plus a pipeline review that exposed @NerraFR as invisible to analytics.
> 
> Adds **`scripts/retitle_youtube_videos.py`** (dry-run by default) to find transcript-fragment titles on pre-2026-07-18 uploads, rebuild them with **`_build_seo_title`** from clean hooks or **digest headlines** (one headline per sibling Short), and apply via new **`engine.youtube.update_video_title`** — read-modify-write on the snippet so **`videos.update`** cannot wipe description, tags, or category.
> 
> **`extract_entity_phrases`** now substring-de-dupes like **`extract_hashtags`**, caps Title-Case entity runs at **three words**, and keeps configured show keywords **protected** from being dropped when a longer phrase contains them.
> 
> **Long-form descriptions** insert an **“In this episode:”** bullet block (from existing **`extract_story_headlines`**) right after the hook/hashtags, before promo lines.
> 
> **`fetch_youtube_analytics._load_index`** loads **`youtube_videos.*.json`** by glob instead of hardcoding **`.ru.json`**, so FR (and future dub channels) feed policy, title hints, and retention joins.
> 
> Tests guard fragment detection, metadata-preserving retitle, tag fragment behavior, and non-overlapping index globs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3686805f8ad0fcd41a910b3ca52154c0936144d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->