### PR TITLE
Add a dispatch workflow to run the YouTube retitle (credentials are in Actions, not on the laptop)

### DIFF
--- a/.github/workflows/retitle-youtube-videos.yml
+++ b/.github/workflows/retitle-youtube-videos.yml
@@ -1,0 +1,130 @@
+name: Retitle YouTube Videos
+
+# On-demand repair of transcript-fragment titles on published videos.
+#
+# Before the July 18 2026 title-bundle work, a Short's title was the raw
+# opening text of its clip — "it's July 1st, 2026. Let's dive into
+# today's Tesla news. Tesla plans to add 1000 #Shorts". Measured across
+# every tracked upload that is 11% of Shorts before the fix against 1%
+# after: the pipeline was repaired and the back catalogue was left live
+# and indexed.
+#
+# This runs scripts/retitle_youtube_videos.py, which rebuilds each title
+# from the episode's committed digest headlines (the Short's own stored
+# hook IS the fragment for exactly these videos, so it cannot be the
+# source) and writes it back with videos.update.
+#
+# It exists as a workflow because the credentials live here. Running the
+# script on a laptop needs YOUTUBE_CLIENT_ID / _SECRET / _REFRESH_TOKEN_*
+# in a local .env; without them the script reports its plan and writes
+# nothing, which is safe but not what you wanted.
+#
+# DRY RUN IS THE DEFAULT. Dispatch once to read the proposals in the job
+# summary, then dispatch again with apply=true.
+#
+# Note on channels: fragment detection is English-language. Selecting
+# ru/fr reads that channel's own index and uses that channel's token
+# (a video can only be updated by the channel that owns it), but the
+# French mid-clause truncation is a different defect — the FR Short
+# title is cut from the FR long title rather than written as a title —
+# and is not what this repairs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Write the titles. Leave false for a dry run.'
+        required: false
+        type: boolean
+        default: false
+      limit:
+        description: 'Max videos to change in one run (0 = no cap).'
+        required: false
+        type: string
+        default: '25'
+      show:
+        description: 'Restrict to one show slug (blank = all shows).'
+        required: false
+        type: string
+        default: ''
+      channel:
+        description: 'Channel whose videos to retitle (en, ru, fr).'
+        required: false
+        type: string
+        default: 'en'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Never let two retitle runs touch the same videos at once.
+  group: retitle-youtube-videos
+  cancel-in-progress: false
+
+jobs:
+  retitle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.12'
+          requirements-file: 'requirements.txt'
+          skip-checkout: 'true'
+
+      - name: Retitle
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+          YOUTUBE_REFRESH_TOKEN_FR: ${{ secrets.YOUTUBE_REFRESH_TOKEN_FR }}
+          APPLY_INPUT: ${{ inputs.apply }}
+          LIMIT_INPUT: ${{ inputs.limit }}
+          SHOW_INPUT: ${{ inputs.show }}
+          CHANNEL_INPUT: ${{ inputs.channel }}
+        run: |
+          set -o pipefail
+          args="--channel ${CHANNEL_INPUT:-en}"
+          if [ "${APPLY_INPUT}" = "true" ]; then
+            args="$args --apply"
+          fi
+          if [ -n "${LIMIT_INPUT}" ]; then
+            args="$args --limit ${LIMIT_INPUT}"
+          fi
+          if [ -n "${SHOW_INPUT}" ]; then
+            args="$args --show ${SHOW_INPUT}"
+          fi
+
+          # Keep the summary even if the script exits non-zero, so a
+          # partial run is still auditable.
+          set +e
+          # shellcheck disable=SC2086
+          python scripts/retitle_youtube_videos.py $args 2>&1 \
+            | tee /tmp/retitle.txt
+          status=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo "## Retitle YouTube videos"
+            echo
+            if [ "${APPLY_INPUT}" = "true" ]; then
+              echo "**Mode: APPLY** — titles were written."
+            else
+              echo "**Mode: dry run** — nothing was written. "
+              echo "Re-dispatch with \`apply: true\` to write these."
+            fi
+            echo
+            echo '```'
+            # The config loader logs one INFO line per show YAML; drop
+            # them so the proposals are the whole summary.
+            grep -v '^INFO Loaded config' /tmp/retitle.txt | tail -c 60000
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit $status

--- a/scripts/retitle_youtube_videos.py
+++ b/scripts/retitle_youtube_videos.py
@@ -107,9 +107,20 @@ def looks_like_fragment(title: str) -> bool:
     return False
 
 
-def _iter_records(show: Optional[str]) -> List[Dict]:
+def _iter_records(show: Optional[str], channel: str = "en") -> List[Dict]:
+    """Video records for ONE channel.
+
+    Each channel keeps its own index — ``youtube_videos.json`` for the
+    EN channel, ``youtube_videos.<lang>.json`` for each dub — and a
+    video can only be updated with the credentials of the channel that
+    owns it. Reading the wrong index would send EN video ids to the RU
+    token and fail every call, so the channel selects the file.
+    """
+    channel = (channel or "en").strip().lower()
+    pattern = ("*/youtube_videos.json" if channel == "en"
+               else f"*/youtube_videos.{channel}.json")
     out: List[Dict] = []
-    for path in sorted((REPO_ROOT / "digests").glob("*/youtube_videos.json")):
+    for path in sorted((REPO_ROOT / "digests").glob(pattern)):
         raw = json.loads(path.read_text(encoding="utf-8"))
         videos = raw.get("videos") if isinstance(raw, dict) else raw
         items = list(videos.values()) if isinstance(videos, dict) else (videos or [])
@@ -174,7 +185,8 @@ def _episode_headlines(cfg, episode: int, cache: Dict) -> List[str]:
     return out
 
 
-def plan(show: Optional[str], include_all: bool) -> List[Dict]:
+def plan(show: Optional[str], include_all: bool,
+         channel: str = "en") -> List[Dict]:
     """Return the list of proposed retitles, newest first."""
     from engine.video_metadata import _build_seo_title
 
@@ -182,7 +194,7 @@ def plan(show: Optional[str], include_all: bool) -> List[Dict]:
     headline_cache: Dict = {}
     used_per_episode: Dict = {}
     proposals: List[Dict] = []
-    for rec in _iter_records(show):
+    for rec in _iter_records(show, channel):
         title = str(rec.get("title") or "")
         published = str(rec.get("published") or "")
         if not include_all and published >= TITLE_FIX_DATE:
@@ -236,7 +248,7 @@ def main(argv=None) -> int:
                     help="which channel's credentials to use (en/ru/fr)")
     args = ap.parse_args(argv)
 
-    proposals = plan(args.show, args.all)
+    proposals = plan(args.show, args.all, args.channel)
     fixable = [p for p in proposals if p.get("new_title")]
     skipped = [p for p in proposals if not p.get("new_title")]
 

--- a/tests/test_retitle_youtube.py
+++ b/tests/test_retitle_youtube.py
@@ -127,3 +127,69 @@ class TestUpdaterPreservesMetadata:
         body = body[:body.index("\ndef ")]
         assert "except HttpError" in body
         assert "except Exception" in body
+
+
+class TestChannelScoping:
+    """A video can only be updated with the credentials of the channel
+    that owns it. Once the workflow exposed a channel input, reading the
+    EN index while holding the RU token would have sent every EN video
+    id to the wrong channel — a run of guaranteed failures that looks
+    like a broken script rather than a wrong argument."""
+
+    def test_each_channel_reads_its_own_index(self):
+        from scripts.retitle_youtube_videos import _iter_records
+
+        en = _iter_records(None, "en")
+        assert en, "EN index should not be empty in this repo"
+        assert all("youtube_videos.json" in r["_index_path"] for r in en)
+        assert all(".ru.json" not in r["_index_path"] for r in en)
+
+        fr = _iter_records(None, "fr")
+        for rec in fr:
+            assert rec["_index_path"].endswith("youtube_videos.fr.json")
+            assert rec.get("channel") == "fr"
+
+    def test_default_channel_is_en(self):
+        from scripts.retitle_youtube_videos import _iter_records
+
+        assert _iter_records(None) == _iter_records(None, "en")
+
+
+class TestWorkflowWiring:
+    WF = REPO_ROOT / ".github" / "workflows" / "retitle-youtube-videos.yml"
+
+    def test_workflow_exists_and_is_dispatch_only(self):
+        import yaml
+
+        data = yaml.safe_load(self.WF.read_text(encoding="utf-8"))
+        triggers = data.get("on") or data.get(True)
+        assert list(triggers) == ["workflow_dispatch"], (
+            "retitling live videos must never fire on a schedule or push"
+        )
+
+    def test_apply_defaults_to_false(self):
+        import yaml
+
+        data = yaml.safe_load(self.WF.read_text(encoding="utf-8"))
+        triggers = data.get("on") or data.get(True)
+        assert triggers["workflow_dispatch"]["inputs"]["apply"]["default"] is False
+
+    def test_inputs_reach_the_script_through_env(self):
+        """Interpolating an input straight into a run: block is a shell
+        injection; they go through env like the caption-scope workflow."""
+        raw = self.WF.read_text(encoding="utf-8")
+        assert "APPLY_INPUT: ${{ inputs.apply }}" in raw
+        assert "SHOW_INPUT: ${{ inputs.show }}" in raw
+        assert "${{ inputs.show }} --" not in raw
+
+    def test_credentials_come_from_secrets(self):
+        raw = self.WF.read_text(encoding="utf-8")
+        for name in ("YOUTUBE_CLIENT_ID", "YOUTUBE_CLIENT_SECRET",
+                     "YOUTUBE_REFRESH_TOKEN_EN"):
+            assert f"{name}: ${{{{ secrets.{name} }}}}" in raw, name
+
+    def test_runs_do_not_overlap(self):
+        import yaml
+
+        data = yaml.safe_load(self.WF.read_text(encoding="utf-8"))
+        assert data["concurrency"]["cancel-in-progress"] is False


### PR DESCRIPTION
The local run produced 31 correct proposals and then wrote nothing:

```
INFO YouTube credentials not fully set for channel=en — skipping
::warning::No YouTube credentials for channel 'en' — nothing written.
```

That's the script behaving correctly — it refuses to half-run — but the credentials live in Actions, so the job should too. Full suite green (4,982 passed), ruff clean.

## How to run it

**Actions tab → "Retitle YouTube Videos" → Run workflow.**

1. Leave `apply` **false** first. The job summary prints all 31 proposals.
2. Read them, then dispatch again with `apply: true`.

Inputs: `apply` (default false), `limit` (default 25), `show` (blank = all), `channel` (default en).

## Design notes

- **Dispatch-only.** Retitling live videos must never fire on a schedule or a push.
- **Dry run is the default**, and the summary carries the full proposal list — so the second dispatch is a decision made against what you just read, not against memory.
- **Inputs reach the script through `env`**, not interpolated into the `run:` block. A show slug pasted straight into a shell line is an injection; this matches the caption-scope workflow's pattern.
- **Concurrency queues rather than cancels** — two overlapping runs would both be writing to the same videos.

## A footgun the channel input would have opened

`_iter_records` always read the EN index. Once a `channel` input existed, selecting `ru` or `fr` would have paired that channel's token with **EN video ids** — every call failing on a video the token doesn't own, which reads as a broken script rather than a wrong argument. Each channel now reads its own index file (`youtube_videos.json` for EN, `youtube_videos.<lang>.json` for dubs), pinned by test.

## What this deliberately does not fix

Fragment detection is English-only, so a `channel: fr` run reports nothing today. That's correct rather than incomplete: the French titles truncate mid-clause (*"…alors que les"*) because the FR Short title is **cut from the FR long title** instead of being written as one. Different defect, different file — guessing at it inside a retitle script would have been the wrong fix in the wrong place. Still on your decision list.

## Verification

- 7 new guards: dispatch-only, `apply` defaults false, inputs travel via env, secrets wiring, non-cancelling concurrency, per-channel index scoping, EN default unchanged.
- Arg construction simulated for both dry-run and apply paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When `apply` is true the workflow mutates live YouTube titles via API; mitigations are dispatch-only, dry-run default, queued concurrency, and channel-scoped indexes, but operator error on the second run remains the main risk.
> 
> **Overview**
> Adds a **manual-only** GitHub Actions workflow so `scripts/retitle_youtube_videos.py` can run with repo secrets (dry run by default, optional `apply`, `limit`, `show`, and `channel`). The job tees script output into the **step summary** for review before a second dispatch with `apply: true`.
> 
> **`retitle_youtube_videos.py`** now scopes record loading by channel: EN uses `youtube_videos.json`, dubs use `youtube_videos.<lang>.json`, and `plan()` passes `channel` through so video IDs match the token used for `videos.update`.
> 
> **Tests** lock in dispatch-only triggers, `apply` defaulting false, env-based input wiring (not shell interpolation), secret usage, non-cancelling concurrency, and per-channel index paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fb6288961c8b7443adbe86eba074529e77d3a5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->