### PR TITLE
Remove the duplicate podcast-variable dict, and the inert guards that hid it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,15 @@ digests/*/youtube_tmp/*.ass
 !outputs/.gitkeep
 
 
+# Node artifacts anywhere, including the repo root. Running `npx` from
+# the root (rather than from workers/gallery) creates a root-level
+# node_modules/ holding tool caches — which was untracked and therefore
+# a candidate to be committed. This repo's largest problem is git
+# history size (landmine #1); 200 MB of dependencies is the last thing
+# it needs.
+node_modules/
+.vite/
+
 # Cloudflare Worker (workers/gallery) build + local-dev artifacts.
 workers/**/node_modules/
 workers/**/.wrangler/

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -527,6 +527,20 @@ def run_generation_phase(
     pod_vars.setdefault("tone_hint", "natural and conversational")
     pod_vars.setdefault("nerra_network_context", "")
 
+    # Hook-failure safety. A memory show's pre-fetch hook normally injects
+    # {narrative_memory_section} (and Привет, Русский! injects
+    # {vocab_review_section}) through extra_context. If the hook fails to
+    # load, the prompt still references the placeholder and
+    # str.format_map raises — the same KeyError class that took the
+    # network down on 2026-07-30. Degrade to an empty section instead.
+    #
+    # These defaults existed only in run_show.py's discarded pod_vars, so
+    # the invariant was never actually enforced;
+    # tests/test_memory_lake_expansion.py passed by counting occurrences
+    # in that dead block. setdefault means a working hook is unaffected.
+    pod_vars.setdefault("narrative_memory_section", "")
+    pod_vars.setdefault("vocab_review_section", "")
+
     # Cold-open + delivery specs (July 30 2026 retention pass). These were
     # wired into run_show.py's pod_vars — which, as the Ep1 comment above
     # records, is NOT the live path: run_show builds that dict and never

--- a/run_show.py
+++ b/run_show.py
@@ -2056,6 +2056,31 @@ def run(args: argparse.Namespace) -> None:
 
         if not args.skip_podcast:
 
+            # !!! KNOWN INERT — DO NOT "CLEAN UP", AND DO NOT SILENTLY WIRE UP.
+            #
+            # `clean_digest` is computed and refined below (podcast-only
+            # cleaning, the Sunday weekly-summary segment, duplicate-headline
+            # stripping) and then READ BY NOTHING. Its only consumer was the
+            # discarded `pod_vars` dict removed on 2026-07-30; the live path
+            # sets the prompt's {digest} to `x_thread`
+            # (engine/pipeline.py: template_vars_for_script["digest"] = x_thread).
+            #
+            # So three things have never reached a podcast script:
+            #   1. `_clean_digest_for_podcast` cleaning
+            #   2. the Sunday weekly-summary segment (landmine #19)
+            #   3. the 100%-duplicate-headline strip
+            #
+            # tests/test_weekly_summary_segment.py passes anyway because it
+            # asserts the APPEND by matching source text, never that the value
+            # reaches the prompt.
+            #
+            # Left computed rather than deleted so the feature isn't quietly
+            # discarded. Connecting it changes the digest every podcast prompt
+            # receives — on every show, and substantially on Sundays — which is
+            # an audio-affecting change and needs an operator A/B listen
+            # (landmine #17). Flagged for that decision, deliberately not made
+            # here.
+            #
             # Strip URLs, emojis, unicode decorations, and other metadata from
             # the digest before feeding it to the podcast script prompt.  The LLM
             # sometimes echoes these through to the script, and TTS reads them
@@ -2114,6 +2139,11 @@ def run(args: argparse.Namespace) -> None:
                             )
                             clean_digest = clean_digest_new
 
+            # NOTE: the value computed here is SUPERSEDED — run_generation_phase
+            # derives its own effective_hook and returns it below, overwriting
+            # this one. What survives is the operator warning in the
+            # topic-driven branch, which is why the block is kept. Do not add
+            # consumers of this local; read the returned value instead.
             if hook:
                 effective_hook = hook
             elif _topic_driven:
@@ -2136,137 +2166,26 @@ def run(args: argparse.Namespace) -> None:
                     f"Here's what's making news in the {config.name} world today."
                 )
 
-            pod_vars = {
-                "episode_num": episode_num,
-                "today_str": today_str,
-                "date_human": today_str,  # alias used by Omni View prompts
-                "digest": clean_digest,
-                "hook": effective_hook,
-            }
-            # Merge extra context for podcast prompt (e.g. tone_hint, intro_line)
-            pod_vars.update(extra_context)
-            # Привет, Русский! vocabulary memory — same hook-failure-safe
-            # defaulting as the digest stage (str.format_map raises
-            # KeyError on missing placeholders).
-            pod_vars.setdefault("vocab_review_section", "")
-            # Phase-3 narrative memory — several podcast prompts reference
-            # {narrative_memory_section}; same hook-failure-safe default as
-            # the digest stage (July 24 2026 memory expansion).
-            pod_vars.setdefault("narrative_memory_section", "")
+            # The show's host name. Used downstream to strip stray
+            # "Patrick:" speaker prefixes from the generated script — the
+            # one thing the removed block below produced that anything
+            # actually read.
+            from engine.intros import get_show_host
 
-            # Provide default intro_line/closing_block if hook didn't supply them.
-            # Uses engine.intros for day-varying, show-specific intros so
-            # listeners don't hear the exact same opening every day.
-            # Episode 1 gets a special intro — the podcast prompt templates handle
-            # the detailed first-episode introduction based on {episode_num}.
-            from engine.intros import (
-                build_intro_line,
-                build_closing_block,
-                build_cold_open_spec,
-                build_delivery_spec,
-                get_show_host,
-                _maybe_append_youtube_cta,
-                _RUSSIAN_SPOKEN_SHOWS,
-            )
-            host = getattr(config.publishing, "host_name", None) or get_show_host(args.show)
-            # Pick the YouTube channel handle so the closing line can mention
-            # the right channel. Empty string means "don't mention YouTube"
-            # (e.g. shows where YouTube publishing isn't enabled yet).
-            _yt_handle = ""
-            if getattr(config, "youtube", None) and config.youtube.enabled:
-                _yt_handle = (
-                    "@NerraRU" if config.youtube.channel == "ru" else "@NerraNetwork"
-                )
-            if episode_num == 1:
-                if config.tts.dialogue_mode:
-                    # Dialogue shows: the generic single-host Ep1 closing
-                    # ("I'm X in Vancouver... see you tomorrow") fights the
-                    # dialogue prompt's speaker-label + exact-sign-off rules
-                    # — DP Pod Ep001 shipped it truncated to "please
-                    # subscribe..." mid-sentence. Use a labeled debut intro
-                    # (the personality's lead host) and the personality's
-                    # own labeled closing, which already carries the
-                    # subscribe ask and ends with the exact sign-off.
-                    _lead = get_show_host(args.show)
-                    pod_vars.setdefault(
-                        "intro_line",
-                        f"{_lead}: Welcome to the very first episode of "
-                        f"{config.name}! Today is {today_str}. {effective_hook}",
-                    )
-                    pod_vars.setdefault(
-                        "closing_block",
-                        build_closing_block(
-                            args.show,
-                            episode_num=episode_num,
-                            today_str=today_str,
-                            date=today,
-                            extra_context=extra_context,
-                            youtube_channel_handle=_yt_handle,
-                        ),
-                    )
-                else:
-                    pod_vars.setdefault(
-                        "intro_line",
-                        f"{host}: Welcome to the very first episode of {config.name}! "
-                        f"Today is {today_str}. {effective_hook}",
-                    )
-                    _ep1_close = (
-                        f"{host}: That wraps up our very first episode of {config.name}! "
-                        f"If you enjoyed this, please subscribe on Apple Podcasts, Spotify, "
-                        f"or wherever you listen — and a rating or review really helps new "
-                        f"listeners find us. "
-                        f"I'm {host} in Vancouver. Thanks for joining me on this journey, "
-                        f"and I'll see you tomorrow for episode two."
-                    )
-                    # Route the YouTube call-out through the shared helper so the
-                    # "@" is stripped (no "at at" stutter) and the EN handle is
-                    # split to the spaced "Nerra Network" — matching every other
-                    # episode's closing.
-                    _ep1_close = _maybe_append_youtube_cta(
-                        _ep1_close,
-                        _yt_handle,
-                        is_ru=args.show in _RUSSIAN_SPOKEN_SHOWS,
-                    )
-                    pod_vars.setdefault("closing_block", _ep1_close)
-            else:
-                pod_vars.setdefault(
-                    "intro_line",
-                    build_intro_line(
-                        args.show,
-                        episode_num=episode_num,
-                        today_str=today_str,
-                        date=today,
-                        extra_context=extra_context,
-                    ),
-                )
-                pod_vars.setdefault(
-                    "closing_block",
-                    build_closing_block(
-                        args.show,
-                        episode_num=episode_num,
-                        today_str=today_str,
-                        date=today,
-                        extra_context=extra_context,
-                        youtube_channel_handle=_yt_handle,
-                    ),
-                )
-            pod_vars.setdefault("tone_hint", "natural and conversational")
-            pod_vars.setdefault("nerra_network_context", "")
-            # Cold-open rules (July 30 2026). One shared spec for every
-            # show so the rule cannot drift per prompt, and so the wording
-            # that governs the first seconds of every episode lives in one
-            # reviewable place.
-            pod_vars.setdefault(
-                "cold_open_spec",
-                build_cold_open_spec(
-                    args.show,
-                    is_ru=args.show in _RUSSIAN_SPOKEN_SHOWS,
-                ),
-            )
-            pod_vars.setdefault(
-                "delivery_spec",
-                build_delivery_spec(args.show, is_ru=args.show in _RUSSIAN_SPOKEN_SHOWS),
-            )
+            host = (getattr(config.publishing, "host_name", None)
+                    or get_show_host(args.show))
+
+            # NOTE: this is where a second, DEAD copy of the podcast
+            # template variables used to be built (removed 2026-07-30).
+            # It computed intro lines, closing blocks, the cold-open and
+            # delivery specs into a `pod_vars` dict that was never passed
+            # to run_generation_phase — the live path rebuilds its own in
+            # engine/pipeline.py. Two production bugs shipped from wiring
+            # a value into the discarded copy: the DP Pod Ep001 truncated
+            # closing, and `KeyError: 'cold_open_spec'` taking down every
+            # show on 2026-07-30. Podcast prompt variables belong in
+            # engine/pipeline.py:run_generation_phase. Anything a show
+            # needs to inject reaches it via `extra_context`.
 
             # === Generation Phase ===
             from engine.pipeline import run_generation_phase

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -187,9 +187,17 @@ class TestEp001Fixes:
         # The generic single-host Ep1 closing fought the dialogue prompt
         # (Ep001 shipped "please subscribe..." truncated mid-sentence);
         # dialogue shows now debut with the personality's labeled closing.
-        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        #
+        # Asserted against engine/pipeline.py, not run_show.py. Ep001
+        # shipped the broken closing precisely BECAUSE the fix went into
+        # run_show.py's `pod_vars` — a dict never passed to
+        # run_generation_phase — so this test was pinning code that could
+        # not run. The dead block was removed 2026-07-30 after the same
+        # trap took the whole network down a second time.
+        src = (PROJECT_ROOT / "engine" / "pipeline.py").read_text(
+            encoding="utf-8")
         ep1_block = src.split("if episode_num == 1:", 1)[1][:2200]
-        assert "config.tts.dialogue_mode" in ep1_block
+        assert "dialogue_mode" in ep1_block
         assert "build_closing_block" in ep1_block
 
     def test_dispatch_prompt_bans_invented_host_anecdotes(self):

--- a/tests/test_intros.py
+++ b/tests/test_intros.py
@@ -667,11 +667,22 @@ class TestDeliverySpec:
             assert "{delivery_spec}" in p.read_text(encoding="utf-8"), p.name
 
     def test_runner_always_supplies_it(self):
+        """Asserted against engine/pipeline.py — the path that RUNS.
+
+        This test used to check run_show.py, which built a `pod_vars`
+        dict that was never passed to run_generation_phase. It passed
+        while nothing supplied the key, and every show died with
+        `KeyError: 'cold_open_spec'` on 2026-07-30. The dead block is
+        gone; the assertion now points at the live builder.
+
+        tests/test_podcast_prompt_placeholders.py covers this
+        behaviourally by rendering every prompt through the real path.
+        """
         from pathlib import Path
         src = (Path(__file__).resolve().parent.parent
-               / "run_show.py").read_text(encoding="utf-8")
-        assert 'pod_vars.setdefault(\n                "delivery_spec"' in src or \
-               '"delivery_spec"' in src
+               / "engine" / "pipeline.py").read_text(encoding="utf-8")
+        assert 'pod_vars.setdefault(' in src
+        assert '"delivery_spec"' in src
 
 
 class TestColdOpenIsCompelling:

--- a/tests/test_memory_lake_expansion.py
+++ b/tests/test_memory_lake_expansion.py
@@ -78,8 +78,18 @@ class TestNewMemoryShows:
         # A hook-load failure on a memory show must degrade to an empty
         # section, never a KeyError in podcast prompt substitution (the
         # digest stage already had this; the podcast stage did not).
-        src = (ROOT / "run_show.py").read_text()
-        assert src.count('setdefault("narrative_memory_section", "")') >= 2
+        #
+        # This used to count TWO occurrences in run_show.py — one for the
+        # digest stage and one in the `pod_vars` dict that was never
+        # passed to run_generation_phase. So the podcast half of the
+        # invariant was never enforced and this test could not tell.
+        # Now asserted on each stage's real owner.
+        digest_src = (ROOT / "run_show.py").read_text()
+        assert 'setdefault("narrative_memory_section", "")' in digest_src, \
+            "digest stage lost its hook-failure default"
+        podcast_src = (ROOT / "engine" / "pipeline.py").read_text()
+        assert 'setdefault("narrative_memory_section", "")' in podcast_src, \
+            "podcast stage (the LIVE path) lost its hook-failure default"
 
     def test_mit_keeps_bespoke_investment_tracker(self):
         # The narrative layer must not replace the trade ledger.

--- a/tests/test_podcast_prompt_placeholders.py
+++ b/tests/test_podcast_prompt_placeholders.py
@@ -127,6 +127,37 @@ def test_live_path_supplies_every_podcast_placeholder(slug):
     )
 
 
+def test_run_show_does_not_rebuild_a_discarded_pod_vars():
+    """The trap itself, removed 2026-07-30 — keep it removed.
+
+    ``run_show.py`` used to build a second, complete set of podcast
+    template variables into a local ``pod_vars`` dict and then never pass
+    it to ``run_generation_phase``. It read as the authoritative place to
+    wire a prompt variable, and twice it wasn't: the DP Pod Ep001
+    truncated closing, and the network-wide ``KeyError: 'cold_open_spec'``.
+
+    Guarding the symptom (the test above) is not enough while the trap is
+    still sitting there looking authoritative.
+    """
+    import ast
+
+    tree = ast.parse((ROOT / "run_show.py").read_text(encoding="utf-8"))
+    # Structural, not a substring match: the comment left behind at the
+    # removal site names `pod_vars` on purpose, and that comment is the
+    # thing telling the next person where prompt variables belong.
+    assigned = {
+        node.id
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store)
+    }
+    assert "pod_vars" not in assigned, (
+        "run_show.py is building podcast template variables again. That "
+        "dict is not what formats the prompt — engine/pipeline.py's "
+        "run_generation_phase is. Put prompt variables there, or pass "
+        "per-show values through extra_context."
+    )
+
+
 def test_the_two_specs_from_the_retention_pass_are_wired():
     """Pin the exact regression: SpaceX Ep50, 2026-07-30 20:54 UTC."""
     import inspect

--- a/tests/test_russian_shows_quality_pass.py
+++ b/tests/test_russian_shows_quality_pass.py
@@ -188,9 +188,24 @@ class TestVocabThemeAndWordOfDay:
                   "shows/prompts/privet_russian_digest.txt"):
             assert "{vocab_review_section}" in (_ROOT / f).read_text(encoding="utf-8")
 
-    def test_run_show_defaults_placeholder(self):
-        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
-        assert src.count('setdefault("vocab_review_section", "")') >= 2
+    def test_both_stages_default_the_placeholder(self):
+        """A failed hook must degrade to an empty section, not a KeyError.
+
+        This counted TWO defaults in run_show.py — one for the digest
+        stage, one in the `pod_vars` dict that was never passed to
+        run_generation_phase. So the podcast half was never actually
+        enforced, and the test could not tell. Now asserted on each
+        stage's real owner; the dead block was removed 2026-07-30 after
+        the same trap took the network down with
+        `KeyError: 'cold_open_spec'`.
+        """
+        digest_src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'setdefault("vocab_review_section", "")' in digest_src, \
+            "digest stage lost its hook-failure default"
+        podcast_src = (_ROOT / "engine" / "pipeline.py").read_text(
+            encoding="utf-8")
+        assert 'setdefault("vocab_review_section", "")' in podcast_src, \
+            "podcast stage (the LIVE path) lost its hook-failure default"
 
     def test_hook_always_returns_key(self):
         from shows.hooks import privet_russian as hook

--- a/workers/gallery/README.md
+++ b/workers/gallery/README.md
@@ -77,10 +77,15 @@ Revoked users immediately get 403 on `/api/download` and 403 on
 `/api/magic` (no new long-lived cookie can be minted).
 
 The check is fail-open if the KV binding is missing (no accidental
-mass lockouts during misconfig). Add the same KV namespace ID you
-already use for rate limiting.
+mass lockouts during misconfig).
 
-No new secrets or bindings required.
+**Currently inert.** No KV namespace has ever been provisioned, so the
+binding is commented out in `wrangler.toml` and both revocation and
+rate limiting are no-ops in production. The procedure above starts
+working once you create the namespace and uncomment the block — see the
+instructions in `wrangler.toml`.
+
+No new secrets required.
 
 ## One-time operator setup
 
@@ -146,13 +151,31 @@ The R2 binding is set declaratively in `wrangler.toml` (not via
 ```bash
 cd workers/gallery
 npm install
-npm test          # 45 unit tests
+npm test          # unit tests (52 at time of writing)
 npm run typecheck
 npm run deploy    # = wrangler deploy
 ```
 
 `wrangler deploy` reads `wrangler.toml`, uploads the bundled Worker,
 and binds the route. First deploy will require `wrangler login`.
+
+**Before you deploy, `git pull`.** Deploying a stale checkout silently
+ships the previous code — the tests are the tell: if `npm test` reports
+an unexpected count, your checkout is behind.
+
+**The `[[kv_namespaces]]` block is commented out on purpose** (see
+`wrangler.toml`). No namespace has ever been provisioned, and wrangler
+validates the whole config before running *any* command — so
+uncommenting it with a blank `id` blocks `wrangler deploy` **and**
+`wrangler kv namespace list`, which is how you would look the id up.
+Leave it commented unless you are actually provisioning KV.
+
+If you edit `wrangler.toml` for a deploy, verify the edit reached disk
+before running anything:
+
+```bash
+git diff --stat wrangler.toml   # no output = your editor didn't save
+```
 
 ### 6. Smoke-test
 
@@ -195,7 +218,7 @@ the page.
 ## Tests
 
 ```bash
-npm test          # vitest run (45 tests in 3 files)
+npm test          # vitest run (3 files)
 npm run typecheck # tsc --noEmit
 ```
 

--- a/workers/gallery/wrangler.toml
+++ b/workers/gallery/wrangler.toml
@@ -26,11 +26,27 @@ routes = [
 binding = "GALLERY_BUCKET"
 bucket_name = "nerra-gallery"
 
-# KV namespace for rate limiting on subscribe/login (medium item from codebase review).
-# Prevents abuse of Buttondown + Resend quotas and Worker CPU.
+# KV namespace for rate limiting on subscribe/login, and for the
+# per-email revocation list. COMMENTED OUT because no namespace has ever
+# been provisioned — so this is not a regression, it is the config
+# finally matching production. Both consumers fail open when the binding
+# is absent (see checkRateLimit / isEmailRevoked in src/handlers.ts), so
+# the Worker runs correctly without it; it simply has no rate limiting.
+#
+# DO NOT uncomment these lines with a blank `id`. Wrangler validates the
+# whole config before running ANY command, so a blank id doesn't just
+# fail `deploy` — it also blocks `wrangler kv namespace list`, which is
+# how you'd look the id up. That loop cost the operator five failed
+# deploys on 2026-07-30.
+#
+# To enable rate limiting, from a directory WITHOUT this wrangler.toml
+# (so the same validation doesn't block you):
+#     cd <repo root>
+#     workers/gallery/node_modules/.bin/wrangler kv namespace create gallery_rate_limits
+# then paste the returned id below and uncomment all four lines.
 # [[kv_namespaces]]
 # binding = "RATE_LIMIT_KV"
-# id = ""          # Fill with real production KV ID after creation: wrangler kv namespace create gallery_rate_limits
+# id = ""
 # preview_id = ""  # Optional preview namespace
 
 # Secrets are set out-of-band via:


### PR DESCRIPTION
Follow-up to #921. That PR guarded the symptom; this removes the trap.

## The trap

`run_show.py` built a complete second set of podcast template variables into a local `pod_vars` and never passed it to `run_generation_phase`. The live path rebuilds its own inside `engine/pipeline.py`. The dead copy read as the authoritative place to wire a prompt variable, and **twice it wasn't**:

- the DP Pod Ep001 truncated closing
- yesterday's `KeyError: 'cold_open_spec'`, which took down every show

## Why deleting 131 lines is safe

Not an assertion — checked:

- **No name escapes the block.** Every name it defined is unreferenced outside it *except* `host`, which is kept. Ruff's `F821` caught `host` when I first removed it (my initial grep was truncated by `head -8`); it's now assigned before all three of its downstream uses, verified by AST.
- **Every builder it called is deterministic** — `build_intro_line`, `build_closing_block`, `build_cold_open_spec`, `build_delivery_spec`, `get_show_host` each called three times, identical output. Neither `engine/intros.py` nor `engine/network_promo.py` writes persistent state, so removing duplicate calls cannot change a byte of what ships.
- **The call contract is unchanged** — same kwargs to `run_generation_phase`, verified by AST.

## Three tests were guarding the dead code

This is how the bug class survives a green suite:

| Test | Was asserting | Now |
|---|---|---|
| `test_intros::test_runner_always_supplies_it` | `delivery_spec` supplied in `run_show.py` | `engine/pipeline.py` |
| `test_dp_pod_show::test_ep1_dialogue_branch_...` | the Ep1 dialogue branch in `run_show.py` — **pinning the very fix that could not run**, which is why Ep001 shipped broken | `engine/pipeline.py` |
| `test_memory_lake_expansion::test_podcast_stage_setdefaults_memory_key` | counted **two** `narrative_memory_section` defaults in `run_show.py`, one in the dead block | each stage's real owner |

The third exposed a live gap: the podcast half of that invariant was **never enforced**, so a hook-load failure on a memory show would `KeyError` exactly as the cold-open bug did. Added the defaults to the live path and verified by simulating a failed hook on `fascinating_frontiers`, `modern_investing` and `privet_russian` — all three now degrade to an empty section instead of crashing. `setdefault`, so a working hook is untouched.

## ⚠️ Found, deliberately NOT fixed — needs your call

**`clean_digest` is computed, refined, and read by nothing.** Its only consumer was the dead dict; the live path sets the prompt's `{digest}` to `x_thread`. So three things have **never reached a podcast script**:

1. `_clean_digest_for_podcast` cleaning
2. **the Sunday weekly-summary segment** (landmine #19)
3. the 100%-duplicate-headline strip

`tests/test_weekly_summary_segment.py` passes anyway — it asserts the *append* by matching source text, never that the value reaches the prompt.

I left it computed with a prominent comment rather than wiring it up, because connecting it changes the digest every podcast prompt receives — on every show, and substantially on Sundays. That is audio-affecting and needs an A/B listen per landmine #17. **Your decision, not mine to make silently.**

## Small cleanups (the ones you asked for)

- `wrangler.toml`: explains why the KV block is commented (no namespace has ever been provisioned — the config now matches production) and how to provision it *without* the validation deadlock, where a blank `id` blocks both `deploy` and the `kv namespace list` you'd use to look the id up. That loop cost five failed deploys.
- `workers/gallery/README.md`: same guidance in §5, a `git pull` + `git diff --stat` pre-deploy check, corrected stale "45 unit tests", and the revocation section now says it's currently inert rather than implying a namespace exists.
- `.gitignore`: root `node_modules/` — running `npx` from the repo root creates one, and this repo's largest problem is git history size.

## Testing

- 2,781 passed on the suite minus three files this container can't run (`feedgen` won't build; system `cryptography` is broken — both pre-existing on `main`).
- 252 passed across every directly affected file.
- `ruff check engine/ run_show.py scripts/` — the CI gate — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg)_