### PR TITLE
Long-form captions from the track, not the pixels — and make @NerraFR readable

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -117,6 +117,16 @@ jobs:
           YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
           YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
           YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+          # @NerraFR. Without this the fetch can SEE the FR video rows
+          # (the glob fix, 2026-07-29) but cannot authenticate to the
+          # channel, so get_channel_credentials_from_env("fr") returns
+          # None and the whole channel is skipped — the 2026-07-30 nightly
+          # ran cleanly and still produced zero fr rows. The upload path
+          # has always had this token (multilingual.yml); only the
+          # read-back was missing it, which is why 42 FR videos published
+          # since 2026-07-21 while every FR show reported short_vpd: null
+          # and sat frozen at its seed tier.
+          YOUTUBE_REFRESH_TOKEN_FR: ${{ secrets.YOUTUBE_REFRESH_TOKEN_FR }}
         run: |
           python scripts/fetch_youtube_analytics.py --out api/youtube_stats.json --days 90 || true
           python scripts/update_youtube_performance.py || true

--- a/engine/config.py
+++ b/engine/config.py
@@ -554,6 +554,12 @@ class YouTubeConfig:
     # spoken hook) + A/B variants. One cheap LLM call/episode; pure metadata,
     # no audio impact. Set false for a fully deterministic hook-based title.
     optimized_titles: bool = True
+    # Burn captions into the long-form PIXELS. Default False: the runner
+    # uploads a real caption track for every long-form video, and doing
+    # both showed two sets of captions the moment a viewer pressed CC.
+    # Shorts are unaffected (they have no caption UI). Set True only for a
+    # surface that will not render a sidecar track.
+    long_form_burn_in_captions: bool = False
     short_duration_seconds: float = 35.0
     # Seconds into the final mixed MP3 where the Shorts clip begins.
     # When unset, ``shorts_start_mode`` picks the offset (default ``voice``

--- a/run_show.py
+++ b/run_show.py
@@ -5368,7 +5368,27 @@ def _publish_youtube(
                     or (long_scene_paths if len(long_scene_paths) >= 2 else None)
                 ),
                 clip_paths=long_clip_paths or None,
-                subtitles_path=srt_path,
+                # Long-form captions come from the REAL caption track
+                # uploaded after the upload below, not from burned-in
+                # pixels. Doing both put two sets of captions on screen the
+                # moment a viewer pressed CC — the pipeline has always
+                # uploaded a track AND baked one in. The track is strictly
+                # better on this surface: it toggles, it auto-translates,
+                # the player positions it, YouTube indexes it for search,
+                # and it does not permanently cover the Grok scene imagery
+                # the episode paid for. Apple's video podcast player also
+                # expects sidecar captions rather than baked ones.
+                #
+                # Shorts KEEP their burn-in — watched muted, in-feed, with
+                # no caption UI to fall back on.
+                #
+                # Per-show escape hatch for a surface that will not render
+                # a track: youtube.long_form_burn_in_captions: true.
+                subtitles_path=(
+                    srt_path
+                    if getattr(config.youtube, "long_form_burn_in_captions", False)
+                    else None
+                ),
                 show_name=config.name,
                 scene_schedule=_visual_plan.get("scene_schedule"),
                 broll_clips=_visual_plan.get("broll_clips"),
@@ -5502,23 +5522,41 @@ def _publish_youtube(
                                 int(result.get("yt_comments_posted", 0)) + 1)
                     except Exception as _exc:  # noqa: BLE001
                         logger.debug("long-form auto-comment skipped: %s", _exc)
-                # Upload the SRT as a real caption track. This is on top of
-                # the burned-in captions — gives YouTube the CC button +
-                # auto-translation + accessibility search. Best-effort:
-                # failures are logged and the run continues.
+                # Upload the SRT as a real caption track. Since July 30
+                # 2026 this is the ONLY caption layer on long-form (the
+                # burn-in is off by default — see build_long_form_video
+                # above), so a failure here means the video ships with no
+                # captions at all rather than merely losing the CC button.
+                # Still best-effort by contract: logged, run continues, and
+                # the metric below records it.
                 if srt_path and srt_path.exists():
                     from engine.youtube import upload_caption_track
                     lang_code = (config.youtube.default_language or "en").lower()
                     track_name = "English" if lang_code == "en" else (
                         "Русский" if lang_code == "ru" else lang_code.upper()
                     )
-                    upload_caption_track(
-                        credentials=credentials,
-                        video_id=upload.video_id,
-                        srt_path=srt_path,
-                        language=lang_code,
-                        name=track_name,
-                    )
+                    try:
+                        upload_caption_track(
+                            credentials=credentials,
+                            video_id=upload.video_id,
+                            srt_path=srt_path,
+                            language=lang_code,
+                            name=track_name,
+                        )
+                        result["caption_track_uploaded"] = True
+                    except Exception as _cap_exc:  # noqa: BLE001
+                        # Its own try/except: a caption failure must not
+                        # abort the surrounding publish block, and now that
+                        # this is the only caption layer on long-form it
+                        # needs a signal louder than a swallowed log line.
+                        result["caption_track_uploaded"] = False
+                        result["caption_track_error"] = str(_cap_exc)[:300]
+                        logger.warning(
+                            "::warning::%s long-form shipped with NO captions "
+                            "— caption-track upload failed (%s). Burn-in is "
+                            "off by default, so the track is the only layer.",
+                            config.slug, _cap_exc,
+                        )
         except Exception as exc:
             logger.exception("YouTube long-form publish failed: %s", exc)
             # Surface the failure reason in the result dict so the

--- a/tests/test_lang_dub.py
+++ b/tests/test_lang_dub.py
@@ -321,3 +321,53 @@ class TestRuEngineUntouched:
         for helper in ("gallery_images_for_episode", "_fresh_manifest_path",
                        "_en_optimized_long_title", "_cover_path"):
             assert helper in src
+
+
+class TestAnalyticsCredentialsCoverEveryDubChannel:
+    """Every channel the network UPLOADS to must also be readable back.
+
+    July 30 2026: @NerraFR published 42 videos from 2026-07-21 while every
+    FR show reported ``short_vpd: null`` and stayed frozen at its seed
+    tier. Two separate causes, fixed a day apart:
+
+      1. ``fetch_youtube_analytics`` globbed only ``youtube_videos.ru.json``
+         beside the base index, so it never SAW the FR rows.
+      2. ``nightly-maintenance.yml`` passed only the EN and RU refresh
+         tokens, so even once it saw them it could not AUTHENTICATE to the
+         channel — ``get_channel_credentials_from_env("fr")`` returned
+         None and the loop skipped it. The 2026-07-30 nightly ran cleanly
+         and still emitted zero fr rows.
+
+    The upload path always had the FR token; only the read-back lacked it.
+    A channel that can be written to and not read from is invisible to the
+    adaptive policy, which is a channel that can never earn a promotion.
+    """
+
+    _NIGHTLY = ".github/workflows/nightly-maintenance.yml"
+
+    def _nightly_env(self):
+        import yaml as _yaml
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        raw = _yaml.safe_load((root / self._NIGHTLY).read_text(encoding="utf-8"))
+        env = {}
+        for job in (raw.get("jobs") or {}).values():
+            for step in (job.get("steps") or []):
+                env.update(step.get("env") or {})
+        return env
+
+    def test_every_registered_dub_language_is_readable(self):
+        from engine.lang_dub import DUB_LANGUAGES
+        env = self._nightly_env()
+        for code, lang in DUB_LANGUAGES.items():
+            var = f"YOUTUBE_REFRESH_TOKEN_{lang.channel.upper()}"
+            assert var in env, (
+                f"{lang.channel_handle} uploads but the nightly analytics "
+                f"fetch has no {var} — the channel is invisible to the "
+                "adaptive policy and can never earn a promotion"
+            )
+
+    def test_base_channels_still_present(self):
+        env = self._nightly_env()
+        for var in ("YOUTUBE_REFRESH_TOKEN_EN", "YOUTUBE_REFRESH_TOKEN_RU"):
+            assert var in env, var

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -2013,3 +2013,55 @@ def test_interleave_broll_into_schedule_scales_holds():
     assert clips == [(Path("/c/x.mp4"), 6.0)]
     total = sum(d for _, d in stills) + sum(d for _, d in clips)
     assert abs(total - 60.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Long-form captions: sidecar track only, no burn-in (July 30 2026)
+#
+# The pipeline had always done BOTH — build_long_form_video received the SRT
+# to burn into the pixels, AND upload_caption_track uploaded the same SRT as
+# a real track. A viewer who pressed CC saw two sets of captions at once.
+#
+# The track wins on this surface: it toggles, auto-translates, the player
+# positions it, YouTube indexes it, and it does not permanently cover the
+# Grok scene imagery the episode paid for. Apple's video podcast player
+# also expects sidecar captions. Shorts KEEP their burn-in — watched muted,
+# in-feed, with no caption UI to fall back on.
+# ---------------------------------------------------------------------------
+
+class TestLongFormCaptionLayer:
+    @staticmethod
+    def _run_show():
+        from pathlib import Path
+        return (Path(__file__).resolve().parent.parent
+                / "run_show.py").read_text(encoding="utf-8")
+
+    def test_burn_in_defaults_off(self):
+        from engine.config import YouTubeConfig
+        assert YouTubeConfig().long_form_burn_in_captions is False
+
+    def test_long_form_render_is_gated_on_the_flag(self):
+        src = self._run_show()
+        assert "long_form_burn_in_captions" in src
+        # The old unconditional form must not come back.
+        assert "\n                subtitles_path=srt_path,\n" not in src
+
+    def test_shorts_burn_in_is_untouched(self):
+        """Shorts are the surface where burned-in captions are correct."""
+        src = self._run_show()
+        assert "subtitles_path=this_srt_path" in src
+
+    def test_caption_track_failure_is_visible(self):
+        """It is now the ONLY caption layer, so silence is not acceptable."""
+        src = self._run_show()
+        assert "caption_track_uploaded" in src
+        assert "shipped with NO captions" in src
+
+    def test_no_show_yaml_turns_burn_in_back_on(self):
+        import pathlib
+        import yaml as _yaml
+        root = pathlib.Path(__file__).resolve().parent.parent
+        for path in sorted((root / "shows").glob("*.yaml")):
+            raw = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            yt = raw.get("youtube") or {}
+            assert yt.get("long_form_burn_in_captions") is not True, path.name


### PR DESCRIPTION
Two changes. The second was found by the post-nightly check-in and wasn't in the original PR.

---

## 1. Long-form captions come from the track, not the pixels

The pipeline did **both**. `build_long_form_video` received the SRT to burn into the frame, *and* `upload_caption_track` uploaded the same SRT as a real caption track for the same video. A viewer who pressed CC saw **two sets of captions at once**.

The track wins on this surface: it toggles, auto-translates, the player positions it, YouTube indexes it for search, and it doesn't permanently cover the Grok scene imagery the episode paid to generate. Apple's video podcast player expects sidecar captions.

**Shorts keep their burn-in, untouched** — watched muted, in-feed, no caption UI to fall back on.

Gated behind `youtube.long_form_burn_in_captions` (default `false`), not deleted. Drift guards assert no show YAML sets it `true` and that the old unconditional `subtitles_path=srt_path` doesn't return.

**One consequence that needed handling:** the caption track used to be a bonus *on top of* the burn-in, so its upload failure was logged and swallowed. It's now the only caption layer — that same silent failure would ship a video with no captions at all. It now has its own `try`/`except`, records `caption_track_uploaded` + the error, and emits a `::warning::` naming the show.

---

## 2. The nightly analytics fetch can now read @NerraFR

The 2026-07-30 nightly ran cleanly — `youtube_stats.json` regenerated at 18:06 UTC, EN rose 527→552 and RU 246→259 — and **still produced zero `fr` rows**. So yesterday's glob fix was necessary but not sufficient.

**Second cause, same blind spot:** `nightly-maintenance.yml` passed only `YOUTUBE_REFRESH_TOKEN_EN` and `_RU`. Once the glob was a pattern the fetch could *see* the FR rows, but `get_channel_credentials_from_env("fr")` returned `None`, so it logged "No credentials for channel=fr" and skipped the channel entirely.

The upload path has always had that token (`multilingual.yml` passes `_FR`). That asymmetry is why **42 FR videos published from 2026-07-21** while every FR show reported `short_vpd: null` and stayed frozen at its seed tier. A channel you can write to but not read from is invisible to the adaptive policy — and a channel invisible to the policy can never earn a promotion however well it performs.

**The guard generalises rather than pinning the FR string:** it walks the `engine.lang_dub` registry and asserts the nightly carries a refresh token for every registered dub channel. Registering a language, wiring its upload, and forgetting its read-back is now a test failure instead of a silent tier freeze.

First real @NerraFR data should appear in the next nightly. **Do not retier on it** — a couple of weeks of velocity is the bar, and the seed tiers are deliberately shorts-only. If the next nightly *still* shows no `fr` rows, the secret's OAuth scope is the next place to look (it may lack `yt-analytics.readonly`).

---

`5077 passed, 5 skipped`; ruff clean. Render/metadata/CI-config only — no audio, outside the landmine #17 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhQHbwSMgbdWBubedxmRm4