### PR TITLE
Speech quality: stop reading URL punctuation aloud, surface the dropped energy wrap (+ the #912 lint fix)

### DIFF
--- a/engine/intros.py
+++ b/engine/intros.py
@@ -966,22 +966,13 @@ def build_intro_line(
 
     host = personality["host"]
     show_name = personality["show_name"]
-    weekday = date.weekday()
 
-    # Select greeting — prefer day-specific if available
-    day_overrides = personality.get("day_colors", {}).get(weekday, {})
-    greeting_pool = day_overrides.get("greetings", personality["greetings"])
-    greeting = _pick(greeting_pool, show_slug, date, salt="greeting")
-
-    # Select opener
-    opener_pool = personality["openers"]
-    opener = _pick(opener_pool, show_slug, date, salt="opener")
-    opener = opener.format(ep=episode_num, date=today_str)
-
-    # Select framing — prefer day-specific if available
-    framing_pool = day_overrides.get("framings", personality["framings"])
-    framing = _pick(framing_pool, show_slug, date, salt="framing")
-
+    # The greeting / opener / framing pools are no longer read HERE — see
+    # the note below. They stay in ``_SHOW_PERSONALITIES`` because
+    # ``build_closing_block`` reads them and because a future variation
+    # experiment can draw on them again; selecting from them in this
+    # function and discarding the result is just dead work.
+    #
     # Assemble — IDENTITY ONLY, and it no longer runs first.
     #
     # July 30 2026 (cold-open change). This used to emit the whole
@@ -1000,9 +991,8 @@ def build_intro_line(
     # weeks later, and nobody ever needed to hear it.
     #
     # The identity line is now short and lands AFTER the cold-open hook
-    # (see ``build_cold_open_spec``). The greeting/framing pools are
-    # retained but no longer used here — the closings still read them,
-    # and a future variation experiment can draw on them again.
+    # (see ``build_cold_open_spec``).
+    #
     # The default identity line is English. A show that is not hosted in
     # English declares its own ``identity_template`` — without one, the
     # July 30 2026 trim would have handed Финансы Просто (an entirely

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -16,8 +16,9 @@ pattern for the other shows):
     future cleanup could fold RU onto this engine once it has weeks of
     parity in production.
   - Language-NEUTRAL machinery (manifest refresh, scene lookup/download,
-    cover resolution, EN-optimized-title lookup, word trimming) is IMPORTED
-    from ``engine.ru_dub`` — one implementation, no drift.
+    cover resolution, EN-optimized-title lookup, clause-aware title
+    trimming) is IMPORTED from ``engine.ru_dub`` — one implementation, no
+    drift.
   - Everything language-SPECIFIC lives in a ``DubLanguage`` spec. Adding a
     future language = one registry entry + ``youtube.dub_languages: [xx]``
     in the show YAML + a ``YOUTUBE_REFRESH_TOKEN_XX`` secret + the channel
@@ -27,8 +28,9 @@ Contract (identical to ru_dub): runs in the decoupled multilingual workflow,
 never the episode critical path; fully best-effort (returns a status dict,
 never raises); no-ops cleanly when the show hasn't opted in
 (``youtube.dub_languages``), the track doesn't exist, or the channel token
-(``YOUTUBE_REFRESH_TOKEN_<CH>``) is unset — so the FR pipeline ships DORMANT
-until the operator creates @NerraFR and adds the secret.
+(``YOUTUBE_REFRESH_TOKEN_<CH>``) is unset — which is how the FR pipeline
+shipped dormant. **@NerraFR has been live since 2026-07-21**; a future
+language stays a clean no-op until its own channel and secret exist.
 """
 
 from __future__ import annotations
@@ -51,7 +53,6 @@ from engine.ru_dub import (  # language-neutral helpers — single source
     _hashtags,
     _is_fresh_episode,
     _clause_trim,
-    _word_trim,
     gallery_images_for_episode,
 )
 

--- a/engine/tts.py
+++ b/engine/tts.py
@@ -143,6 +143,8 @@ def prepare_text_for_tts(text: str) -> str:
         text,
     )
 
+    text = _speech_safe_urls(text)
+
     corrections = _load_pronunciation_map()
     for written, spoken in corrections.items():
         if not written or not spoken:
@@ -151,6 +153,68 @@ def prepare_text_for_tts(text: str) -> str:
         text = re.sub(pattern, str(spoken), text, flags=re.IGNORECASE)
 
     return text.strip()
+
+
+# A domain-like token followed by a path: "nerranetwork.com/start-here",
+# "example.org/a/b". Captures the host and the path separately so only the
+# PATH is rewritten.
+# A dot inside the path must be followed by more path characters, so a
+# SENTENCE-ending period is never swallowed — the voice needs that period
+# to close the sentence, and an earlier version of this pattern ate it.
+_URL_IN_SPEECH = re.compile(
+    r"\b((?:[a-z0-9-]+\.)+(?:com|org|net|io|ai|co|dev|gov|edu))"
+    r"/([A-Za-z0-9\-_/]+(?:\.[A-Za-z0-9\-_/]+)*)",
+    re.IGNORECASE,
+)
+
+
+# Set by ``_speak_with_grok`` when the chunk-boundary guard drops the
+# speech wrap, drained once per episode by run_show. Module-level for the
+# same reason ``digests.xai_grok`` accumulates search usage this way: the
+# synthesis layer has no tracker reference to write through.
+_WRAP_DROPPED: dict = {}
+
+
+def drain_wrap_drop() -> dict:
+    """Return and clear the speech-wrap drop record for this process."""
+    global _WRAP_DROPPED
+    out, _WRAP_DROPPED = _WRAP_DROPPED, {}
+    return out
+
+
+def _speech_safe_urls(text: str) -> str:
+    """Make URL paths readable aloud without touching ordinary prose.
+
+    Grok TTS speaks the hyphen in a URL path as the WORD "hyphen": the
+    network cross-promo's "nerranetwork.com/start-here" shipped as
+    "slash start hyphen here", and "/age-of-ai-apply" as "of hyphen AI
+    apply". Measured across 1,191 episodes that had both a TTS input and
+    a Whisper transcript of the audio that shipped: 95 spoken "hyphen"s
+    across 67 episodes, 36 of them from these promo URLs.
+
+    The scope is deliberately narrow. Those same 1,191 episodes fed the
+    voice 28,955 hyphenated compounds and only 0.33% leaked, so hyphens
+    are overwhelmingly handled correctly and a blanket strip would
+    rewrite ~29,000 tokens to fix ~95. Only the PATH of a domain-like
+    token is touched: hyphens and slashes become spaces, and the file
+    extension is dropped. The host keeps its dots, so "nerranetwork.com"
+    still reads as the brand.
+
+    Prose is untouched because a bare hyphenated word has no preceding
+    domain to match, and a hyphenated word inside a sentence that merely
+    follows a URL is outside the matched span.
+    """
+    if not text or "/" not in text:
+        return text
+
+    def _spoken(match: re.Match) -> str:
+        host, path = match.group(1), match.group(2)
+        path = re.sub(r"\.(?:html?|php|aspx?)$", "", path, flags=re.IGNORECASE)
+        # Slashes and hyphens both become pauses in speech, not words.
+        path = re.sub(r"[/\-_.]+", " ", path).strip()
+        return f"{host} {path}".rstrip()
+
+    return _URL_IN_SPEECH.sub(_spoken, text)
 
 
 def validate_elevenlabs_auth(api_key: str) -> None:
@@ -922,6 +986,15 @@ def _speak_with_grok(
         )
         speech_wrap_open = ""
         speech_wrap_close = ""
+        # Record it as well as logging it. The warning above has fired on
+        # 5.1% of the 1,270 committed episodes — 16% on Modern Investing
+        # and 11% on Tesla — so roughly one Tesla episode in nine ships
+        # with different vocal energy from the other eight, and nothing
+        # surfaced that. A log line in a CI job is not a signal anyone
+        # sees; run_show drains this into the episode metrics.
+        global _WRAP_DROPPED
+        _WRAP_DROPPED = {"dropped": True, "chunks": len(chunks),
+                         "chars": len(text)}
 
     def _wrap(s: str) -> str:
         if not (speech_wrap_open or speech_wrap_close):

--- a/run_show.py
+++ b/run_show.py
@@ -2875,6 +2875,29 @@ def run(args: argparse.Namespace) -> None:
                 _tts_duration = time.monotonic() - t0
                 logger.info("TTS synthesis took %.1fs", _tts_duration)
                 metrics.record("tts_duration_s", round(_tts_duration, 2))
+
+                # Did the chunk-boundary guard drop the <fast> energy wrap
+                # on this episode? It fires whenever the script overflows
+                # the single-call budget, which is 5.1% of episodes
+                # network-wide but 16% on Modern Investing and 11% on
+                # Tesla — so the same show ships two different vocal
+                # energies depending on script length, and until now that
+                # was only a log line. Recorded so the dashboard can show
+                # the rate and the operator can decide whether the
+                # inconsistency or the lift matters more.
+                from engine.tts import drain_wrap_drop
+                _wrap_drop = drain_wrap_drop()
+                metrics.record("tts_speech_wrap_dropped", bool(_wrap_drop))
+                if _wrap_drop:
+                    metrics.record("tts_chunks", int(_wrap_drop.get("chunks", 0)))
+                    logger.warning(
+                        "::warning::%s Ep%s shipped WITHOUT the <fast> energy "
+                        "wrap (script %s chars -> %s chunks). Vocal energy "
+                        "differs from this show's other episodes.",
+                        config.slug, episode_num,
+                        _wrap_drop.get("chars"), _wrap_drop.get("chunks"),
+                    )
+
                 from engine.tracking import record_tts_usage
                 record_tts_usage(tracker, len(podcast_script), provider=config.tts.provider)
 

--- a/tests/test_p3_hygiene.py
+++ b/tests/test_p3_hygiene.py
@@ -391,3 +391,47 @@ class TestAppleReporterFreshness:
         raw = (REPO_ROOT / ".github" / "workflows"
                / "nightly-maintenance.yml").read_text(encoding="utf-8")
         assert "check_apple_reporter_freshness.py" in raw
+
+
+class TestRuffGateRunsLocally:
+    """``pytest`` must fail on what the CI lint step fails on.
+
+    July 30 2026: the full local suite passed (5,023 tests) while CI went
+    red, because the lint step in ``.github/workflows/test.yml`` was the
+    only thing running ruff and nothing in the suite did. The retention
+    pass stopped using ``build_intro_line``'s greeting/framing selections
+    but left them assigned, which is an F841 — invisible locally, a red
+    check on the PR.
+
+    Skips when ruff isn't installed rather than failing: CI installs it
+    and runs the explicit step regardless, so the value here is catching
+    it in a dev environment before the push, not gating one without ruff.
+    """
+
+    # Mirrors the CI invocation's targets. CI adds --fix
+    # --exit-non-zero-on-fix (fail even when auto-fixable); a plain check
+    # fails on the same findings without mutating the working tree.
+    _TARGETS = ["engine/", "run_show.py", "scripts/"]
+
+    def test_ruff_is_clean(self):
+        pytest.importorskip("ruff", reason="ruff not installed in this env")
+        result = subprocess.run(
+            [sys.executable, "-m", "ruff", "check", *self._TARGETS],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            "ruff would fail CI:\n" + (result.stdout or result.stderr)
+        )
+
+    def test_targets_match_the_ci_step(self):
+        """A target added to CI but not here would go unchecked locally."""
+        raw = (REPO_ROOT / ".github" / "workflows"
+               / "test.yml").read_text(encoding="utf-8")
+        line = next(ln for ln in raw.splitlines() if "ruff check" in ln)
+        for target in self._TARGETS:
+            assert target in line, f"CI no longer lints {target}"
+        # And nothing in CI's list is missing from ours.
+        ci_targets = [tok for tok in line.split()
+                      if not tok.startswith("-") and tok not in
+                      ("run:", "ruff", "check")]
+        assert sorted(ci_targets) == sorted(self._TARGETS), ci_targets

--- a/tests/test_tts_grok.py
+++ b/tests/test_tts_grok.py
@@ -764,3 +764,109 @@ def test_synthesize_sections_passes_wrap_through(tmp_path: Path, monkeypatch):
         _, kwargs = call
         assert kwargs["speech_wrap_open"] == "<fast>"
         assert kwargs["speech_wrap_close"] == "</fast>"
+
+
+# ---------------------------------------------------------------------------
+# Speech-safe URL paths (July 30 2026)
+#
+# Found by comparing each episode's TTS input against the Whisper transcript
+# of the audio that actually shipped — 1,191 episodes had both. Grok TTS
+# speaks the hyphen in a URL path as the WORD "hyphen": the network
+# cross-promo's "nerranetwork.com/start-here" aired as "slash start hyphen
+# here" and "/age-of-ai-apply" as "of hyphen AI apply". 95 spoken "hyphen"s
+# across 67 episodes, 36 of them from these promo URLs.
+#
+# The scope is narrow ON PURPOSE. Those same episodes fed the voice 28,955
+# hyphenated compounds and only 0.33% leaked, so a blanket strip would
+# rewrite ~29,000 tokens to fix ~95.
+# ---------------------------------------------------------------------------
+
+class TestSpeechSafeUrls:
+    @staticmethod
+    def _f(text):
+        from engine.tts import _speech_safe_urls
+        return _speech_safe_urls(text)
+
+    def test_the_real_shipped_lines(self):
+        """Exactly the copy that produced the artifact on air."""
+        assert "hyphen" not in self._f(
+            "New to the network? nerranetwork.com/start-here picks the "
+            "right daily briefing for you in about two minutes.")
+        assert self._f("apply at nerranetwork.com/age-of-ai-apply.") == \
+            "apply at nerranetwork.com age of ai apply."
+
+    def test_sentence_period_survives(self):
+        """The voice needs the period to close the sentence.
+
+        A dot inside the path must be followed by more path characters —
+        an earlier version of the pattern swallowed the sentence-final
+        period along with the path.
+        """
+        out = self._f("at nerranetwork.com/thedppod. This episode used AI.")
+        assert out.startswith("at nerranetwork.com thedppod.")
+        assert out.endswith("This episode used AI.")
+
+    def test_file_extension_is_not_spoken(self):
+        assert self._f("See nerranetwork.com/data.html for more.") == \
+            "See nerranetwork.com data for more."
+
+    def test_prose_hyphens_are_untouched(self):
+        """28,955 hyphenated compounds ship correctly — do not touch them."""
+        for line in (
+            "No fresh contaminated-sites thresholds appear in the index.",
+            "NASA plans six post-certification missions.",
+            "The state-of-the-art model is open-weights and multi-modal.",
+            "It was a well-known trade-off in high-volume manufacturing.",
+        ):
+            assert self._f(line) == line, line
+
+    def test_bare_domain_is_untouched(self):
+        """No path means nothing to rewrite — the brand keeps its dots."""
+        assert self._f("All our shows are free at nerranetwork.com.") == \
+            "All our shows are free at nerranetwork.com."
+
+    def test_runs_on_every_tts_input(self):
+        """Wired into prepare_text_for_tts, not just callable in isolation."""
+        from engine.tts import prepare_text_for_tts
+        assert "hyphen" not in prepare_text_for_tts(
+            "Visit nerranetwork.com/start-here today.")
+        assert "start here" in prepare_text_for_tts(
+            "Visit nerranetwork.com/start-here today.")
+
+    def test_no_promo_surface_still_ships_a_hyphenated_path(self):
+        """The copy itself should also be speakable, belt and braces."""
+        from engine.network_promo import NETWORK_SURFACES
+        for surface in NETWORK_SURFACES:
+            spoken = self._f(str(surface.get("spoken") or ""))
+            assert "hyphen" not in spoken.lower(), surface.get("id")
+
+
+class TestSpeechWrapDropIsVisible:
+    """The <fast> wrap drop must be a metric, not only a log line.
+
+    The chunk-boundary guard fires whenever a script overflows the
+    single-call budget: 5.1% of the 1,270 committed episodes network-wide,
+    but 16% on Modern Investing and 11% on Tesla. So roughly one Tesla
+    episode in nine ships with different vocal energy from the other
+    eight, and nothing surfaced it.
+    """
+
+    def test_drain_returns_then_clears(self):
+        """A later episode in the same process must not inherit the flag."""
+        from engine import tts
+        tts._WRAP_DROPPED = {"dropped": True, "chunks": 2, "chars": 15200}
+        first = tts.drain_wrap_drop()
+        assert first["chunks"] == 2
+        assert tts.drain_wrap_drop() == {}
+
+    def test_clean_episode_drains_empty(self):
+        from engine import tts
+        tts._WRAP_DROPPED = {}
+        assert tts.drain_wrap_drop() == {}
+
+    def test_run_show_records_the_metric(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent
+               / "run_show.py").read_text(encoding="utf-8")
+        assert "drain_wrap_drop" in src
+        assert "tts_speech_wrap_dropped" in src


### PR DESCRIPTION
Two speech-quality defects plus the lint fix that #912 merged red.

## How these were found

By comparing each episode's **TTS input** against the **Whisper transcript of the audio that actually shipped** — 1,191 episodes have both files on disk. That matters here: landmine #17 records a **100% regression rate** for theory-driven changes to this voice (every phonetic respelling, the `<build-intensity>` wrap, the `<emphasis>` injector). So nothing below is "this should sound better" — it's what the voice measurably did.

## 1. Grok TTS speaks the hyphen in a URL path as the word "hyphen"

The network cross-promo aired:

| written | what listeners heard |
|---|---|
| `nerranetwork.com/start-here` | "slash start **hyphen** here" |
| `nerranetwork.com/age-of-ai-apply` | "of **hyphen** AI apply" |

**95 spoken "hyphen"s across 67 episodes**, 36 from these promo URLs, most recent 2026-07-26.

`_speech_safe_urls` runs inside `prepare_text_for_tts`, so it covers every TTS input rather than the five promo strings that trip it today. Only the **path** of a domain-like token is rewritten — hyphens, slashes and underscores become spaces, file extensions drop. The host keeps its dots, so the brand still reads as "nerranetwork dot com".

**The narrow scope is the point.** Those same episodes fed the voice **28,955 hyphenated compounds and only 0.33% leaked** — hyphens are overwhelmingly handled correctly, and a blanket strip would rewrite ~29,000 tokens to fix ~95. `contaminated-sites`, `post-certification`, `state-of-the-art` are asserted unchanged.

One bug worth recording: the first version of the pattern matched greedily and **swallowed the sentence-ending period** — which the voice needs to close the sentence. A dot must now be followed by more path. Guarded.

## 2. The `<fast>` energy wrap silently drops on 5% of episodes

When a script overflows the single-call budget it's split, and the chunk-boundary guard drops the wrap rather than re-introduce the leak that had Grok voicing "Fast." aloud at boundaries. **That guard is correct and stays.** What was missing is that it only *logged*.

Measured across the 1,270 committed TTS scripts:

| show | episodes over the single-call budget |
|---|---|
| Modern Investing | **16%** |
| Tesla Shorts Time | **11%** |
| Planetterrian | 10% |
| network-wide | 5.1% |

So roughly **one Tesla episode in nine ships with different vocal energy** from the other eight, nobody chose which, and nothing reported it. `run_show` now drains the drop into `tts_speech_wrap_dropped` / `tts_chunks` and emits a `::warning::` naming the episode.

This **measures** the inconsistency rather than resolving it — choosing between uniform delivery without the lift and the current mixed state is an A/B listen, not a code change.

## Checked and deliberately not changed

- **`grok-voice-tts-1.0` (May 15 2026) is the only released version** of the TTS model. The network is already on the latest; there is nothing to migrate to.
- **`nassa`** — the June 10 repair layer targets it, and it hasn't appeared in a TTS script since Tesla Ep488 (2026-05-27). The recent-looking hit was "**Nassau**". Genuinely closed.
- **`/thedppod`** renders correctly as "slash the DP pod" — my initial hypothesis that it mangled was wrong.

## 3. The #912 lint fix

#912 merged with a red check: `build_intro_line` still selected a greeting/opener/framing it no longer used, and `lang_dub` still imported `_word_trim`. The pools stay in `_SHOW_PERSONALITIES` (the closings read them); only the discarding work is gone.

**Nothing in the test suite ran ruff** — 5,023 local tests passed while CI failed. `TestRuffGateRunsLocally` now runs the same check under pytest, and a second test keeps the targets in sync with CI in both directions. I verified the guard bites by injecting a real `F841`; the *first* verification attempt passed against a deliberate violation because ruff ignores underscore-prefixed names.

---

`5035 passed, 5 skipped`; ruff clean.

**Audio note:** no prompt or voice-setting changes here, but the URL fix does change what the outro says on shows carrying a promo surface with a path — worth one listen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4