### PR TITLE
Weekly review: fix skip-reason reporting, SPCX TTS bookkeeping (review in progress)

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -408,7 +408,21 @@ jobs:
           python run_show.py ${{ matrix.show }} $EXTRA_FLAGS 2>&1
           EXIT_CODE=$?
           if [ $EXIT_CODE -eq 2 ]; then
-            echo "::warning::Show ${{ matrix.show }} skipped — insufficient articles for a quality episode"
+            # Exit 2 covers several graceful-skip reasons (insufficient
+            # articles, thin podcast script, empty narrative queue, ...).
+            # Surface the REAL reason from the skip marker run_show writes —
+            # the 2026-07-31 Tesla thin-script skip was reported here as
+            # "insufficient articles" and sent the operator debugging the
+            # wrong subsystem.
+            SKIP_DIR="digests/${{ matrix.show }}"
+            [ "${{ matrix.show }}" = "tesla" ] && SKIP_DIR="digests/tesla_shorts_time"
+            SKIP_MARKER="$SKIP_DIR/.skip_$(date -u +%Y%m%d).json"
+            if [ -f "$SKIP_MARKER" ]; then
+              SKIP_REASON=$(python -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('reason','unknown') + ': ' + d.get('detail',''))" "$SKIP_MARKER" 2>/dev/null || echo "unknown")
+              echo "::warning::Show ${{ matrix.show }} skipped — $SKIP_REASON"
+            else
+              echo "::warning::Show ${{ matrix.show }} skipped (exit 2, no skip marker found — likely insufficient articles)"
+            fi
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -92,7 +92,20 @@ def pronunciation_overrides() -> dict:
     NOT a phonetic respelling of a word — so it is outside the landmine #17 ban
     on theory-driven respellings.
     """
-    return {"extra_words": {"tf": "tons-force"}}
+    return {
+        "extra_words": {"tf": "tons-force"},
+        # SPCX is already letter-spelled at TTS-call time by
+        # shows/pronunciation_map.yaml, but that leaves the saved _tts.txt
+        # carrying the raw ticker while the voice receives "S P C X" — the
+        # 2026-07-31 Ep051 ticker investigation had to reconstruct what the
+        # voice was actually sent because the on-disk script didn't show it.
+        # Expanding at script-save time too makes the committed TTS text
+        # match the audio input byte-for-byte (the TTS-call map then finds
+        # nothing left to replace — the voice receives the identical string,
+        # so this is bookkeeping, not an audio change). The chapter patterns
+        # in shows/spacex.yaml already tolerate both forms.
+        "extra_acronyms": {"SPCX": "S P C X"},
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Weekly code-review pass over the past week's changes, plus fixes for today's two operator-reported failures. **Review still in progress** — additional confirmed fixes from the audio/video/funnel/website sweeps will land on this branch; this description will be updated when the pass is complete.

## Landed so far

### 1. `run-show.yml` reported every graceful skip as "insufficient articles"
Today's Tesla Ep558 skip was actually `podcast_script_too_thin` (1,133 words after cleanup vs the 1,200 soft floor — 60% of Tesla's 2,000-word target). The hardcoded workflow warning pointed at the fetch layer, which was healthy (82 articles). The workflow now reads the `.skip_<date>.json` marker `run_show.py` writes and surfaces its real `reason` + `detail`.

Diagnosis of the skip itself: the script generation undershot (1,002 words raw; the sanctioned publication-floor retry got it to 1,204; dedup/cleaning left 1,133). Contributing factor: the digest was degenerate — the same Giga Shanghai/WSJ story appeared as two story blocks and `'1.2 million'` repeated 5× (both were warned about in the log but only warned). The floor worked as designed: documented skip instead of a thin episode.

### 2. SpaceX saved TTS text didn't match what the voice receives
`shows/pronunciation_map.yaml` expands `SPCX → "S P C X"` at TTS-call time — *after* the `_tts.txt` is saved — so the committed script showed a raw `SPCX` while the voice got the letter-spelled form. The Ep051 ticker investigation had to reconstruct the actual TTS input. The spacex hook now expands SPCX at script-save time too; the TTS-call map then finds nothing left to replace, so **the audio input is byte-identical** — bookkeeping only.

## ⚠️ SPCX mispronunciation on Ep051 — A/B-listen required, NOT applied
The map was working: both ticker mentions reached the voice as `S P C X`. But Ep051's Whisper transcript reads **"S&P CX"** where every episode since June reads "SPCX" — i.e. today the voice rendered the spaced letters with an "S-and-P" index-style reading. No code on the TTS path changed between Ep050 (clean) and Ep051, so this is a TTS rendering slip on the spaced-letter form, most plausibly primed by the financial context ("closed at $112.20").

Proposed fix candidates (per the landmine-#17 rule — theory-driven voice changes have a 100% regression rate, so not applied blind):
- Map `SPCX: "S.P.C.X."` (period-separated initialism form — the standard TTS-unambiguous spelling, breaks the S-and-P association)
- Or drop the raw ticker from the LLM's mid-script market note entirely and let only the hook-built closing carry it

Both need one listen on the production voice before shipping.

## Operator decision surfaced: `clean_digest` has never reached a podcast script
The July 30 refactor (#921) documented that the podcast-only digest cleaning, the **Sunday week-in-review segment (landmine #19)**, and the duplicate-headline strip are computed and read by nothing — the live path feeds the raw digest to the podcast prompt. The existing `weekly_summary_segment_effective` metric already records the honest `false`. Wiring it is a one-line change but alters the digest every podcast prompt receives (audio-affecting → your A/B call). Today's Tesla thin-script skip is a live example of what the duplicate-strip would have mitigated.

## Verification
- Full pytest suite green locally (including `test_spacex_show.py`, `test_pronunciation.py` — 267 passed on the touched areas)
- Workflow YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_