### PR TITLE
Hotfix: supply the cold-open and delivery specs on the path that actually runs

### DIFF
--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -367,6 +367,8 @@ def run_generation_phase(
     from engine.intros import (
         build_intro_line,
         build_closing_block,
+        build_cold_open_spec,
+        build_delivery_spec,
         _maybe_append_youtube_cta,
         _RUSSIAN_SPOKEN_SHOWS,
     )
@@ -524,6 +526,28 @@ def run_generation_phase(
 
     pod_vars.setdefault("tone_hint", "natural and conversational")
     pod_vars.setdefault("nerra_network_context", "")
+
+    # Cold-open + delivery specs (July 30 2026 retention pass). These were
+    # wired into run_show.py's pod_vars — which, as the Ep1 comment above
+    # records, is NOT the live path: run_show builds that dict and never
+    # passes it into run_generation_phase. So all 14 podcast prompts gained
+    # {cold_open_spec} and 17 gained {delivery_spec} while nothing supplied
+    # either, and the next run of EVERY show died in load_prompt with
+    # `KeyError: 'cold_open_spec'` (SpaceX Ep50, 2026-07-30 20:54 UTC — the
+    # first show to tick over after the change merged).
+    #
+    # setdefault, not assignment: a show whose pre-fetch hook supplies its
+    # own spec via extra_context keeps it.
+    _spec_slug = getattr(config, "slug", "") or (
+        getattr(args, "show", "") if args is not None else ""
+    )
+    _spec_is_ru = _spec_slug in _RUSSIAN_SPOKEN_SHOWS
+    pod_vars.setdefault(
+        "cold_open_spec", build_cold_open_spec(_spec_slug, is_ru=_spec_is_ru),
+    )
+    pod_vars.setdefault(
+        "delivery_spec", build_delivery_spec(_spec_slug, is_ru=_spec_is_ru),
+    )
 
     # Append the rotating Nerra Network cross-promo to the spoken closing.
     # Done HERE (after closing_block is resolved from any source) so it covers

--- a/tests/test_podcast_prompt_placeholders.py
+++ b/tests/test_podcast_prompt_placeholders.py
@@ -1,0 +1,140 @@
+"""Every podcast prompt placeholder must be supplied by the LIVE path.
+
+The bug this exists to prevent, in full, because it took the whole
+network down:
+
+The July 30 2026 retention pass added ``{cold_open_spec}`` to all 14
+podcast prompts and ``{delivery_spec}`` to 17, and wired both into the
+``pod_vars`` dict in ``run_show.py``. But ``run_show.py`` builds that
+dict and never passes it to ``run_generation_phase`` — the live path
+rebuilds its own ``pod_vars`` inside ``engine/pipeline.py`` (there is a
+comment there saying exactly this, from the *previous* time someone was
+caught by it). So nothing supplied either key, and the next run of every
+show died in ``load_prompt`` with ``KeyError: 'cold_open_spec'``.
+SpaceX Ep50 was the first to tick over, 2026-07-30 20:54 UTC.
+
+``tests/test_prompt_fidelity.py`` could not catch this: it renders each
+prompt with "a forgiving mapping (every placeholder -> '')", which by
+construction can never notice a key the pipeline fails to provide.
+
+So this test drives the REAL ``run_generation_phase`` with the LLM calls
+stubbed and asserts the prompt formats. Testing the live function rather
+than re-deriving its variable set is the point — a reimplementation
+would drift from the thing it is supposed to guard.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine.config import discover_show_slugs, load_config  # noqa: E402
+from engine.generator import load_prompt  # noqa: E402
+from engine import pipeline  # noqa: E402
+
+
+# Placeholders that a per-show pre-fetch hook injects through
+# ``extra_context`` rather than the pipeline. These are legitimately
+# absent when the hook doesn't run.
+#
+# ADDING A PLACEHOLDER TO A PODCAST PROMPT? It must either be supplied by
+# engine/pipeline.py's pod_vars (the live path) or be listed here with
+# the hook that provides it. Wiring it into run_show.py's pod_vars is NOT
+# enough — that dict is discarded.
+_HOOK_SUPPLIED = {
+    "narrative_memory_section",          # shows/hooks/<slug>.py via show_memory
+    "vocab_review_section",              # shows/hooks/privet_russian.py
+    "ipo_debut_section",                 # shows/hooks/spacex.py
+    "tesla_narrative_status_block",      # shows/hooks/tesla.py
+    "tesla_performance_signals_block",   # shows/hooks/tesla.py
+    "tesla_theme_context_block",         # shows/hooks/tesla.py
+}
+
+
+def _podcast_shows():
+    out = []
+    for slug in discover_show_slugs():
+        try:
+            cfg = load_config(ROOT / "shows" / f"{slug}.yaml")
+        except Exception:  # noqa: BLE001
+            continue
+        if cfg.llm.podcast_prompt_file:
+            out.append(slug)
+    return out
+
+
+def _missing_placeholders(slug: str) -> list:
+    """Run the live generation path; return placeholders it failed to fill."""
+    cfg = load_config(ROOT / "shows" / f"{slug}.yaml")
+    missing: list = []
+
+    def _fake_podcast(vars_dict, config, tracker=None):
+        try:
+            load_prompt(config.llm.podcast_prompt_file, vars_dict)
+        except KeyError as exc:
+            missing.append(str(exc).strip("'"))
+        # Long enough to clear the runner's word-count gates.
+        return "word " * 400
+
+    logging.disable(logging.CRITICAL)
+    try:
+        with mock.patch("engine.generator.generate_podcast_script",
+                        _fake_podcast), \
+             mock.patch("engine.generator.generate_digest",
+                        lambda *a, **k: "# Digest\nbody"):
+            try:
+                pipeline.run_generation_phase(
+                    cfg,
+                    episode_num=50,
+                    today_str="2026-07-30",
+                    hook="A representative episode hook.",
+                    x_thread="# Show\nbody text",
+                    # Deliberately EMPTY so hook-supplied keys surface and
+                    # get checked against the registry above.
+                    extra_context={},
+                    template_vars={"digest": "body"},
+                    args=SimpleNamespace(show=slug),
+                )
+            except KeyError as exc:
+                missing.append(str(exc).strip("'"))
+            except Exception:  # noqa: BLE001 — only KeyError is in scope
+                pass
+    finally:
+        logging.disable(logging.NOTSET)
+    return missing
+
+
+@pytest.mark.parametrize("slug", _podcast_shows())
+def test_live_path_supplies_every_podcast_placeholder(slug):
+    unexpected = [k for k in _missing_placeholders(slug)
+                  if k not in _HOOK_SUPPLIED]
+    assert not unexpected, (
+        f"{slug}'s podcast prompt references {unexpected}, which "
+        "engine/pipeline.py does not supply. Wiring it into run_show.py's "
+        "pod_vars does NOT count — that dict is never passed to "
+        "run_generation_phase. Either add it to pod_vars in "
+        "engine/pipeline.py, or add it to _HOOK_SUPPLIED in this test with "
+        "the hook that provides it."
+    )
+
+
+def test_the_two_specs_from_the_retention_pass_are_wired():
+    """Pin the exact regression: SpaceX Ep50, 2026-07-30 20:54 UTC."""
+    import inspect
+
+    src = inspect.getsource(pipeline.run_generation_phase)
+    for key in ("cold_open_spec", "delivery_spec"):
+        assert f'"{key}"' in src, (
+            f"{key} is referenced by the podcast prompts but no longer "
+            "supplied by the live generation path — this is the exact "
+            "shape that broke every show on 2026-07-30."
+        )


### PR DESCRIPTION
**Production is down for every show.** SpaceX Ep50 failed at 20:54 UTC:

```
File "engine/generator.py", line 138, in load_prompt
    return raw.format_map(template_vars)
KeyError: 'cold_open_spec'
```

## Cause

The July 30 retention pass added `{cold_open_spec}` to all **14** podcast prompts and `{delivery_spec}` to **17**, and wired both into the `pod_vars` dict in `run_show.py`.

That dict is discarded. `run_generation_phase` rebuilds its own `pod_vars` inside `engine/pipeline.py`, and that is the path that formats the prompt. `engine/pipeline.py` already carries a comment recording the same trap catching the DP Pod Ep001 intro:

> *"run_show builds its own pod_vars but never passes them into run_generation_phase; **THIS block is the live path**"*

So this is the second time the duplicated dict has shipped a bug to air.

Every show was one scheduled run from the same crash — SpaceX was simply the first to tick over after the change merged. Ep049 succeeded this morning because it ran before it landed.

## Fix

Supply both keys in `engine/pipeline.py`, where the prompts are actually formatted. `setdefault`, not assignment, so a show whose pre-fetch hook supplies its own spec keeps it.

## Why the existing guard missed it

`tests/test_prompt_fidelity.py` renders every prompt with — its own words — *"a forgiving mapping (every placeholder -> '')"*. By construction that cannot distinguish a placeholder the pipeline supplies from one it never provides.

The new `tests/test_podcast_prompt_placeholders.py` drives the **real** `run_generation_phase` with the LLM calls stubbed and asserts the prompt formats. Testing the live function rather than re-deriving its variable set is deliberate — a reimplementation would drift from the thing it guards.

Placeholders that legitimately arrive from a per-show hook are listed explicitly, so the next person adding one is told at test time which of the two dicts to wire it into.

## Verification

- **Reverted the fix and re-ran the new test: 14 of 16 fail.** With the fix: 16/16 pass.
- Drove the live path for **all 15 shows** — no show is missing `cold_open_spec` or `delivery_spec`. The only remaining absences are hook-supplied keys, surfaced deliberately by passing an empty `extra_context`.
- Reproduced the exact SpaceX Ep50 call (`load_prompt(config.llm.podcast_prompt_file, vars)`) end-to-end: no `KeyError`, and both specs are present and non-empty.
- 231 passed across `test_prompt_fidelity`, `test_intros`, `test_generator`, `test_pipeline_safety`, `test_episode_validity`.
- `ruff check engine/ run_show.py scripts/` — the CI gate — passes.

## After merging

SpaceX Ep50 needs a re-run; the schedule gate's duplicate guard only blocks *scheduled* reruns, so a manual `workflow_dispatch` for `spacex` will go through.

## Follow-up worth considering (not in this PR)

`run_show.py`'s `pod_vars` block is dead code that looks authoritative — it computes intro lines, closing blocks and both specs into a dict nobody reads. It has now caused two production incidents. Deleting it, or making `run_show` pass it through, would remove the trap rather than guard it. Happy to do that as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg)_