### PR TITLE
Fix CST-100 spoken as "central standard time", and captions overflowing off the top of the frame

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -1123,10 +1123,63 @@ def replace_times(text: str) -> str:
     return text
 
 
+# A timezone abbreviation is only a timezone when it FOLLOWS a time. Every
+# legitimate use in the network's 1,270 committed TTS scripts does: "eight
+# thirty-four a.m. Pacific Daylight Time", "1 P.M. Eastern Daylight Time".
+# Times are already spelled out by the time this runs, but the a.m./p.m.
+# marker survives, so it is the reliable anchor.
+#
+# The anchor has to cover 24-hour times too. Those carry no a.m./p.m.
+# marker, and by this point the digits are already words: "Liftoff occurred
+# at 0850 UTC" reaches here as "at oh eight fifty UTC". SpaceX Daily uses
+# exactly that shape, so a marker-only anchor would have stopped expanding
+# UTC on the show that uses it most.
+_NUM_WORD = (r"oh|zero|one|two|three|four|five|six|seven|eight|nine|ten|"
+             r"eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|"
+             r"eighteen|nineteen|twenty|thirty|forty|fifty|hundred")
+_TIME_BEFORE_TZ = re.compile(
+    r"(?:\d|noon|midnight|o'clock|[ap]\.?\s?m\.?|\b(?:" + _NUM_WORD + r"))"
+    r"[\s,-]*$", re.IGNORECASE)
+
+# Product designations that COLLIDE with a timezone abbreviation, expanded
+# letter-wise before the timezone pass can touch them. Boeing's CST-100
+# Starliner is Crew Space Transportation, and SpaceX Daily Ep049 aired
+# "Boeing's central standard time 100 Starliner" twice (operator-caught,
+# 2026-07-30). Spoken as letters, which is how the vehicle is said aloud.
+_TZ_COLLIDING_PRODUCTS: Dict[str, str] = {
+    r"\bCST-?\s?100\b": "C S T one hundred",
+}
+
+
 def replace_timezones(text: str) -> str:
-    """Expand timezone abbreviations to full names."""
+    """Expand timezone abbreviations to full names — when they ARE timezones.
+
+    This used to expand every whole-word match unconditionally, which is
+    correct for "5 p.m. CST" and wrong for anything that merely shares the
+    letters. Boeing's CST-100 Starliner shipped as "central standard
+    time-100 Starliner" on SpaceX Daily Ep049.
+
+    Measured against every committed TTS script: 33 legitimate expansions
+    all follow a time expression and are preserved by the guard, and the
+    only two it blocks are the Ep049 CST-100 pair. The guard also covers
+    collisions that have not happened yet — "BST" is a binary search tree
+    in an AI-news episode, "IST" and "MST" have their own product uses.
+    """
+    for pattern, spoken in _TZ_COLLIDING_PRODUCTS.items():
+        text = re.sub(pattern, spoken, text, flags=re.IGNORECASE)
+
     for tz, expansion in TIMEZONE_EXPANSIONS.items():
-        text = re.sub(rf"\b{re.escape(tz)}\b", expansion, text)
+        # Bind the string this pass scans, so the lookbehind never reads a
+        # later iteration's rewritten text through the closure.
+        source = text
+
+        def _maybe(match: re.Match, _exp: str = expansion, _src: str = source) -> str:
+            before = _src[max(0, match.start() - 40):match.start()]
+            if _TIME_BEFORE_TZ.search(before):
+                return _exp
+            return match.group(0)   # not a timezone here — leave it alone
+
+        text = re.sub(rf"\b{re.escape(tz)}\b", _maybe, source)
     return text
 
 

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -42,6 +42,43 @@ def _format_srt_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"
 
 
+def _wrap_all_lines(text: str, max_chars: int) -> List[str]:
+    """Greedy word-wrap into as many lines as the text needs.
+
+    Pure wrapping with no line cap, so it can never drop a word. The cue
+    box's line limit is applied by ``_split_caption_text``, which groups
+    these lines into cue-sized blocks.
+    """
+    lines: List[str] = []
+    current = ""
+    for word in " ".join((text or "").split()).split():
+        candidate = f"{current} {word}".strip()
+        if len(candidate) <= max_chars or not current:
+            current = candidate
+        else:
+            lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+    return lines
+
+
+def _split_caption_text(text: str, max_chars: int = 55,
+                        max_lines: int = 3) -> List[str]:
+    """Wrap *text* into as many cue-sized blocks as it needs.
+
+    One Whisper segment can be far longer than a caption box. Returning a
+    LIST rather than one over-stuffed block is what keeps every cue inside
+    the frame while still showing every word: the caller shares the
+    segment's time range across the blocks.
+    """
+    lines = _wrap_all_lines(text, max_chars)
+    if not lines:
+        return [""]
+    return ["\n".join(lines[i:i + max_lines])
+            for i in range(0, len(lines), max_lines)]
+
+
 def _wrap_caption_line(text: str, max_chars: int = 55,
                        max_lines: int = 3) -> str:
     """Greedy word-wrap so each caption stays within *max_lines*.
@@ -84,10 +121,20 @@ def _wrap_caption_line(text: str, max_chars: int = 55,
         lines.append(current)
         current = ""
         if len(lines) >= max_lines:
-            # Already filled all ``max_lines`` complete lines.
-            # Tack the remaining words onto the LAST committed
-            # line and let libass clip on the right. The earlier
-            # lines stay intact (no overwrite — that was the bug).
+            # Kept for direct callers, which need this to stay lossless.
+            # The SRT path no longer reaches here — it uses
+            # ``_split_caption_text``, which turns the overflow into its
+            # OWN cue instead of stuffing one line.
+            #
+            # Why that matters: this branch used to append the remainder
+            # "and let libass clip on the right". libass does not clip;
+            # with the default WrapStyle it WORD-WRAPS, and because cues
+            # are bottom-anchored the extra lines grow upward and off the
+            # top of the frame. A real SpaceX Ep049 cue carried a 298-char
+            # last line, which wraps to ~13 rendered lines at ~98 px each
+            # — about 1,270 px of text in a 1,080 px frame. That is the
+            # "script cut off at the top" reported on both YouTube and the
+            # Apple video feed.
             rest = " ".join(words[i:])
             lines[-1] = (lines[-1] + " " + rest).strip()
             return "\n".join(lines)
@@ -164,14 +211,24 @@ def transcript_to_srt(transcript_path: Path, srt_path: Path,
             continue
         if end_f - start_f < min_segment_duration:
             continue
-        wrapped = _wrap_caption_line(text)
-        cues.append(
-            f"{cue_index}\n"
-            f"{_format_srt_timestamp(start_f)} --> "
-            f"{_format_srt_timestamp(end_f)}\n"
-            f"{wrapped}\n"
-        )
-        cue_index += 1
+        # A Whisper segment can be much longer than one caption box. Split
+        # it into cue-sized blocks and share the segment's time range
+        # between them, so every word still appears and no single cue
+        # overflows the frame.
+        blocks = _split_caption_text(text)
+        span = (end_f - start_f) / len(blocks)
+        for n, block in enumerate(blocks):
+            if not block.strip():
+                continue
+            b_start = start_f + n * span
+            b_end = start_f + (n + 1) * span if n < len(blocks) - 1 else end_f
+            cues.append(
+                f"{cue_index}\n"
+                f"{_format_srt_timestamp(b_start)} --> "
+                f"{_format_srt_timestamp(b_end)}\n"
+                f"{block}\n"
+            )
+            cue_index += 1
 
     if not cues:
         logger.warning(

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -324,3 +324,101 @@ def test_find_transcript_for_episode(tmp_path: Path):
 
     missing = find_transcript_for_episode(digests, "TST", 99, "20260427")
     assert missing is None
+
+
+# ---------------------------------------------------------------------------
+# Long cues must not overflow the frame (July 30 2026)
+#
+# Operator: "All videos now on Apple and YouTube have the script over the
+# video, but it is cutting off at the top."
+#
+# Root cause was a wrong assumption in the May 2026 fix: it appended a long
+# segment's remainder to the last line "and let libass clip on the right".
+# libass does NOT clip — with the default WrapStyle it word-wraps, and cues
+# are bottom-anchored, so the extra lines grow UPWARD off the top of the
+# frame. A real SpaceX Ep049 cue carried a 298-character last line, which
+# wraps to ~13 rendered lines at ~98 px each: ~1,270 px of text in a
+# 1,080 px frame.
+# ---------------------------------------------------------------------------
+
+class TestLongSegmentsBecomeMultipleCues:
+    _MAX_CHARS = 55
+    _MAX_LINES = 3
+
+    @staticmethod
+    def _blocks(text, **kw):
+        from engine.captions import _split_caption_text
+        return _split_caption_text(text, **kw)
+
+    def test_a_long_segment_splits_instead_of_overflowing(self):
+        text = " ".join(f"word{i}" for i in range(120))
+        blocks = self._blocks(text)
+        assert len(blocks) > 1
+        for b in blocks:
+            lines = b.split("\n")
+            assert len(lines) <= self._MAX_LINES, b
+            for line in lines:
+                assert len(line) <= self._MAX_CHARS, line
+
+    def test_no_word_is_lost_or_duplicated(self):
+        """The May 2026 bug this replaces was silent word LOSS."""
+        text = " ".join(f"w{i}" for i in range(250))
+        joined = " ".join(l for b in self._blocks(text) for l in b.split("\n"))
+        assert joined.split() == text.split()
+
+    def test_short_segment_is_a_single_cue(self):
+        assert self._blocks("A short line of narration.") == \
+            ["A short line of narration."]
+
+    def test_real_transcript_cues_fit_the_frame(self):
+        """Replay the episode the operator reported."""
+        import json
+        from pathlib import Path
+        from engine.captions import transcript_to_srt
+        root = Path(__file__).resolve().parent.parent
+        src = sorted((root / "digests" / "spacex").glob("*_transcript.json"))
+        if not src:
+            import pytest
+            pytest.skip("no committed SpaceX transcript")
+        out = Path(__import__("tempfile").mkdtemp()) / "t.srt"
+        transcript_to_srt(src[-1], out, audio_offset_seconds=0.0)
+        cues = out.read_text(encoding="utf-8").strip().split("\n\n")
+        for cue in cues:
+            body = [l for l in cue.split("\n")[2:] if l.strip()]
+            assert len(body) <= self._MAX_LINES, cue[:160]
+            for line in body:
+                assert len(line) <= self._MAX_CHARS, line
+
+        # And the SRT still carries every transcribed word.
+        segments = json.loads(src[-1].read_text(encoding="utf-8"))["segments"]
+        expected = " ".join((s.get("text") or "").strip()
+                            for s in segments).split()
+        got = " ".join(l for c in cues for l in c.split("\n")[2:]).split()
+        assert got == expected
+
+    def test_no_control_character_reaches_the_srt(self):
+        """An earlier draft passed the overflow through a NUL marker."""
+        from engine.captions import _split_caption_text
+        text = " ".join(f"word{i}" for i in range(200))
+        for block in _split_caption_text(text):
+            assert "\x00" not in block
+
+    def test_split_cues_share_the_segment_time_range(self):
+        """Split blocks must not all sit on the segment's start time."""
+        import json
+        import tempfile
+        from pathlib import Path
+        from engine.captions import transcript_to_srt
+        long_text = " ".join(f"word{i}" for i in range(150))
+        tmp = Path(tempfile.mkdtemp())
+        src = tmp / "t.json"
+        src.write_text(json.dumps(
+            {"segments": [{"start": 10.0, "end": 40.0, "text": long_text}]}),
+            encoding="utf-8")
+        out = tmp / "t.srt"
+        transcript_to_srt(src, out, audio_offset_seconds=0.0)
+        cues = out.read_text(encoding="utf-8").strip().split("\n\n")
+        assert len(cues) > 1
+        starts = [c.split("\n")[1].split(" --> ")[0] for c in cues]
+        assert len(set(starts)) == len(starts), starts
+        assert cues[-1].split("\n")[1].endswith("00:00:40,000")

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -1299,3 +1299,116 @@ class TestTeslaIntroFormatting:
         closing = _pick_closing(context)
         assert "Patrick" in closing
         assert "tomorrow" in closing.lower()
+
+
+# ---------------------------------------------------------------------------
+# Timezone abbreviations only expand when they ARE timezones (July 30 2026)
+#
+# Operator caught SpaceX Daily Ep049 saying "Boeing's central standard
+# time 100 Starliner" — twice. Boeing's CST-100 Starliner is Crew Space
+# Transportation; ``replace_timezones`` had been expanding every whole-word
+# match unconditionally.
+#
+# The corruption was upstream of the voice: the digest and the reader copy
+# both said "CST-100" correctly and the TTS INPUT already read "Central
+# Standard Time-100", so this is a text-processing bug, not a TTS one.
+#
+# Measured before changing anything: of the timezone expansions across every
+# committed TTS script, 33 are legitimate and all follow a time expression;
+# the only 2 that do not are the Ep049 pair. Across 102 digests containing a
+# timezone abbreviation, exactly 1 changes behaviour.
+# ---------------------------------------------------------------------------
+
+class TestTimezoneExpansionNeedsATime:
+    @staticmethod
+    def _f(text):
+        from assets.pronunciation import replace_timezones
+        return replace_timezones(text)
+
+    def test_the_operator_reported_sentences(self):
+        """The exact lines that aired wrong."""
+        for line in (
+            "Kelly Ortberg said the company is feeling pretty good about a "
+            "possible CST-100 Starliner flight this year.",
+            "Observers noted that Boeing's CST-100 Starliner could still "
+            "reach orbit this year.",
+        ):
+            out = self._f(line)
+            assert "Central Standard Time" not in out, out
+            assert "C S T one hundred" in out, out
+
+    def test_cst_100_spelling_variants(self):
+        for written in ("CST-100", "CST100", "CST 100", "cst-100"):
+            out = self._f(f"Boeing's {written} Starliner is on the pad.")
+            assert "Central Standard Time" not in out, written
+            assert "C S T one hundred" in out, written
+
+    def test_real_timezone_uses_still_expand(self):
+        """Every legitimate expansion in the corpus follows a time."""
+        cases = [
+            ("lifted off at approximately eight thirty-four a.m. PDT.",
+             "Pacific Daylight Time"),
+            ("Mercury reaches its stationary point at 1 P.M. EDT.",
+             "Eastern Daylight Time"),
+            ("The flight window opens at five thirty a.m. EDT on June 24.",
+             "Eastern Daylight Time"),
+            ("scheduled between nine oh eight A M and nine fifty-seven A M "
+             "BST on April 30.", "British Summer Time"),
+            ("The deadline is 5 p.m. CST.", "Central Standard Time"),
+        ]
+        for line, expected in cases:
+            assert expected in self._f(line), line
+
+    def test_unrelated_uses_are_left_alone(self):
+        """Same letters, different meaning — no preceding time, no expansion."""
+        for line in (
+            "The team replaced the BST with a hash map for lookups.",
+            "The IST framework shipped a new release.",
+        ):
+            assert self._f(line) == line, line
+
+    def test_guard_does_not_read_a_later_rewrite(self):
+        """The lookbehind must scan the string this pass started with.
+
+        The expansion loop reassigns ``text`` per timezone, so a closure
+        reading the outer name could see an already-rewritten string and
+        judge the wrong context.
+        """
+        line = ("Launch at 9 a.m. EDT, and separately the CST-100 Starliner "
+                "remains grounded.")
+        out = self._f(line)
+        assert "Eastern Daylight Time" in out
+        assert "Central Standard Time" not in out
+
+    def test_corpus_regression_is_limited_to_the_known_case(self):
+        """Re-run over the committed digests: only Ep049 may change."""
+        import re
+        from pathlib import Path
+        from assets.pronunciation import TIMEZONE_EXPANSIONS
+        root = Path(__file__).resolve().parent.parent
+        abbr = re.compile(r"\b(" + "|".join(TIMEZONE_EXPANSIONS) + r")\b")
+        changed = []
+        for p in (root / "digests").rglob("*.md"):
+            text = p.read_text(encoding="utf-8", errors="replace")
+            if not abbr.search(text):
+                continue
+            legacy = text
+            for tz, exp in TIMEZONE_EXPANSIONS.items():
+                legacy = re.sub(rf"\b{re.escape(tz)}\b", exp, legacy)
+            if self._f(text) != legacy:
+                changed.append(p.name)
+        assert len(changed) <= 1, (
+            f"the guard changed {len(changed)} committed digests, expected "
+            f"only the CST-100 one: {changed[:8]}"
+        )
+
+    def test_24_hour_times_still_expand(self):
+        """UTC times carry no a.m./p.m. marker.
+
+        By the time this runs the digits are already words, so "0850 UTC"
+        arrives as "oh eight fifty UTC". A marker-only anchor stopped
+        expanding UTC on SpaceX Daily — the show that uses it most — which
+        tests/test_spacex_show.py caught.
+        """
+        assert "U T C" in self._f("Liftoff occurred at oh eight fifty UTC.")
+        assert "U T C" in self._f("The burn completed at fourteen hundred UTC.")


### PR DESCRIPTION
Both operator-reported. Both turned out to be upstream of the thing they looked like.

## 1. "Boeing's central standard time 100 Starliner" (SpaceX Ep049)

Boeing's CST-100 Starliner is *Crew Space Transportation*. It aired wrong **twice**.

**This was not a TTS problem.** The digest and the reader copy both say `CST-100` correctly — the **TTS input itself** already read `Central Standard Time-100 Starliner`. `assets.pronunciation.replace_timezones` was expanding every whole-word match of every timezone abbreviation unconditionally, with no test that the letters were being used as a timezone.

A timezone now has to **follow a time**. That rule came from the data, not from assumption:

- Across every committed TTS script, **all 33 legitimate expansions follow a time expression**; the only 2 that don't are the Ep049 pair.
- Replayed over the **102 committed digests** containing a timezone abbreviation, **exactly 1** changes behaviour.

`CST-100` is additionally expanded letter-wise ahead of the timezone pass, so the vehicle is spoken the way it's actually said aloud rather than left to the TTS normalizer to guess. The guard also covers collisions that haven't happened yet — `BST` is a binary search tree in an AI-news episode.

**Two things I got wrong first, both caught before merge:**
- The lookbehind read the loop variable through a closure. The expansion loop reassigns `text` once per timezone, so a *later* iteration's rewritten string could have been the one judged for context.
- The first anchor required an a.m./p.m. marker or a digit — which broke **24-hour times**. By the time this runs the digits are already words, so `0850 UTC` arrives as "oh eight fifty UTC" and stopped expanding, on SpaceX Daily, the show that uses UTC most. `tests/test_spacex_show.py` caught it.

## 2. Captions cut off at the top (YouTube + Apple)

The May 2026 fix appended a long segment's remainder to the last caption line "and let libass clip on the right".

**libass does not clip.** With the default `WrapStyle` it word-**wraps**, and cues are bottom-anchored — so the extra lines grow *upward* and off the top of the frame.

Measured on the episode reported:

| | before | after |
|---|---|---|
| longest caption line | **298 chars** (budget: 55) | 55 |
| max lines per cue | 3 declared… | 3 actual |
| tallest cue rendered | **~1,270 px** in a 1,080 px frame | 292 px (27%) |
| cues | 47 | 79 |
| words preserved | — | **1,393 / 1,393, in order** |

At FontSize 26 (libass scales by 1080/288 → ~98 px), a 298-char line wraps to ~13 rendered lines. That's the overflow.

`_split_caption_text` now returns as many cue-sized blocks as a segment needs, and `transcript_to_srt` shares the segment's time range across them. Wrapping and line-capping became separate concerns: `_wrap_all_lines` wraps without a cap so it can't drop a word, `_split_caption_text` groups into cues, and `_wrap_caption_line` keeps its previous lossless contract for direct callers.

**Also got wrong first:** the initial version returned overflow through a NUL marker embedded in `_wrap_caption_line`'s return value, changing a helper's contract out from under its callers. `tests/test_captions.py` caught the control character leaking into wrapped output.

---

`5048 passed, 5 skipped`; ruff clean. Render/text-processing only — no voice settings, no prompts, no audio chain changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_