### PR TITLE
Make the spoken-URL fix actually fire, and correct a de-esser that never existed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1702,11 +1702,26 @@ decision); everything else has a live status card.
       handles dates, currencies, and ordinary numbers — the
       `pronunciation_map.yaml` layer remains for proper-noun / acronym
       overrides.
-    - **Voice EQ chain** (`engine/audio.py:_voice_norm_full_cmd`)
-      gained a 6.5 kHz dip (`equalizer=f=6500:t=q:w=1.5:g=-3`) for
-      gentle de-essing on the new custom voice. Previous chain
-      (highpass / lowpass / loudnorm / compressor / limiter) is
-      otherwise unchanged.
+    - **Voice EQ chain** (`engine/audio.py:_voice_norm_full_cmd`) —
+      highpass 80 / lowpass 15k / adeclick+afftdn / loudnorm -18 /
+      acompressor 4:1 / alimiter. **This entry used to claim the chain
+      "gained a 6.5 kHz dip (`equalizer=f=6500:t=q:w=1.5:g=-3`) for
+      gentle de-essing". It never did** — `git log -S "6500"` on
+      `engine/audio.py` returns nothing, the string has never existed in
+      the file. Corrected 2026-07-30. Do not "restore" it: there is
+      nothing to restore.
+      **De-essing was then measured and deliberately declined.** With a
+      live key, 2:34 of real Tesla Ep557 synthesized on the production
+      voice and pushed through the chain shows the midrange flat
+      (-0.1 dB) while the sibilance band (5.5-8.5 kHz) gains **+5.1 dB**
+      and air (8.5-16 kHz) **+5.0 dB** — the 4:1 broadband compressor
+      lifts consonants faster than vowels. Four variants (no de-ess /
+      static -3 dB / static -5 dB / ffmpeg `deesser`) were rendered and
+      **the operator listened: all four sound the same on this voice.**
+      So the +5 dB is a measurement, not a defect, and the network ships
+      the chain unchanged — adding a stage that buys no audible benefit
+      but alters every episode on 15 shows is the landmine-#17 shape.
+      Re-open only with listening evidence, not spectra.
     - **Final mix** (`engine/audio.py:_final_mix_cmd`) replaced the
       simple `amix` with sidechain-ducked music + EBU R128 loudnorm
       to **-16 LUFS** (Apple Podcasts / Spotify spec). Music

--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -83,9 +83,32 @@ def strip_urls(text: str) -> str:
     # Replace bare domain names (no protocol) with spoken form so TTS
     # doesn't mangle them via acronym expansion (e.g. "chat.openai.com"
     # would otherwise become "chat.Open A I.com").
+    #
+    # The PATH is handled here too, in the same pass. It has to be: this
+    # rewrite turns ".com" into " dot com", and any later attempt to
+    # recognise the URL then fails to match, because the thing it is
+    # looking for no longer looks like a domain. That is exactly how the
+    # first version of this fix (engine.tts._speech_safe_urls, PR #913)
+    # ended up dead in production — it passed its unit tests on a raw URL
+    # and never fired on the real pipeline, where this function runs
+    # first. Verified against live Grok TTS on 2026-07-30.
+    #
+    # Grok TTS speaks a hyphen in a path as the WORD "hyphen":
+    # "nerranetwork.com/start-here" aired as "slash start hyphen here".
+    # Hyphens, slashes and underscores are pauses in speech, not words.
+    def _spoken_domain(m: re.Match) -> str:
+        host = m.group("host").replace(".", " dot ")
+        path = m.group("path") or ""
+        if not path:
+            return host
+        path = re.sub(r"\.(?:html?|php|aspx?)$", "", path.lstrip("/"),
+                      flags=re.IGNORECASE)
+        return f"{host} {re.sub(r'[/_.-]+', ' ', path)}".rstrip()
+
     text = re.sub(
-        r"\b(\w+(?:\.\w+)*\.(?:com|org|net|io|ai|co|dev))\b",
-        lambda m: m.group(0).replace(".", " dot "),
+        r"\b(?P<host>\w+(?:\.\w+)*\.(?:com|org|net|io|ai|co|dev))"
+        r"(?P<path>/[A-Za-z0-9\-_/]+(?:\.[A-Za-z0-9\-_/]+)*)?",
+        _spoken_domain,
         text,
     )
     return text

--- a/tests/test_pronunciation.py
+++ b/tests/test_pronunciation.py
@@ -1412,3 +1412,61 @@ class TestTimezoneExpansionNeedsATime:
         """
         assert "U T C" in self._f("Liftoff occurred at oh eight fifty UTC.")
         assert "U T C" in self._f("The burn completed at fourteen hundred UTC.")
+
+
+class TestSpokenUrlsThroughTheWholeChain:
+    """URL paths must be speakable after the FULL pronunciation chain.
+
+    July 30 2026, found with a live Grok TTS key. PR #913 added
+    ``engine.tts._speech_safe_urls`` and unit-tested it on a raw URL, where
+    it passed. In production it never fired: ``assets.pronunciation``
+    runs FIRST and rewrites "nerranetwork.com" to "nerranetwork dot com",
+    after which the later regex no longer recognises a domain. The fix
+    shipped dead.
+
+    The lesson is the test shape, not the regex — these assert the output
+    of ``run_show._apply_pronunciation`` followed by
+    ``engine.tts.prepare_text_for_tts``, which is what the voice actually
+    receives. Confirmed against synthesized audio: Whisper heard "start
+    here", with no "hyphen" and no "slash".
+    """
+
+    @staticmethod
+    def _voice_receives(text, slug="spacex"):
+        import run_show
+        from engine.tts import prepare_text_for_tts
+        return prepare_text_for_tts(run_show._apply_pronunciation(text, slug))
+
+    def test_promo_urls_have_no_spoken_punctuation(self):
+        for line in (
+            "New to the network? nerranetwork.com/start-here picks your briefing.",
+            "Apply at nerranetwork.com/age-of-ai-apply today.",
+            "The Dispatch Wall at nerranetwork.com/thedppod.",
+            "Live dashboards are at nerranetwork.com/data.",
+        ):
+            out = self._voice_receives(line)
+            assert "/" not in out, out
+            assert "-" not in out.split("dot com")[-1], out
+
+    def test_path_words_survive(self):
+        out = self._voice_receives(
+            "New to the network? nerranetwork.com/start-here picks your briefing.")
+        assert "start here" in out, out
+
+    def test_file_extension_not_spoken(self):
+        out = self._voice_receives("See nerranetwork.com/data.html for more.")
+        assert "html" not in out.lower(), out
+
+    def test_bare_domain_unchanged_in_meaning(self):
+        out = self._voice_receives("All our shows are free at nerranetwork.com.")
+        assert "dot com" in out and "/" not in out, out
+
+    def test_subdomain_still_handled(self):
+        out = self._voice_receives("Read chat.openai.com for details.")
+        assert "dot" in out and "/" not in out, out
+
+    def test_every_promo_surface_is_speakable(self):
+        from engine.network_promo import NETWORK_SURFACES
+        for surface in NETWORK_SURFACES:
+            out = self._voice_receives(str(surface.get("spoken") or ""))
+            assert "/" not in out, (surface.get("id"), out)


### PR DESCRIPTION
Two corrections, both found by pointing a **live Grok TTS key** at the real pipeline instead of reasoning about it.

## 1. The URL fix from #913 was dead in production

`engine.tts._speech_safe_urls` was unit-tested on a raw URL, where it passed. **It never fired on a real episode.**

`assets.pronunciation` runs *first* and rewrites `nerranetwork.com` → `nerranetwork dot com`. After that, the later regex is looking for a domain and there's no longer anything shaped like one. The voice was still receiving `nerranetwork dot com/start-here` and still saying **"start hyphen here"**.

```
original      : nerranetwork.com/start-here picks your briefing.
after pronunc : nerranetwork dot com/start-here picks your briefing.   <-- pattern destroyed
after tts prep: Nerra Network dot com/start-here picks your briefing.  <-- fix can't match
```

Handled now in `strip_urls`, in the same pass that already converts the domain — which is the only place it *can* be handled, since that pass is what destroys the pattern.

**Verified end to end against synthesized audio.** Whisper heard "start here", with no "hyphen" and no "slash", and "eastern daylight time" still expands.

### The test shape was the actual bug

The isolated unit test passed the whole time. The new cases assert the output of `run_show._apply_pronunciation` **followed by** `engine.tts.prepare_text_for_tts` — what the voice really receives — rather than one function on its own.

## 2. CLAUDE.md documented a de-esser that has never existed

Landmine #17 claimed the voice chain "gained a 6.5 kHz dip (`equalizer=f=6500:t=q:w=1.5:g=-3`) for gentle de-essing."

`git log -S "6500"` on `engine/audio.py` **returns nothing** — the string has never been in the file. A future session reading that entry would have tried to restore something that was never there.

### Measured while correcting it, then declined

2:34 of real Tesla Ep557 synthesized on the production voice and pushed through the chain:

| band | change through the chain |
|---|---|
| midrange 300 Hz–2 kHz | **−0.1 dB** (flat) |
| sibilance 5.5–8.5 kHz | **+5.1 dB** |
| air 8.5–16 kHz | **+5.0 dB** |

The 4:1 broadband compressor lifts consonants faster than vowels. Four variants were rendered — no de-ess, static −3 dB, static −5 dB, and ffmpeg's dynamic `deesser` — and **the operator listened to all four and heard no difference.**

So the chain ships **unchanged**. The +5 dB is a measurement, not a defect, and adding a stage that buys no audible benefit while altering every episode on fifteen shows is exactly the shape landmine #17 exists to prevent. The entry now records the verdict so it isn't re-litigated from spectra alone.

## Also verified clean (real audio, not inference)

| check | raw TTS | after `normalize_voice` | final mix |
|---|---|---|---|
| clipped samples | 0 | 0 | 0 |
| click candidates | **0** | **0** | **0** |
| noise floor | −71.6 dBFS | −74.9 dBFS | −60.8 dBFS |
| hiss (HF in silence) | 0.47% | 0.05% | 0.01% |

Final mix lands at **−16.2 LUFS** against the −16 target. The **multi-chunk crossfade** path (the 5% of episodes that split) produces boundaries indistinguishable from ordinary speech — notch depths below the file maximum, sample deltas a third of it. No seams, no tics.

---

`5054 passed, 5 skipped`; ruff clean. Total TTS spend for the whole investigation: **~$0.04**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4)_