### PR TITLE
Fix the Ken Burns motion, stop feeding headlines to a video model, and track audience demographics

### DIFF
--- a/engine/shorts_ab.py
+++ b/engine/shorts_ab.py
@@ -128,21 +128,44 @@ def plan_variants(config, shorts_count: int) -> List[str]:
     return plan
 
 
-def _clip_contexts(hook: str, scene_prompts: Optional[Sequence[str]],
+def _clip_contexts(config, hook: str, scene_prompts: Optional[Sequence[str]],
                    count: int) -> List[str]:
-    """Per-clip subject text, richest source first.
+    """Per-clip subject text — CONCRETE scenes, never news headlines.
 
-    The scene prompts the episode's Grok Imagine stills already used are
-    the best available description of what this episode looks like, so
-    the video arm stays visually on-topic with the control instead of
-    drifting into generic stock motion.
+    The first cut of this passed the episode's extracted headlines
+    straight through, and the operator's verdict on the resulting Short
+    was "pretty bad video content and pretty nonsensical". That is the
+    predictable outcome: a headline like "Rocket Lab's purchase of
+    Aridium for $8bn brings L-band spectrum holdings under one roof" has
+    no depictable content, so a text-to-video model renders an
+    incoherent approximation of a financial abstraction.
+
+    A video model needs a *physical scene*. The show YAML already
+    curates exactly that for the still pipeline —
+    ``youtube.image_queries`` ("Falcon 9 rocket night launch", "Raptor
+    engine static fire") — chosen precisely because unguided queries
+    produced garbage (landmine #14, where raw ``keywords`` sent Pexels
+    looking for fashion models). Those subjects are the right input
+    here too, and reusing them keeps the video arm visually consistent
+    with the stills arm it is being compared against.
+
+    The episode hook is used only as a last resort, and the raw
+    headlines are no longer used at all.
     """
-    contexts = [c for c in (scene_prompts or []) if (c or "").strip()]
-    if not contexts and hook:
-        contexts = [hook]
-    if not contexts:
+    queries: List[str] = []
+    yt = getattr(config, "youtube", None)
+    if yt is not None:
+        queries = [str(q).strip() for q in
+                   (getattr(yt, "image_queries", None) or []) if str(q).strip()]
+    if not queries:
+        # No curated subjects: fall back to the scene prompts (already
+        # image-generation phrasing) and only then to the hook.
+        queries = [c for c in (scene_prompts or []) if (c or "").strip()]
+    if not queries and hook:
+        queries = [hook]
+    if not queries:
         return []
-    return [contexts[i % len(contexts)] for i in range(max(1, count))]
+    return [queries[i % len(queries)] for i in range(max(1, count))]
 
 
 def build_variant(
@@ -213,7 +236,7 @@ def build_variant(
         clip_set = generate_short_clips(
             work_dir=work_dir,
             episode_num=episode_num,
-            contexts=_clip_contexts(hook, scene_prompts, count),
+            contexts=_clip_contexts(config, hook, scene_prompts, count),
             hook=hook,
             show_config=config,
             count=count,

--- a/engine/video.py
+++ b/engine/video.py
@@ -489,8 +489,107 @@ _XFADE_TRANSITIONS = [
 # output resolution is what hides ``zoompan``'s integer-pixel stepping;
 # dropping to 1.0 would sharpen the still frame and introduce visible
 # judder in the motion, which is the worse trade on a slideshow.
-_PRESCALE = 1.15
+_PRESCALE = 2.0
 _ZOOM_MAX = 1.09
+
+# ---------------------------------------------------------------------------
+# Ken Burns (July 30 2026 motion pass — measured, not guessed)
+# ---------------------------------------------------------------------------
+# Three defects were found by rendering the shipping filter graph at
+# 1920x1080 and measuring frames. All three are fixed by
+# ``_ken_burns_chain`` below; the numbers are from that A/B on a 12 s
+# scene (the long-form default):
+#
+# 1. THE MOTION STOPPED. The zoom was a fixed per-frame increment against
+#    a cap: ``min(zoom+0.0006,1.09)``. That reaches the cap after
+#    (1.09-1.0)/0.0006 = 150 frames = 5.0 s at 30 fps, and then the image
+#    is perfectly static for the rest of the scene. Measured: **57.1% of
+#    a 12 s scene was a frozen still**, and worse on longer holds (10 s of
+#    a 15 s ``_MAX_SCENE_HOLD_S`` hold). Now the zoom is normalised to the
+#    segment: it runs from 1.0 to _ZOOM_MAX across exactly the scene's own
+#    frame count, so it never freezes and never depends on hold length.
+#    Measured after: **0.0% frozen**.
+#
+# 2. THE ZOOM ANCHORED TO THE TOP-LEFT CORNER. ``zoompan``'s x and y
+#    default to "0" (confirmed against ffmpeg 7.0's own
+#    ``-h filter=zoompan``), and this pipeline never set them — so every
+#    scene on the network zoomed into its top-left corner, sliding the
+#    subject down and right. Measured drift of a dead-centre subject over
+#    one scene: 0.044 of frame width. Now the anchor is expressed
+#    explicitly. Measured after: **0.000**.
+#
+# 3. JUDDER — one frame in three was IDENTICAL. ``zoompan`` computes x/y
+#    in integer source pixels, so at a 1.15x pre-scale a slow zoom often
+#    doesn't advance a whole pixel between frames, and the motion stutters
+#    at an effective ~20 fps inside a 30 fps video. Raising the pre-scale
+#    gives sub-pixel headroom. Measured judder (coefficient of variation
+#    of per-frame change, lower is smoother): 1.15x -> 0.391,
+#    2.0x -> 0.221, 3.0x -> 0.101, against render cost +17% and +121%.
+#    2.0x is the knee and is what ``_PRESCALE`` now is.
+#
+# Deliberately NOT eased. A smoothstep ramp reads better in theory, but
+# its slow start/end re-introduce exactly the sub-pixel stepping of (3):
+# measured 0.8% frozen and CV 0.271 against linear's 0.0% and 0.221, for
+# more render time. Constant velocity is also what documentary Ken Burns
+# actually uses.
+#
+# Render-only: no audio path is touched, so this sits outside the
+# landmine #17 A/B-listen gate.
+
+# Gentle, deterministic move per scene index — varied enough not to feel
+# mechanical, never so much that it draws attention to itself. Index, not
+# randomness, so a re-render of the same episode is identical.
+_KB_MOVES = ("in_centre", "out_centre", "in_pan_x", "out_pan_y")
+
+
+def _ken_burns(frames: int, move: str, *,
+               zoom_max: float = _ZOOM_MAX) -> Tuple[str, str, str]:
+    """Return ``(z, x, y)`` zoompan expressions for one scene.
+
+    *frames* is the scene's own output frame count, which is what makes
+    the motion duration-independent: a 4 s scene and a 15 s scene both
+    travel the full zoom range over their own length.
+    """
+    n = max(2, int(frames))
+    # Normalised progress 0..1 across this scene, in OUTPUT frames.
+    p = f"(on/{n - 1})"
+    amp = round(zoom_max - 1.0, 6)
+
+    if move.startswith("out"):
+        z = f"({zoom_max}-{amp}*{p})"
+    else:
+        z = f"(1+{amp}*{p})"
+
+    if move == "in_pan_x":
+        cx, cy = f"(0.42+0.16*{p})", "0.5"
+    elif move == "out_pan_y":
+        cx, cy = "0.5", f"(0.58-0.16*{p})"
+    else:
+        cx, cy = "0.5", "0.5"
+
+    # Anchor is the centre POINT of the visible window, so the framing
+    # stays put (or travels deliberately) instead of drifting to a corner.
+    return z, f"iw*{cx}-(iw/zoom/2)", f"ih*{cy}-(ih/zoom/2)"
+
+
+def _ken_burns_chain(src: str, out_label: str, *, frames: int, index: int,
+                     width: int, height: int, fps: int,
+                     prescale: float = _PRESCALE,
+                     trim_seconds: Optional[float] = None) -> str:
+    """The full scale -> crop -> zoompan chain for one still."""
+    pre_w, pre_h = int(width * prescale), int(height * prescale)
+    z, x, y = _ken_burns(frames, _KB_MOVES[index % len(_KB_MOVES)])
+    chain = (
+        f"{src}"
+        f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase"
+        f":{_SCALE_FLAGS},"
+        f"crop={pre_w}:{pre_h},setsar=1,"
+        f"zoompan=z='{z}':x='{x}':y='{y}':d={frames}"
+        f":s={width}x{height}:fps={fps}"
+    )
+    if trim_seconds is not None:
+        chain += f",trim=duration={trim_seconds:.2f},setpts=PTS-STARTPTS"
+    return chain + out_label
 
 # ffmpeg's default scaler is bicubic. Lanczos preserves noticeably more
 # detail when upsampling, which is the only regime this pipeline is ever
@@ -532,9 +631,6 @@ def _slideshow_filter_graph(scene_count: int, *,
             f"scene_durations length {len(scene_durations)} != "
             f"scene_count {scene_count}"
         )
-    pre_w = int(width * _PRESCALE)
-    pre_h = int(height * _PRESCALE)
-    zoom_expr = f"min(zoom+0.0006,{_ZOOM_MAX})"
     use_xfade = crossfade and crossfade > 0 and scene_count >= 2
     xfade_pad = crossfade if use_xfade else 0.0
     durs: List[float] = (
@@ -547,16 +643,12 @@ def _slideshow_filter_graph(scene_count: int, *,
     for i in range(scene_count):
         clip_len = durs[i] + xfade_pad
         frames_per_scene = int(clip_len * fps)
-        chains.append(
-            f"[{i}:v]"
-            f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase"
-            f":{_SCALE_FLAGS},"
-            f"crop={pre_w}:{pre_h},setsar=1,"
-            f"zoompan=z='{zoom_expr}':d={frames_per_scene}"
-            f":s={width}x{height}:fps={fps},"
-            f"trim=duration={clip_len:.2f},setpts=PTS-STARTPTS"
-            f"[s{i}]"
-        )
+        chains.append(_ken_burns_chain(
+            f"[{i}:v]", f"[s{i}]",
+            frames=frames_per_scene, index=i,
+            width=width, height=height, fps=fps,
+            trim_seconds=clip_len,
+        ))
 
     if not use_xfade:
         concat_in = "".join(f"[s{i}]" for i in range(scene_count))
@@ -680,14 +772,12 @@ def _hybrid_filter_graph(visuals: Sequence[tuple], *,
     """filter_complex mixing Ken-Burns stills with native video clips.
 
     *visuals* is an ordered list of ``(path, is_video, duration)`` tuples.
-    Image segments get the same 1.00→1.12 zoom as the pure slideshow; video
-    segments are scaled/cropped to fill the frame and play their own frames
-    (trimmed to *duration*). Everything is normalised to ``fps`` + SAR 1 so
-    the final ``concat`` is seamless.
+    Image segments get the same duration-normalised, centred Ken Burns as
+    the pure slideshow (``_ken_burns_chain``); video segments are
+    scaled/cropped to fill the frame and play their own frames (trimmed to
+    *duration*). Everything is normalised to ``fps`` + SAR 1 so the final
+    ``concat`` is seamless.
     """
-    pre_w = int(width * 1.15)
-    pre_h = int(height * 1.15)
-    zoom_expr = "min(zoom+0.0006,1.12)"
     chains: List[str] = []
     for i, (_path, is_video, duration) in enumerate(visuals):
         if is_video:
@@ -699,16 +789,16 @@ def _hybrid_filter_graph(visuals: Sequence[tuple], *,
                 f"[s{i}]"
             )
         else:
+            # Same duration-normalised, centred Ken Burns as the pure
+            # slideshow — the stills between clips used to freeze after
+            # 5 s and drift to the top-left exactly like every other one.
             frames = int(float(duration) * fps)
-            chains.append(
-                f"[{i}:v]"
-                f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase,"
-                f"crop={pre_w}:{pre_h},setsar=1,"
-                f"zoompan=z='{zoom_expr}':d={frames}"
-                f":s={width}x{height}:fps={fps},"
-                f"trim=duration={float(duration):.2f},setpts=PTS-STARTPTS"
-                f"[s{i}]"
-            )
+            chains.append(_ken_burns_chain(
+                f"[{i}:v]", f"[s{i}]",
+                frames=frames, index=i,
+                width=width, height=height, fps=fps,
+                trim_seconds=float(duration),
+            ))
     concat_in = "".join(f"[s{i}]" for i in range(len(visuals)))
     chains.append(f"{concat_in}concat=n={len(visuals)}:v=1:a=0[v]")
     return ";".join(chains)
@@ -1131,6 +1221,13 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
             f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
         )
     else:
+        # Degraded path: one static cover behind the whole episode, with a
+        # very slow drift so it isn't a frozen JPEG. The rate is
+        # deliberately tiny (1.08 over ~11 min at 30 fps) and is left
+        # alone; what's fixed here is the ANCHOR. Without explicit x/y,
+        # zoompan defaults both to "0" and creeps the cover toward its
+        # top-left corner for the entire episode. Centred, the drift is a
+        # slow push-in on the artwork instead.
         pre_w = int(width * _PRESCALE)
         pre_h = int(height * _PRESCALE)
         zoom_expr = "min(zoom+0.000004,1.08)"
@@ -1139,7 +1236,9 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
             f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase"
             f":{_SCALE_FLAGS},"
             f"crop={pre_w}:{pre_h},setsar=1,"
-            f"zoompan=z='{zoom_expr}':d=1:s={width}x{height}:fps={fps}"
+            f"zoompan=z='{zoom_expr}'"
+            f":x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)'"
+            f":d=1:s={width}x{height}:fps={fps}"
             f"[bg]"
         )
 

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -190,6 +190,105 @@ def _query_batch(service, video_ids: List[str], start: str, end: str) -> Dict[st
     return out
 
 
+# Demographics window. 28 days to match what YouTube Studio's own
+# Audience tab shows, so a number here can be checked against the app.
+_DEMO_DAYS = 28
+# The video filter accepts a bounded id list; keep well under the API's
+# limit so a big channel doesn't 400 the whole report.
+_DEMO_FILTER_MAX = 200
+
+
+def _viewer_percentages(service, start: str, end: str,
+                        video_ids: Optional[List[str]] = None) -> List[dict]:
+    """Age x gender split as ``viewerPercentage`` rows.
+
+    Percentages cover SIGNED-IN viewers only and sum to 100 across the
+    whole matrix — YouTube reports no absolute counts here. Passing
+    *video_ids* restricts the report to those videos, which is how the
+    Shorts-vs-long-form split is produced (the API has no "Shorts"
+    dimension; our own index knows which is which).
+
+    Returns [] on any failure — demographics are a reporting nicety and
+    must never take down the nightly analytics fetch.
+    """
+    params = dict(
+        ids="channel==MINE", startDate=start, endDate=end,
+        metrics="viewerPercentage", dimensions="ageGroup,gender",
+    )
+    if video_ids:
+        params["filters"] = "video==" + ",".join(video_ids[:_DEMO_FILTER_MAX])
+    try:
+        resp = service.reports().query(**params).execute()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("demographics query skipped (%s): %s",
+                    "filtered" if video_ids else "channel", str(exc)[:160])
+        return []
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    out = []
+    for row in resp.get("rows", []) or []:
+        rec = dict(zip(headers, row))
+        try:
+            pct = float(rec.get("viewerPercentage") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        out.append({
+            # "age25-34" -> "25-34"; leave anything unexpected alone.
+            "age": str(rec.get("ageGroup", "")).replace("age", ""),
+            "gender": str(rec.get("gender", "")),
+            "pct": round(pct, 3),
+        })
+    return out
+
+
+def _geography(service, start: str, end: str, limit: int = 25) -> List[dict]:
+    """Top viewing countries by views. [] on any failure."""
+    try:
+        resp = service.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics="views,estimatedMinutesWatched", dimensions="country",
+            sort="-views", maxResults=limit,
+        ).execute()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("geography query skipped: %s", str(exc)[:160])
+        return []
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    rows = []
+    for row in resp.get("rows", []) or []:
+        rec = dict(zip(headers, row))
+        rows.append({
+            "country": rec.get("country", ""),
+            "views": int(float(rec.get("views") or 0)),
+            "minutes": round(float(rec.get("estimatedMinutesWatched") or 0), 1),
+        })
+    total = sum(r["views"] for r in rows) or 0
+    for r in rows:
+        # Share of the REPORTED countries, and honestly labelled as such:
+        # the API returns a top-N, so this is not a share of all views.
+        r["pct_of_listed"] = round(100.0 * r["views"] / total, 2) if total else None
+    return rows
+
+
+def _summarise_demographics(rows: List[dict]) -> dict:
+    """Marginals worth putting on a dashboard card."""
+    if not rows:
+        return {}
+    by_gender: Dict[str, float] = defaultdict(float)
+    by_age: Dict[str, float] = defaultdict(float)
+    for r in rows:
+        by_gender[r["gender"]] += r["pct"]
+        by_age[r["age"]] += r["pct"]
+    older = sum(p for a, p in by_age.items()
+                if a in ("55-64", "65-"))
+    under_25 = sum(p for a, p in by_age.items()
+                   if a in ("13-17", "18-24"))
+    return {
+        "by_gender": {k: round(v, 2) for k, v in sorted(by_gender.items())},
+        "by_age": {k: round(v, 2) for k, v in sorted(by_age.items())},
+        "pct_55_plus": round(older, 2),
+        "pct_under_25": round(under_25, 2),
+    }
+
+
 def _channel_snapshot(credentials) -> Optional[dict]:
     """Channel-level statistics via the Data API (subs, total views).
 
@@ -314,8 +413,41 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
         # Channel-level snapshot + 30-day day-series (subs growth).
         snap = _channel_snapshot(creds) or {}
         series = _channel_day_series(service)
-        if snap or series:
+
+        # Audience demographics + geography (July 2026). Studio shows
+        # these per channel but not split by format; the Shorts/long
+        # split is the interesting cut, because Shorts skew young
+        # everywhere and a channel whose Shorts DON'T is a different
+        # strategic situation from one whose long-form drags the average
+        # up. The API has no Shorts dimension, so the split comes from
+        # filtering on our own index's `kind`.
+        demo_start = (today - _dt.timedelta(days=_DEMO_DAYS)).isoformat()
+        demo: Dict[str, object] = {"window_days": _DEMO_DAYS}
+        all_rows = _viewer_percentages(service, demo_start, end)
+        if all_rows:
+            demo["all"] = all_rows
+            demo["summary"] = _summarise_demographics(all_rows)
+            for kind in ("long", "short"):
+                kind_ids = [
+                    r["video_id"] for r in rows
+                    if (r.get("kind") or "") == kind
+                    and (r.get("published") or "") >= demo_start
+                ]
+                if len(kind_ids) < 3:
+                    continue    # too few videos for a meaningful split
+                kind_rows = _viewer_percentages(service, demo_start, end,
+                                                video_ids=kind_ids)
+                if kind_rows:
+                    demo[kind] = kind_rows
+                    demo[f"{kind}_summary"] = _summarise_demographics(kind_rows)
+        geo = _geography(service, demo_start, end)
+
+        if snap or series or all_rows or geo:
             snap["day_series"] = series
+            if all_rows:
+                snap["demographics"] = demo
+            if geo:
+                snap["geography"] = geo
             channels_block[channel] = snap
 
     if not any_data:

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -2383,6 +2383,57 @@ def build_audience_section(root: Path) -> Dict[str, Any]:
         except Exception as exc:  # noqa: BLE001
             section["spotify"] = {"configured": True, "error": str(exc)}
 
+    # ---- YouTube audience demographics (July 30 2026) ----------------
+    # Studio shows these per channel but never split by format, and the
+    # split is the interesting cut: Shorts skew young almost everywhere,
+    # so a channel whose Shorts DON'T is a different strategic situation
+    # from one whose long-form simply drags the average up. Trended here
+    # rather than read off a phone screenshot.
+    section["youtube_audience"] = {"configured": False}
+    yt_path = root / "api" / "youtube_stats.json"
+    if yt_path.exists():
+        try:
+            yt = json.loads(yt_path.read_text(encoding="utf-8"))
+            channels = {}
+            for ch, block in (yt.get("channels") or {}).items():
+                demo = (block or {}).get("demographics") or {}
+                geo = (block or {}).get("geography") or []
+                if not demo and not geo:
+                    continue
+                entry: Dict[str, Any] = {
+                    "window_days": demo.get("window_days"),
+                    "summary": demo.get("summary") or {},
+                    "top_countries": [
+                        {"country": g.get("country"),
+                         "views": g.get("views"),
+                         "pct_of_listed": g.get("pct_of_listed")}
+                        for g in geo[:10]
+                    ],
+                }
+                # Only present when enough videos of that kind existed to
+                # ask for the split — absent means "not measured", which
+                # the card must not render as a zero.
+                for kind in ("long", "short"):
+                    key = f"{kind}_summary"
+                    if demo.get(key):
+                        entry[key] = demo[key]
+                channels[ch] = entry
+            if channels:
+                section["youtube_audience"] = {
+                    "configured": True,
+                    "generated": yt.get("generated"),
+                    "channels": channels,
+                    # The percentages describe SIGNED-IN viewers only, a
+                    # subset of views. Carried to the UI so nobody reads
+                    # "0.0% under 25" as a headcount.
+                    "note": ("viewerPercentage covers signed-in viewers "
+                             "only; country shares are of the reported "
+                             "top countries, not of all views"),
+                }
+        except Exception as exc:  # noqa: BLE001
+            section["youtube_audience"] = {"configured": False,
+                                           "error": str(exc)}
+
     return section
 
 

--- a/tests/test_shorts_ab.py
+++ b/tests/test_shorts_ab.py
@@ -175,6 +175,33 @@ class TestBuildVariantFallsBackHonestly:
         assert len(result.clip_paths) == 3
         assert result.cost_usd == pytest.approx(1.05)
 
+    def test_clip_subjects_are_scenes_not_headlines(self, spacex):
+        """A video model needs something depictable.
+
+        The first cut fed the episode's extracted headlines to the clip
+        prompt, and the operator's verdict on the resulting Short was
+        "pretty bad video content and pretty nonsensical" — a $8bn
+        spectrum acquisition has no physical form to render. The show's
+        curated ``image_queries`` are concrete scenes and are what the
+        still pipeline already uses.
+        """
+        from engine.shorts_ab import _clip_contexts
+
+        headline = "Rocket Lab's purchase of Aridium for $8 billion"
+        got = _clip_contexts(spacex, "an episode hook", [headline], 3)
+        assert got, "no clip subjects produced"
+        assert headline not in got, "raw news headlines are back in the prompt"
+        assert set(got) <= set(spacex.youtube.image_queries)
+
+    def test_clip_subjects_fall_back_when_a_show_curates_none(self, spacex):
+        from engine.shorts_ab import _clip_contexts
+
+        spacex.youtube.image_queries = []
+        got = _clip_contexts(spacex, "the hook", ["a scene prompt"], 2)
+        assert got == ["a scene prompt", "a scene prompt"]
+        spacex.youtube.image_queries = []
+        assert _clip_contexts(spacex, "the hook", [], 1) == ["the hook"]
+
     def test_clips_are_requested_vertical(self, spacex, tmp_path, monkeypatch):
         seen = {}
 

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -601,11 +601,58 @@ def test_slideshow_filter_graph_zoom_per_scene():
     stacking magnification on an upsample. Asserted against the constant
     rather than a literal so the two cannot drift apart; the band is
     pinned in tests/test_video_render_quality.py.
+
+    July 30 2026: the fixed per-frame increment is gone. It reached the
+    ceiling after 5 s and then the picture was FROZEN for the rest of the
+    scene — 57.1% of a 12 s scene, measured by rendering. The zoom is now
+    normalised to each scene's own frame count, so it travels the same
+    range whatever the hold length and never stops. The ceiling is still
+    asserted against the constant so the two cannot drift apart.
     """
     from engine.video import _ZOOM_MAX
 
     graph = _slideshow_filter_graph(scene_count=2)
-    assert f"min(zoom+0.0006,{_ZOOM_MAX})" in graph
+    # Duration-normalised: progress is a function of the output frame
+    # number, not an accumulator against a cap.
+    assert "on/" in graph
+    assert str(_ZOOM_MAX) in graph
+    assert "min(zoom+0.0006" not in graph, (
+        "the capped-accumulator zoom is back — it freezes the image for "
+        "the remainder of every scene once the cap is reached"
+    )
+
+
+def test_slideshow_zoom_is_anchored_not_left_to_default():
+    """zoompan's x/y default to "0" — the TOP-LEFT corner.
+
+    The pipeline never set them, so every scene on the network zoomed
+    into its top-left corner and slid the subject down and right
+    (measured drift of a centred subject: 0.044 of frame width per
+    scene; 0.000 after this fix). Confirmed against ffmpeg 7.0's own
+    ``-h filter=zoompan``, which documents x and y as default "0".
+    """
+    graph = _slideshow_filter_graph(scene_count=2)
+    assert ":x='" in graph and ":y='" in graph, (
+        "zoompan without explicit x/y anchors to the top-left corner"
+    )
+    assert "iw/zoom/2" in graph and "ih/zoom/2" in graph
+
+
+def test_slideshow_prescale_leaves_subpixel_headroom():
+    """zoompan steps x/y in whole SOURCE pixels.
+
+    At the old 1.15x pre-scale a slow zoom often failed to advance a
+    pixel between frames: 77.2% of consecutive frames were byte-identical
+    (measured), i.e. the motion stuttered at well under the video's own
+    frame rate. 2.0x brought that to 33.3% for +17% render time; 3.0x
+    halves it again but costs +121%, which the 40-minute pipeline budget
+    does not have to spare.
+    """
+    from engine.video import _PRESCALE
+
+    assert _PRESCALE >= 2.0, (
+        "pre-scale below 2.0 reintroduces visible integer-pixel judder"
+    )
 
 
 def test_slideshow_cmd_has_one_input_per_scene(tmp_path):

--- a/tests/test_youtube_demographics.py
+++ b/tests/test_youtube_demographics.py
@@ -1,0 +1,171 @@
+"""Guards for the YouTube audience demographics + geography fetch.
+
+Added July 30 2026 after the operator read these off a phone screenshot
+and asked two questions the repo could not answer: is the near-total
+male skew real, and is the zero-under-25 figure real or an artifact?
+
+The strategically interesting cut is **Shorts vs long-form**, which
+Studio does not offer. Shorts skew young almost everywhere, so a channel
+whose Shorts don't is a different situation from one whose long-form
+drags the average up. The Analytics API has no Shorts dimension, so the
+split comes from filtering the report on our own index's ``kind``.
+
+Everything here is best-effort by contract: demographics are a reporting
+nicety and must never take down the nightly analytics fetch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location(
+        "fya_demo", ROOT / "scripts" / "fetch_youtube_analytics.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Reports:
+    def __init__(self, payloads, boom=False):
+        self.payloads, self.boom, self.calls = payloads, boom, []
+
+    def query(self, **kw):
+        self.calls.append(kw)
+        self._kw = kw
+        return self
+
+    def execute(self):
+        if self.boom:
+            raise RuntimeError("403 insufficient permissions")
+        return self.payloads.get(self._kw.get("dimensions"), {})
+
+
+class _Service:
+    def __init__(self, payloads, boom=False):
+        self._r = _Reports(payloads, boom)
+
+    def reports(self):
+        return self._r
+
+
+_DEMO = {
+    "ageGroup,gender": {
+        "columnHeaders": [{"name": "ageGroup"}, {"name": "gender"},
+                          {"name": "viewerPercentage"}],
+        "rows": [["age65-", "male", 32.7], ["age55-64", "male", 23.6],
+                 ["age45-54", "male", 19.6], ["age25-34", "female", 0.5]],
+    },
+    "country": {
+        "columnHeaders": [{"name": "country"}, {"name": "views"},
+                          {"name": "estimatedMinutesWatched"}],
+        "rows": [["US", 5081, 900.0], ["JP", 470, 60.0], ["CA", 429, 55.0]],
+    },
+}
+
+
+class TestViewerPercentages:
+    def test_age_labels_are_stripped_of_the_api_prefix(self):
+        m = _module()
+        rows = m._viewer_percentages(_Service(_DEMO), "2026-07-02", "2026-07-29")
+        assert {r["age"] for r in rows} == {"65-", "55-64", "45-54", "25-34"}
+
+    def test_a_video_filter_is_sent_when_ids_are_given(self):
+        """This is what produces the Shorts-vs-long split."""
+        m = _module()
+        svc = _Service(_DEMO)
+        m._viewer_percentages(svc, "2026-07-02", "2026-07-29",
+                              video_ids=["a", "b", "c"])
+        assert svc.reports().calls[-1]["filters"] == "video==a,b,c"
+
+    def test_the_filter_list_is_bounded(self):
+        # An unbounded id list would 400 the whole report on a big channel.
+        m = _module()
+        svc = _Service(_DEMO)
+        m._viewer_percentages(svc, "2026-07-02", "2026-07-29",
+                              video_ids=[f"v{i}" for i in range(500)])
+        sent = svc.reports().calls[-1]["filters"].split("==")[1].split(",")
+        assert len(sent) == m._DEMO_FILTER_MAX
+
+    def test_a_failure_is_an_empty_list_not_an_exception(self):
+        m = _module()
+        assert m._viewer_percentages(_Service({}, boom=True), "a", "b") == []
+
+    def test_geography_failure_is_also_contained(self):
+        m = _module()
+        assert m._geography(_Service({}, boom=True), "a", "b") == []
+
+
+class TestSummary:
+    def test_marginals_match_the_studio_screenshot(self):
+        m = _module()
+        rows = m._viewer_percentages(_Service(_DEMO), "a", "b")
+        s = m._summarise_demographics(rows)
+        # 23.6 + 32.7 from the operator's 2026-07-29 screenshot.
+        assert s["pct_55_plus"] == pytest.approx(56.3, abs=0.05)
+        assert s["pct_under_25"] == 0
+        assert s["by_gender"]["female"] == pytest.approx(0.5)
+
+    def test_empty_input_summarises_to_nothing_not_to_zeros(self):
+        # "not measured" and "measured as zero" must stay distinguishable.
+        assert _module()._summarise_demographics([]) == {}
+
+
+class TestGeography:
+    def test_shares_are_labelled_as_of_listed_countries(self):
+        """The API returns a top-N, so a share of it is NOT a share of
+        all views. The key name has to say so — the operator's own
+        screenshot listed ten countries summing to ~52%."""
+        m = _module()
+        rows = m._geography(_Service(_DEMO), "a", "b")
+        assert all("pct_of_listed" in r for r in rows)
+        assert sum(r["pct_of_listed"] for r in rows) == pytest.approx(100, abs=0.1)
+
+
+class TestDashboardSurface:
+    def test_absent_stats_report_not_configured(self, tmp_path):
+        sys.path.insert(0, str(ROOT / "scripts"))
+        from generate_dashboard import build_audience_section
+
+        out = build_audience_section(tmp_path)
+        assert out["youtube_audience"]["configured"] is False
+
+    def test_demographics_reach_the_dashboard(self, tmp_path):
+        import json
+
+        sys.path.insert(0, str(ROOT / "scripts"))
+        from generate_dashboard import build_audience_section
+
+        api = tmp_path / "api"
+        api.mkdir()
+        (api / "youtube_stats.json").write_text(json.dumps({
+            "generated": "2026-07-30T18:00:00Z",
+            "channels": {"en": {
+                "demographics": {
+                    "window_days": 28,
+                    "summary": {"pct_55_plus": 56.3, "pct_under_25": 0.0,
+                                "by_gender": {"male": 99.5, "female": 0.5}},
+                    "short_summary": {"pct_under_25": 12.0},
+                },
+                "geography": [{"country": "US", "views": 5081,
+                               "pct_of_listed": 70.0}],
+            }},
+        }))
+        out = build_audience_section(tmp_path)["youtube_audience"]
+        assert out["configured"] is True
+        en = out["channels"]["en"]
+        assert en["summary"]["pct_55_plus"] == 56.3
+        # The Shorts split is the whole point of the fetch.
+        assert en["short_summary"]["pct_under_25"] == 12.0
+        # ...and long-form is ABSENT rather than zeroed when unmeasured.
+        assert "long_summary" not in en
+        assert "signed-in" in out["note"]


### PR DESCRIPTION
Two operator reports: the Grok-video Short was "pretty bad and pretty nonsensical", and the Ken Burns motion needed to be a better, more consistent illusion of movement. I rendered the shipping filter graph at 1920×1080 with ffmpeg and measured actual frames rather than reasoning about the code.

## Three defects in the Ken Burns, all measured

**1. The motion stopped.** `min(zoom+0.0006,1.09)` is a fixed per-frame increment against a cap. It reaches the cap after 150 frames — 5.0s at 30fps — and the picture is then *perfectly static*.

> **57.1% of a 12-second scene was a frozen still**, and 10 of the 15 seconds at `_MAX_SCENE_HOLD_S`.

Now normalised to each scene's own frame count: a 4s scene and a 15s scene both travel the full range over their own length.

**2. Every scene zoomed into its top-left corner.** `zoompan`'s `x` and `y` default to `"0"` — confirmed against ffmpeg 7.0's own `-h filter=zoompan` — and this pipeline never set them. A dead-centre subject drifted 0.044 of frame width per scene, down and to the right.

**3. One frame in three was byte-identical.** `zoompan` steps x/y in whole *source* pixels, so at the 1.15× prescale a slow zoom often failed to advance a pixel between frames — motion stuttering well under the video's frame rate.

### Before / after, on the real pipeline code

| | before | after |
|---|---|---|
| frozen | 57.1% | **0.0%** |
| subject drift | 0.044 | **0.000** |
| identical consecutive frames | 77.2% | **33.3%** |

Filmstrip of six frames across one 12s scene (old top, new bottom): the old row's corner marker stops changing after frame 3 and the centre subject creeps right; the new row moves continuously and stays put.

### Two places measurement overruled me

- **Easing measured worse than linear** — 0.8% frozen / CV 0.271 vs 0.0% / 0.221 — because its slow start and end re-introduce defect 3. Constant velocity is also what documentary Ken Burns actually uses.
- **3.0× prescale** halves the residual stepping again but costs **+121% render time**, which the 40-minute pipeline budget can't spare. 2.0× is +17% and is the knee.

Both are recorded in the code with the numbers, so the next person doesn't re-litigate them.

Applied to all three `zoompan` sites: the slideshow, the stills+clips hybrid, and the single-pass static cover — which had been creeping toward its top-left corner for *entire episodes*.

## The nonsensical video Short

The cause was mine. The clip prompt's `Subject:` was fed the episode's extracted **news headlines**, so a text-to-video model was asked to depict *"Rocket Lab's purchase of Aridium for $8 billion brings L-band spectrum holdings under one roof"* — an abstraction with no physical form.

It now uses the show's curated `youtube.image_queries`, which are concrete scenes chosen for exactly this reason (landmine #14, where raw keywords sent Pexels looking for fashion models), and are the same subjects the stills arm uses — which also keeps the two arms comparable:

```
Subject: Falcon 9 rocket night launch
Subject: Starship on the launch pad
Subject: Super Heavy booster tower catch
```

**Recommendation:** watch the next one. If it's still bad, set `shorts_ab_enabled: false` — output that looks broken doesn't need 14 episodes per arm to reject, and that's a cheap answer rather than a failed experiment.

## Audience demographics + geography

`fetch_youtube_analytics.py` now pulls age×gender and country per channel, **including the Shorts-vs-long-form split Studio doesn't offer** — the Analytics API has no Shorts dimension, so the report is filtered on our own index's `kind`. This answers the two questions a screenshot couldn't: whether the 99.5% male skew and the 0.0% under-25 hold for Shorts as well as long-form.

Honesty carried through to the UI: percentages are labelled as **signed-in viewers only**, country shares as a share of the **reported top countries** rather than of all views, and an unmeasured split is *absent* rather than zeroed.

## Testing

- New render-derived guards in `test_video_commands.py`: the capped-accumulator zoom can't come back, `x`/`y` must be explicit, prescale must stay ≥2.0.
- `tests/test_youtube_demographics.py` — 10 tests including the bounded video filter and failure containment.
- 239 passed across every directly affected file; the single failure is this container's broken system `cryptography`, pre-existing on `main`.
- `ruff check engine/ run_show.py scripts/` passes.

Render/metadata-only — no audio path is touched, so outside the landmine #17 A/B-listen gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhiaNApLY6VUw9CxyQT9Jg)_