### PR TITLE
Weekly review, part 2: A/B contamination, tonight's MIT monthly crash, spoken-URL regression + 12 more confirmed fixes

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -105,8 +105,15 @@ def strip_urls(text: str) -> str:
                       flags=re.IGNORECASE)
         return f"{host} {re.sub(r'[/_.-]+', ' ', path)}".rstrip()
 
+    # The trailing \b after the TLD is load-bearing: without it ".net"
+    # matches as a prefix inside ".netlify.app" (MAB ships those demo
+    # links regularly — 10 committed occurrences) and the URL is
+    # half-converted ("snake-awakening dot netlify.app"). \b still sits
+    # before both a path "/" and a sentence-final "." (non-word chars),
+    # so the promo-URL path handling is unaffected; it only blocks
+    # letter-continuation. Dropped by the 2026-07-30 rewrite, restored.
     text = re.sub(
-        r"\b(?P<host>\w+(?:\.\w+)*\.(?:com|org|net|io|ai|co|dev))"
+        r"\b(?P<host>\w+(?:\.\w+)*\.(?:com|org|net|io|ai|co|dev))\b"
         r"(?P<path>/[A-Za-z0-9\-_/]+(?:\.[A-Za-z0-9\-_/]+)*)?",
         _spoken_domain,
         text,

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -352,16 +352,30 @@ def transcript_to_srt_window(
         # Rebase onto the Shorts clip's t=0 origin.
         rel_start = clipped_start - window_start_seconds
         rel_end = clipped_end - window_start_seconds
-        wrapped = _wrap_caption_line(
+        # Split oversized segments into cue-sized blocks that share the
+        # segment's time range — the same fix transcript_to_srt received
+        # (2026-07-30). _wrap_caption_line's lossy branch stuffed the
+        # whole remainder into the last line; libass word-wraps rather
+        # than clips, so at 24 chars x 2 lines a normal 100-150-char
+        # Whisper segment grew the bottom-anchored FontSize-48 card
+        # upward into the hook-overlay zone.
+        blocks = _split_caption_text(
             text, max_chars=wrap_max_chars, max_lines=wrap_max_lines,
         )
-        cues.append(
-            f"{cue_index}\n"
-            f"{_format_srt_timestamp(rel_start)} --> "
-            f"{_format_srt_timestamp(rel_end)}\n"
-            f"{wrapped}\n"
-        )
-        cue_index += 1
+        span = (rel_end - rel_start) / max(1, len(blocks))
+        for n, block in enumerate(blocks):
+            if not block.strip():
+                continue
+            b_start = rel_start + n * span
+            b_end = (rel_start + (n + 1) * span
+                     if n < len(blocks) - 1 else rel_end)
+            cues.append(
+                f"{cue_index}\n"
+                f"{_format_srt_timestamp(b_start)} --> "
+                f"{_format_srt_timestamp(b_end)}\n"
+                f"{block}\n"
+            )
+            cue_index += 1
 
     if not cues:
         logger.info(

--- a/engine/funnel.py
+++ b/engine/funnel.py
@@ -209,6 +209,20 @@ def campaign_id(
         show = "unknown"
     chan = _norm(channel) or "en"
     knd = _norm(kind) or "short"
+    if knd not in KINDS:
+        # Build/parse must stay exact inverses: parse_campaign_id rejects
+        # kinds outside the closed vocabulary, so an out-of-vocabulary
+        # kind here would build a campaign that ships fine and then lands
+        # every session it earns in `unattributed` — silently. Same
+        # pattern as the empty-slug guard above: loud, then coerce.
+        logger.warning(
+            "funnel: kind %r is not in the closed vocabulary %s — "
+            "coercing to 'short' so the campaign stays parseable "
+            "(show %s, episode %s). Placements belong in the placement/"
+            "content field, not in kind.",
+            kind, sorted(KINDS), show, episode,
+        )
+        knd = "short"
     try:
         ep = max(0, int(episode))
     except (TypeError, ValueError):

--- a/engine/intros.py
+++ b/engine/intros.py
@@ -883,8 +883,21 @@ _SHOW_PERSONALITIES: dict[str, dict[str, Any]] = {
 # Milestone detection
 # ---------------------------------------------------------------------------
 
-def _milestone_note(episode_num: int) -> str | None:
-    """Return a brief milestone acknowledgment for round episode numbers."""
+def _milestone_note(episode_num: int, *, is_ru: bool = False) -> str | None:
+    """Return a brief milestone acknowledgment for round episode numbers.
+
+    ``is_ru`` picks the Russian phrasing for the Russian-spoken shows —
+    the identity line was carefully localized in the July 30 cold-open
+    pass, but this tail was appended unconditionally in English, so
+    Финансы Просто's Ep100 would have opened with the Olya voice reading
+    an English sentence mid-Russian-intro.
+    """
+    if is_ru:
+        if episode_num == 100:
+            return "Это сотый выпуск — настоящая веха. Спасибо, что вы с нами."
+        if episode_num % 100 == 0 and episode_num > 0:
+            return "Ещё одна круглая отметка — спасибо, что слушаете."
+        return None
     if episode_num == 100:
         return "That's episode one hundred — a big milestone. Thank you for being here."
     if episode_num == 200:
@@ -1013,7 +1026,9 @@ def build_intro_line(
 
     # Milestones are genuinely worth saying out loud — a 500th episode
     # is a credibility signal, unlike a date.
-    milestone = _milestone_note(episode_num)
+    milestone = _milestone_note(
+        episode_num, is_ru=show_slug in _RUSSIAN_SPOKEN_SHOWS
+    )
     if milestone:
         intro = f"{intro} {milestone}"
 

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -540,6 +540,14 @@ def run_generation_phase(
     # in that dead block. setdefault means a working hook is unaffected.
     pod_vars.setdefault("narrative_memory_section", "")
     pod_vars.setdefault("vocab_review_section", "")
+    # Tesla's bespoke memory module injects three placeholders of its own
+    # (the generalized shows share {narrative_memory_section} above). A
+    # tesla hook-load failure would KeyError the podcast prompt exactly
+    # like the 2026-07-30 cold_open_spec outage — same guard, same
+    # setdefault semantics (a working hook is untouched).
+    pod_vars.setdefault("tesla_narrative_status_block", "")
+    pod_vars.setdefault("tesla_performance_signals_block", "")
+    pod_vars.setdefault("tesla_theme_context_block", "")
 
     # Cold-open + delivery specs (July 30 2026 retention pass). These were
     # wired into run_show.py's pod_vars — which, as the Ep1 comment above

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -381,7 +381,12 @@ def _clause_trim(text: str, limit: int, lang: str = "") -> str:
     pattern = _DANGLING_RE.get((lang or "").strip().lower())
     if pattern is None:
         return trimmed
-    floor = max(1, int(limit * _MIN_TRIM_RATIO))
+    # Floor against the ACTUAL text length, not the budget: a title that
+    # arrives already shorter than 55% of the limit (e.g. 31 chars vs a
+    # 70-char budget) previously started below the floor, so the peel
+    # loop never ran and the dangling "à"/"de" tail — the exact defect
+    # this function exists to remove — survived untouched.
+    floor = max(1, int(min(len(trimmed), limit) * _MIN_TRIM_RATIO))
     while len(trimmed) > floor:
         shorter = pattern.sub("", trimmed).rstrip(" ,.:;—-…")
         if shorter == trimmed:
@@ -410,7 +415,7 @@ def _policy_plan(config) -> Dict[str, object]:
             slug=config.slug,
             channel="ru",
             yaml_publish_long=True,   # legacy ru_dub always built the long
-            yaml_shorts=1,            # policy may raise (capped at 2 below)
+            yaml_shorts=1,            # policy may raise (cap: MAX_SHORTS_PER_EPISODE)
             # July 18 2026: the RU Short path genuinely runs the smart
             # selector on its own RU transcript, so the policy is allowed
             # to raise the Shorts count (RU Shorts are the network's

--- a/engine/shorts_ab.py
+++ b/engine/shorts_ab.py
@@ -191,6 +191,12 @@ def build_variant(
 
     def _fall_back(reason: str) -> ShortVariant:
         result.variant = VARIANT_STILLS
+        # Clear any clips already attached: run_show passes
+        # result.clip_paths into build_short_video, and the hybrid render
+        # fires on >= 2 usable clips — so a "not enough clips" fallback
+        # that kept 2 paths would RECORD stills while SHIPPING video,
+        # the disguised-arm case this module's contract forbids.
+        result.clip_paths = []
         result.fallback_reason = reason
         logger.warning(
             "Shorts A/B: Short #%d falls back to stills (%s) — the "
@@ -209,7 +215,10 @@ def build_variant(
         resolution = str(getattr(yt, "shorts_ab_resolution", "720p") or "720p")
         budget_s = float(getattr(yt, "shorts_ab_budget_seconds", 420.0) or 420.0)
         max_cost = float(getattr(yt, "shorts_ab_max_cost_usd", 1.25) or 1.25)
-        min_clips = max(1, int(getattr(yt, "shorts_ab_min_clips", 2) or 2))
+        # Floor 2, not 1: the hybrid renderer requires >= 2 usable clips
+        # (engine/video.py) — a min_clips of 1 would record grok_video
+        # and then ship stills when a single clip landed.
+        min_clips = max(2, int(getattr(yt, "shorts_ab_min_clips", 2) or 2))
     except (TypeError, ValueError) as exc:
         return _fall_back(f"malformed shorts_ab config: {exc}")
 

--- a/engine/video.py
+++ b/engine/video.py
@@ -560,10 +560,22 @@ def _ken_burns(frames: int, move: str, *,
     else:
         z = f"(1+{amp}*{p})"
 
+    # Pan amplitude is bounded by the zoom's feasible window: at zoom z
+    # the visible-window CENTRE can only sit in [1/(2z), 1-1/(2z)], i.e.
+    # +/-(1-1/z)/2 around 0.5 — which is 0 at zoom 1.0 and only ~0.041 at
+    # 1.09. The previous fixed 0.42→0.58 sweep (+/-0.08) exceeded that for
+    # roughly the first and last 40% of every pan scene; zoompan clamps
+    # x/y, so those phases rendered as edge-anchored zooms (a milder
+    # reprise of the corner-drift defect this function was written to
+    # fix). The pan now ramps from centre exactly as fast as the growing
+    # zoom makes room: in-pans start centred and drift as they tighten,
+    # out-pans return to centre as they widen, and the requested centre
+    # stays inside the feasible window for every frame.
+    travel = round((1.0 - 1.0 / zoom_max) / 2.0, 6)
     if move == "in_pan_x":
-        cx, cy = f"(0.42+0.16*{p})", "0.5"
+        cx, cy = f"(0.5+{travel}*{p})", "0.5"
     elif move == "out_pan_y":
-        cx, cy = "0.5", f"(0.58-0.16*{p})"
+        cx, cy = "0.5", f"(0.5+{travel}-{travel}*{p})"
     else:
         cx, cy = "0.5", "0.5"
 

--- a/engine/youtube_policy.py
+++ b/engine/youtube_policy.py
@@ -104,7 +104,13 @@ def resolve_publish_plan(
         YAML count requires ``shorts_start_mode: smart`` (the multi-Short
         path needs the top-N window selector). Lowering is always allowed.
     """
-    yaml_shorts_floor = max(1, int(yaml_shorts or 1))
+    # Clamp the YAML value too: the no-policy / adaptive-off paths return
+    # this verbatim and run_show has no bound of its own, so a YAML
+    # `shorts_per_episode: 10` would previously ship 10 Shorts whenever
+    # the policy file was missing or the show opted out of adaptation.
+    yaml_shorts_floor = min(
+        MAX_SHORTS_PER_EPISODE, max(1, int(yaml_shorts or 1))
+    )
     plan: Dict[str, object] = {
         "publish_long": bool(yaml_publish_long),
         "shorts": yaml_shorts_floor,

--- a/generate_html.py
+++ b/generate_html.py
@@ -30,6 +30,7 @@ from jinja2 import Environment, FileSystemLoader
 # RSS feeds, network HTML) scrubs at the same boundary. See utils.py
 # for the May 7 2026 operator-caught regression that prompted this.
 from engine.utils import strip_lone_surrogates as _strip_lone_surrogates
+from engine import titles as _titles
 
 ROOT = Path(__file__).resolve().parent
 TEMPLATES_DIR = ROOT / "templates"
@@ -2467,8 +2468,10 @@ def generate_show_page(slug, *, dry_run=False):
             dynamic_meta_description = f"Latest: {latest_episode_title}. {cfg.get('meta_description', '')}".strip()
             # Page title becomes "Show — Latest Hook Snippet | Nerra Network" (safe length)
             hook_snippet = latest_episode_title.split(":", 1)[-1].strip() if ":" in latest_episode_title else latest_episode_title
-            if len(hook_snippet) > 70:
-                hook_snippet = hook_snippet[:67] + "…"
+            # Titles rule (CLAUDE.md top rule): every truncation goes through
+            # engine/titles.py. The old raw slice cut mid-word on published
+            # <title>s ("…configuration na…" on spacex.html, 2026-07-31).
+            hook_snippet = _titles.clip_words(hook_snippet, _titles.WEB_TITLE_LEAD_MAX)
             page_title = f"{cfg['name']} — {hook_snippet} | Nerra Network"
 
     # Modern Investing: pull the mock-trade performance block from
@@ -2519,8 +2522,9 @@ def generate_show_page(slug, *, dry_run=False):
     latest_episode_title = static_episodes[0]["title"] if static_episodes else None
     if latest_episode_title:
         hook_snippet = latest_episode_title.split(":", 1)[-1].strip() if ":" in latest_episode_title else latest_episode_title
-        if len(hook_snippet) > 68:
-            hook_snippet = hook_snippet[:65] + "…"
+        # Titles rule: clip through engine/titles.py, never a raw slice (the
+        # two slice sites here even disagreed with each other, 67 vs 65).
+        hook_snippet = _titles.clip_words(hook_snippet, _titles.WEB_TITLE_LEAD_MAX)
         page_title = f"{cfg['name']} — {hook_snippet} | Nerra Network"
         meta_description = f"Latest: {latest_episode_title}. {cfg.get('meta_description', '')}".strip()
 

--- a/management.html
+++ b/management.html
@@ -1127,7 +1127,8 @@
           });
         });
         card.appendChild(h("p", { class: "fine-list", html:
-          "Tier A = long + 2 Shorts · B = long + 1 · C = shorts-only · D = probe. " +
+          "Tiers gate LONG-FORM (A/B = long on · C = shorts-only · D = probe); " +
+          "Shorts count follows short_vpd bands independently, up to 3/episode. " +
           "vpd = long/short views-per-day over " + (ytPolicy.window_days || 14) +
           "d; Shorts are never zeroed (they're the recovery signal)." }));
       }
@@ -1490,6 +1491,24 @@
       card.appendChild(h("p", { class: "fine-list", html:
         "<span class='k'>" + money(ml.network_cost_7d_usd) + "</span> dub spend · 7d" }));
       const langColor = { fr: "var(--series-1)", ru: "var(--series-2)", es: "var(--series-3)", zh: "var(--series-4)" };
+      // Per-language downloads vs cost — the decision instrument the July 29
+      // cost pass shipped ("a language reading zero across several weeks is a
+      // candidate to switch off"). Without these rows the signal only existed
+      // in raw api/dashboard.json. "—" = not yet measured (null), never 0.
+      if (ml.by_language && Object.keys(ml.by_language).length) {
+        Object.keys(ml.by_language).sort().forEach((lang) => {
+          const bl = ml.by_language[lang];
+          const dl30 = bl.measured ? (bl.downloads_30d + " dl·30d") : "dl not measured yet";
+          const row = h("div", { style: "display:flex;align-items:center;gap:8px;padding:3px 0;" });
+          row.appendChild(h("span", { class: "chip on", title: lang + " across " + bl.shows + " show(s)" }));
+          row.lastChild.appendChild(h("span", { class: "dot", style: "background:" + (langColor[lang] || "var(--series-1)") + ";" }));
+          row.lastChild.appendChild(document.createTextNode(lang.toUpperCase()));
+          row.appendChild(h("span", { style: "font-size:12px;color:var(--ink-2);", text: dl30 }));
+          row.appendChild(h("span", { style: "font-size:11.5px;color:var(--ink-4);", text:
+            money(bl.approx_cost_7d_usd) + " · 7d · " + bl.shows + " shows" }));
+          card.appendChild(row);
+        });
+      }
       Object.keys(ml.per_show).sort().forEach((slug) => {
         const c = ml.per_show[slug];
         const row = h("div", { style: "display:flex;align-items:center;gap:8px;padding:5px 0;flex-wrap:wrap;" });

--- a/run_show.py
+++ b/run_show.py
@@ -5577,6 +5577,14 @@ def _publish_youtube(
             _short_variant_results: "list" = []
             _short_variants = list(_short_variant_plan)
             _ab_spent_usd = 0.0
+            # Record an experiment arm ONLY for shows actually running the
+            # experiment. plan_variants returns "stills" for every show (it
+            # doubles as the render plan), and passing that through to
+            # metadata/index/analytics stamped variant="stills" on EVERY
+            # network Short from 2026-07-30 on — filling the A/B control
+            # arm with cross-show Shorts whose baselines differ ~10x from
+            # the spacex treatment arm. Non-participants record no arm.
+            _ab_on = _shorts_ab.is_enabled(config)
             _yt_channel = (
                 getattr(config.youtube, "channel", "en") or "en"
             ).lower()
@@ -5855,7 +5863,7 @@ def _publish_youtube(
                         long_form_url=long_url,
                         optimized_title=_opt_short_title,
                         channel=_yt_channel,
-                        variant=_variant.variant,
+                        variant=(_variant.variant if _ab_on else ""),
                     )
                     upload_thumb = (
                         this_short_thumb_path
@@ -5889,7 +5897,9 @@ def _publish_youtube(
                             channel=(getattr(config.youtube, "channel", "en") or "en"),
                             # The arm this Short ACTUALLY shipped —
                             # analytics reads the experiment from here.
-                            variant=_variant.variant,
+                            # Empty for non-participating shows so the
+                            # control arm stays same-show, same-channel.
+                            variant=(_variant.variant if _ab_on else ""),
                             index_path=digests_dir / "youtube_videos.json",
                         )
                     except Exception as _exc:
@@ -5934,7 +5944,7 @@ def _publish_youtube(
                                     config, channel=_yt_channel),
                                 getattr(config, "slug", ""), episode_num,
                                 channel=_yt_channel, kind="short",
-                                variant=_variant.variant,
+                                variant=(_variant.variant if _ab_on else ""),
                                 placement=_funnel.PLACEMENT_COMMENT,
                             ) or (config.publishing.rss_link or "")
                             _cmt = ("\u25b6 Full episode: " + _cmt_target

--- a/scripts/build_funnel.py
+++ b/scripts/build_funnel.py
@@ -219,6 +219,13 @@ def _clicks(ga4: Optional[dict]) -> Dict[str, Any]:
         entry["sessions"] += sessions
         entry["engaged_sessions"] += engaged
 
+    # Sessions our campaign ids actually explain. Kept separate from the
+    # raw total: "totals.sessions" includes organic/(not set) rows, and
+    # presenting it as funnel clicks was the one flattering number in an
+    # otherwise honest report.
+    out["totals"]["attributed_sessions"] = (
+        out["totals"]["sessions"] - out["unattributed"]["sessions"]
+    )
     out["by_show"] = {k: dict(v) for k, v in sorted(per_show.items())}
     out["by_channel"] = {k: dict(v) for k, v in sorted(per_channel.items())}
     out["by_variant"] = {k: dict(v) for k, v in sorted(per_variant.items())}
@@ -356,12 +363,45 @@ def _pilots(show_funnels: Dict[str, Any], reach: Dict[str, Any],
             views = ch_reach.get("views")
             sessions = ((clicks.get("by_channel") or {})
                         .get(channel, {}).get("sessions"))
+            # Show sessions scoped to THIS pilot's channel: by_show[slug]
+            # sums the show's campaigns across ALL channels, so once EN
+            # spacex campaign traffic exists it would inflate the RU
+            # pilot's click-through. by_campaign rows carry the parsed
+            # show+channel, so the scoped sum costs nothing extra.
             show_sessions = ((clicks.get("by_show") or {})
                              .get(slug, {}).get("sessions"))
+            pilot_sessions = None
+            if isinstance(clicks.get("by_campaign"), dict):
+                matched = [
+                    int(row.get("sessions") or 0)
+                    for row in clicks["by_campaign"].values()
+                    if row.get("show") == slug
+                    and row.get("channel") == channel
+                ]
+                pilot_sessions = sum(matched) if matched else 0
             landed = ((visits.get("by_destination") or {})
                       .get(key, {}).get("sessions"))
             tag = cfg.get("capture_tag")
             subscribers = ((captures.get("by_list") or {}) or {}).get(tag)
+            # Windowed signup EVENTS attributable to this pilot's
+            # campaigns — same window as `landed`, so the rate compares
+            # like with like. The all-time Buttondown tag count stays in
+            # the stages block as the cumulative truth, but dividing it
+            # by a windowed session count drifts upward forever (and past
+            # 100%), so it no longer feeds a rate.
+            pilot_signups = None
+            events = captures.get("signup_events_by_campaign")
+            if isinstance(events, dict) and captures.get(
+                    "signup_events_total") is not None:
+                import engine.funnel as _F
+                total_ev = 0
+                for name, count in events.items():
+                    parsed_ev = _F.parse_campaign_id(str(name))
+                    if (parsed_ev is not None
+                            and parsed_ev.show == slug
+                            and parsed_ev.channel == channel):
+                        total_ev += int(count or 0)
+                pilot_signups = total_ev
 
             out[key] = {
                 "show": slug,
@@ -377,10 +417,13 @@ def _pilots(show_funnels: Dict[str, Any], reach: Dict[str, Any],
                 "rates": {
                     # Reach -> click is the number this pilot exists to
                     # move: how many of the people who watched came.
-                    "click_through_pct": _rate(show_sessions, views),
-                    "capture_pct": _rate(subscribers, landed),
+                    # Channel-scoped sessions over channel-scoped reach.
+                    "click_through_pct": _rate(pilot_sessions, views),
+                    # Windowed signups over windowed landings.
+                    "capture_pct": _rate(pilot_signups, landed),
                 },
                 "channel_sessions": sessions,
+                "show_sessions_all_channels": show_sessions,
             }
     return out
 
@@ -404,9 +447,21 @@ def build(window_days: int = 30) -> Dict[str, Any]:
     visits = _visits(ga4, destinations)
     captures = _captures(bd, ga4)
 
+    # Null-vs-0 rule applied precisely: only an UNMEASURED input (or a
+    # denominator below the floor) yields null — a measured zero in the
+    # NUMERATOR is a real rate of 0. The previous `x or None` on the
+    # numerators made 0% coverage (the honest launch state: campaigns
+    # exist, none parse yet) unrepresentable — it rendered as "not
+    # measured", the exact inversion the honesty rules forbid.
+    _clicks_measured = bool(clicks.get("configured"))
+    _attributed = (
+        clicks["totals"]["attributed_sessions"] if _clicks_measured else None
+    )
     network_rates = {
+        # Attributed sessions only: dividing ALL site sessions (organic
+        # included) by YouTube views flattered the funnel.
         "reach_to_click_pct": _rate(
-            clicks["totals"]["sessions"] or None,
+            _attributed,
             reach["totals"]["youtube_views"] or None),
         "visit_to_capture_pct": _rate(
             captures.get("signup_events_total"),
@@ -415,9 +470,8 @@ def build(window_days: int = 30) -> Dict[str, Any]:
         # number here means the funnel report is describing a minority of
         # reality and should be read as such.
         "attribution_coverage_pct": _rate(
-            (clicks["totals"]["sessions"]
-             - clicks["unattributed"]["sessions"]) or None,
-            clicks["totals"]["sessions"] or None),
+            _attributed,
+            clicks["totals"]["sessions"] if _clicks_measured else None),
     }
 
     return {

--- a/scripts/build_shorts_ab_report.py
+++ b/scripts/build_shorts_ab_report.py
@@ -123,20 +123,61 @@ def welch_difference(treatment: Sequence[float],
     }
 
 
+def _enabled_show_slugs() -> set:
+    """Shows that actually run the experiment (shorts_ab_enabled: true).
+
+    Read from the YAMLs rather than assumed: between 2026-07-30 and
+    2026-07-31 run_show stamped ``variant: "stills"`` on EVERY network
+    Short (plan_variants doubles as the render plan and its output was
+    recorded verbatim), so the indexes contain "control" rows from shows
+    that were never in the experiment. Filtering to enabled shows keeps
+    those contaminated rows out of the comparison — a control arm drawn
+    from other shows/channels measures the network, not the motion.
+    """
+    slugs = set()
+    for path in sorted((_ROOT / "shows").glob("*.yaml")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            import yaml
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            if (data.get("youtube") or {}).get("shorts_ab_enabled"):
+                slugs.add(data.get("slug") or path.stem)
+        except Exception as exc:  # noqa: BLE001
+            log.debug("skip %s: %s", path.name, exc)
+    return slugs
+
+
 def _collect_videos() -> List[dict]:
-    """Every analytics row that carries an experiment arm."""
+    """Every analytics row that carries an experiment arm, from
+    participating shows only."""
     stats = _ROOT / "api" / "youtube_stats.json"
     try:
         payload = json.loads(stats.read_text(encoding="utf-8"))
     except Exception as exc:  # noqa: BLE001
         log.warning("cannot read %s: %s", stats, exc)
         return []
+    enabled = _enabled_show_slugs()
     rows = []
-    for block in (payload.get("shows") or {}).values():
+    dropped = 0
+    for slug, block in (payload.get("shows") or {}).items():
         for video in (block or {}).get("videos") or []:
             variant = (video.get("variant") or "").strip()
-            if variant in (VARIANT_STILLS, VARIANT_GROK_VIDEO):
-                rows.append(video)
+            if variant not in (VARIANT_STILLS, VARIANT_GROK_VIDEO):
+                continue
+            # Fail open when the shows/ registry is unreadable (enabled
+            # is empty) — a missing registry means we cannot distinguish
+            # participants, and dropping EVERY row would silently report
+            # "collecting" forever.
+            if enabled and slug not in enabled:
+                dropped += 1
+                continue
+            rows.append(video)
+    if dropped:
+        log.info(
+            "dropped %d variant-tagged video(s) from non-participating "
+            "shows (2026-07-30/31 contamination window)", dropped,
+        )
     return rows
 
 

--- a/scripts/fetch_ga4_stats.py
+++ b/scripts/fetch_ga4_stats.py
@@ -135,7 +135,11 @@ def fetch(prop: str, days: int) -> Dict[str, Any]:
                     {"name": "engagedSessions"},
                     {"name": "userEngagementDuration"}],
         "orderBys": [{"metric": {"metricName": "sessions"}, "desc": True}],
-        "limit": 200,
+        # Rows are source x medium x campaign triples. Per-episode
+        # campaigns accrue at ~13 shows x 30 eps x channels, so a 200-row
+        # cap would silently truncate the tail within weeks — shifting
+        # totals.sessions and attribution_coverage_pct without any signal.
+        "limit": 2000,
     }))
     # Landing pages, so a funnel destination's own performance is visible
     # even for visits GA4 could not attribute to a campaign.
@@ -172,7 +176,11 @@ def fetch(prop: str, days: int) -> Dict[str, Any]:
         }))
     except Exception as exc:  # noqa: BLE001 — never fail the whole fetch
         logger.warning("GA4 conversion report unavailable: %s", exc)
-        conversions = []
+        # None, not [] — an empty list means "measured, zero conversions"
+        # and build_funnel reports it as a fact; a failed report must
+        # surface as "not measured" (null) or the funnel claims nobody
+        # converted on a day it simply couldn't read the data.
+        conversions = None
 
     totals = {
         "active_users": sum(int(r.get("activeUsers", 0)) for r in day_series),

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -2586,8 +2586,22 @@ def build_funnel_section(root: Path) -> Dict[str, Any]:
                    "YouTube views",
                    (reach.get("totals") or {}).get("podcast_downloads"),
                    "podcast downloads"),
+            # attributed_sessions, not the raw total: totals.sessions
+            # includes organic/(not set) rows, so labelling it
+            # "attributed sessions" showed a number up to 10x the truth
+            # while ALSO listing the unattributed count beside it.
+            # Fallback subtraction covers a funnel.json built before the
+            # field existed.
             _stage("click", "Click", click.get("configured"),
-                   (click.get("totals") or {}).get("sessions"),
+                   ((click.get("totals") or {}).get("attributed_sessions")
+                    if (click.get("totals") or {}).get(
+                        "attributed_sessions") is not None
+                    else (
+                        (click.get("totals") or {}).get("sessions", 0)
+                        - ((click.get("unattributed") or {})
+                           .get("sessions") or 0)
+                    ) if (click.get("totals") or {}).get("sessions")
+                    is not None else None),
                    "attributed sessions",
                    (click.get("unattributed") or {}).get("sessions"),
                    "unattributed"),
@@ -2607,7 +2621,14 @@ def build_funnel_section(root: Path) -> Dict[str, Any]:
         "by_source": capture.get("by_source") or {},
         "unmeasured": [
             name for name, block in stages.items()
+            # Capture's TOTAL is measured as soon as Buttondown answers
+            # (the stage row above shows a real number); listing it under
+            # "not yet measured" at the same time — because per-source
+            # attribution still needs the tag fetch — made the card
+            # contradict itself. Only a stage with NO number is unmeasured.
             if not (block or {}).get("configured")
+            and not (name == "capture"
+                     and (block or {}).get("total_configured"))
         ],
     })
 

--- a/scripts/run_monthly_mit_episode.py
+++ b/scripts/run_monthly_mit_episode.py
@@ -289,13 +289,20 @@ def _parse_date_safe(value: Any) -> _dt.date | None:
 def generate_monthly_podcast_script(report_md: str, config, *, month: int, year: int) -> str | None:
     """Ask the LLM to turn the monthly report markdown into a podcast script."""
     from engine.generator import _call_grok, load_prompt
+    from engine.intros import build_delivery_spec
 
     prompt_path = PROJECT_ROOT / "shows" / "prompts" / "modern_investing_monthly_podcast.txt"
+    # {delivery_spec} was added to this prompt by the 2026-07-30 retention
+    # pass, which wired the supply into engine/pipeline.py — but this
+    # script is a THIRD formatting path (neither run_show's digest stage
+    # nor run_generation_phase), so the placeholder had no supplier and
+    # load_prompt raised KeyError, killing the monthly episode.
     template = load_prompt(str(prompt_path), template_vars={
         "month_name": calendar.month_name[month],
         "year": str(year),
         "host_name": config.publishing.host_name or "Patrick",
         "report": report_md,
+        "delivery_spec": build_delivery_spec("modern_investing"),
     })
 
     model = getattr(config.llm, "synth_model", "") or config.llm.model

--- a/scripts/send_ru_spacex_weekly.py
+++ b/scripts/send_ru_spacex_weekly.py
@@ -92,7 +92,11 @@ def _tagged(url: str, placement: str) -> str:
         url,
         source=funnel.SOURCE_NEWSLETTER,
         medium=funnel.MEDIUM_EMAIL,
-        campaign="nn-spacex-ru-email-ep000",
+        # Built, not hand-written: the funnel rule (CLAUDE.md) exists
+        # because literal campaign strings drift silently when the
+        # format changes. ep000 = the weekly letter, not one episode.
+        campaign=funnel.campaign_id(
+            SHOW_SLUG, 0, channel="ru", kind="email"),
         placement=placement,
     )
 
@@ -101,7 +105,10 @@ def recent_ru_episodes(days: int = 7,
                        today: Optional[dt.date] = None) -> List[Dict]:
     """Episodes from the last *days* that have a Russian audio track."""
     today = today or dt.date.today()
-    cutoff = today - dt.timedelta(days=days)
+    # days-1: `cutoff <= when <= today` is inclusive on both ends, so a
+    # plain `days` span covered 8 calendar days and re-included last
+    # Sunday's episode in this Sunday's letter.
+    cutoff = today - dt.timedelta(days=max(0, days - 1))
     path = _ROOT / "digests" / SHOW_SLUG / f"summaries_{SHOW_SLUG}.json"
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -252,11 +259,21 @@ def build_body(episodes: List[Dict], launch: Optional[Dict],
 
 
 def _already_sent_this_week(week_ending: dt.date) -> bool:
+    """True when the marker records a send in the same ISO week.
+
+    Compared by ISO (year, week), not exact date: the marker stores the
+    date the letter went out, and a delayed cron / Monday re-dispatch
+    lands on a DIFFERENT date in the SAME week — an exact-date compare
+    would double-mail the list, which is the one unrecoverable failure
+    for a 'one letter a week' promise.
+    """
     try:
-        return SEND_MARKER.read_text(encoding="utf-8").strip() == \
-            week_ending.isoformat()
-    except OSError:
+        recorded = dt.date.fromisoformat(
+            SEND_MARKER.read_text(encoding="utf-8").strip()
+        )
+    except (OSError, ValueError):
         return False
+    return recorded.isocalendar()[:2] == week_ending.isocalendar()[:2]
 
 
 def _record_send(week_ending: dt.date) -> None:

--- a/templates/show_page_dp_pod.html.j2
+++ b/templates/show_page_dp_pod.html.j2
@@ -353,6 +353,13 @@
       <a href="{{ rss_url }}">RSS feed</a>
       <a href="{{ path_prefix }}{{ blog_page }}">Episode notes &amp; transcripts</a>
       <a href="#archive">All episodes</a>
+      {# Story Tracker: DP Pod joined the show-memory registry in July 2026
+         and thedppod-narrative.html has been generated + sitemapped since,
+         but this custom template never linked it (the button lives in the
+         generic show_page.html.j2) — the page was reachable from nowhere. #}
+      {% if narrative_page_url %}
+      <a href="{{ path_prefix }}{{ narrative_page_url }}">Progress tracker</a>
+      {% endif %}
     </div>
     <div style="margin-top:1.2rem;">{{ ai_badge(path_prefix=path_prefix) }}</div>
   </section>

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -256,11 +256,15 @@ class TestDebutRework:
         prev = hook._previous_lever_for_dispatch()
         assert prev.startswith("PREVIOUS LEVER")
         # The quoted lever body (after the colon) must be a real aired action —
-        # not a phantom heat-pump callback. The instruction preamble may still
-        # mention heat pumps as a forbidden example.
+        # not a phantom callback. NOTE: no banned-token assertions here. The
+        # original bug was an INVENTED heat-pump lever, and this test once
+        # asserted "heat-pump" never appears — until Ep024 (2026-07-31)
+        # aired a GENUINE heat-pump-assessment lever and the suite went red
+        # on legitimate data (the exact trap the comment below describes).
+        # The verbatim-from-digest check is the real, data-independent guard:
+        # a lever quoted verbatim from the cited committed digest cannot be
+        # a phantom, whatever words it uses.
         quoted = prev.split("):", 1)[-1]
-        assert "heat-pump" not in quoted.lower()
-        assert "heat pump" not in quoted.lower()
         # Data-independent reality check (the old hard-coded token list broke
         # the suite whenever a new episode's lever used different words): the
         # quoted text must come verbatim from the cited episode's committed

--- a/tests/test_shorts_ab.py
+++ b/tests/test_shorts_ab.py
@@ -372,17 +372,27 @@ class TestVideoIndexCarriesTheVariant:
 # ---------------------------------------------------------------------------
 
 class TestReport:
-    def _write_stats(self, tmp_path, videos):
+    def _write_stats(self, tmp_path, videos, extra_shows=None):
         api = tmp_path / "api"
         api.mkdir(parents=True, exist_ok=True)
-        (api / "youtube_stats.json").write_text(json.dumps(
-            {"shows": {"spacex": {"videos": videos}}}))
+        shows = {"spacex": {"videos": videos}}
+        shows.update(extra_shows or {})
+        (api / "youtube_stats.json").write_text(json.dumps({"shows": shows}))
+        # Enrollment registry: only spacex runs the experiment. Without
+        # this the report cannot tell participants from bystanders — the
+        # 2026-07-30/31 window stamped variant="stills" on every network
+        # Short, and an unfiltered report drew its control arm from the
+        # whole network.
+        shows_dir = tmp_path / "shows"
+        shows_dir.mkdir(parents=True, exist_ok=True)
+        (shows_dir / "spacex.yaml").write_text(
+            "slug: spacex\nyoutube:\n  shorts_ab_enabled: true\n")
         return api
 
-    def _build(self, tmp_path, videos):
+    def _build(self, tmp_path, videos, extra_shows=None):
         import importlib
 
-        api = self._write_stats(tmp_path, videos)
+        api = self._write_stats(tmp_path, videos, extra_shows=extra_shows)
         module = importlib.import_module("scripts.build_shorts_ab_report")
         original = module._ROOT
         module._ROOT = tmp_path
@@ -417,6 +427,25 @@ class TestReport:
         # arm with a different production era.
         assert data["arms"]["stills"]["n"] == 1
         assert data["arms"]["grok_video"]["n"] == 0
+
+    def test_non_participating_shows_never_enter_the_control_arm(
+            self, tmp_path):
+        """Between 2026-07-30 and 07-31 run_show recorded variant="stills"
+        on every network Short (plan_variants doubles as the render plan
+        and its output was recorded verbatim). Those rows must not become
+        control data: a control arm drawn from other shows/channels
+        measures the network, not the motion."""
+        tesla_short = {"show_slug": "tesla", "kind": "short",
+                       "variant": "stills", "views": 5000,
+                       "average_view_percentage": 55.0,
+                       "subscribers_gained": 3}
+        data = self._build(
+            tmp_path,
+            [self._video("stills"), self._video("grok_video")],
+            extra_shows={"tesla": {"videos": [tesla_short, tesla_short]}},
+        )
+        assert data["arms"]["stills"]["n"] == 1
+        assert data["arms"]["grok_video"]["n"] == 1
 
     def test_overlapping_arms_report_no_measurable_difference(self, tmp_path):
         from scripts.build_shorts_ab_report import MIN_PER_ARM

--- a/thedppod.html
+++ b/thedppod.html
@@ -6,11 +6,11 @@
     <meta name="description" content="Latest: Ep 24: Heat pumps now heat 46% of new U.S. homes, giving households a direct route to lower…. The DP Pod — the Do Positive Podcast with Dan and Patrick. Daily good news in science and tech plus one concrete individual action with honest numbers. Do something about it.">
     
     <meta name="keywords" content="good news, positive news, optimism, science podcast, climate solutions, individual action, mental health, mindset, do positive, dp pod">
-    <title>The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households a di… | Nerra Network</title>
+    <title>The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households… | Nerra Network</title>
     <meta name="theme-color" content="#0B7A45">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households a di… | Nerra Network">
+    <meta property="og:title" content="The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households… | Nerra Network">
     <meta property="og:description" content="Latest: Ep 24: Heat pumps now heat 46% of new U.S. homes, giving households a direct route to lower…. The DP Pod — the Do Positive Podcast with Dan and Patrick. Daily good news in science and tech plus one concrete individual action with honest numbers. Do something about it.">
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://nerranetwork.com/assets/covers/dp-pod.jpg">
@@ -19,7 +19,7 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households a di… | Nerra Network">
+    <meta name="twitter:title" content="The DP Pod: The Do Positive Podcast — Heat pumps now heat 46% of new U.S. homes, giving households… | Nerra Network">
     <meta name="twitter:description" content="Latest: Ep 24: Heat pumps now heat 46% of new U.S. homes, giving households a direct route to lower…. The DP Pod — the Do Positive Podcast with Dan and Patrick. Daily good news in science and tech plus one concrete individual action with honest numbers. Do something about it.">
     <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/dp-pod.jpg">
 
@@ -813,6 +813,10 @@
       <a href="dp_pod_podcast.rss">RSS feed</a>
       <a href="blog/dp_pod/index.html">Episode notes &amp; transcripts</a>
       <a href="#archive">All episodes</a>
+      
+      
+      <a href="thedppod-narrative.html">Progress tracker</a>
+      
     </div>
     <div style="margin-top:1.2rem;"><a href="ai-disclosure.html" class="nn-ai-badge" rel="nofollow"
    title="How we use AI — full transparency"


### PR DESCRIPTION
Continuation of #924 (merged earlier with the skip-reason and SPCX bookkeeping fixes). This lands the rest of the weekly review: every fix below is a **confirmed** defect from the July 24–31 changes, verified by running the code, with drift guards where the bug class warranted one. Also fixes the CI failure that was red on `main` this morning.

## Time-sensitive (why this PR shouldn't wait)

1. **MIT monthly recap crashes tonight at 22:00 UTC** (last trading day of July). The retention pass added `{delivery_spec}` to the monthly podcast prompt, but `scripts/run_monthly_mit_episode.py` is a *third* formatting path the July 30 KeyError fixes didn't cover — `load_prompt` raises `KeyError: 'delivery_spec'` outside the try/except and no July recap ships. Now supplied at the format site with the same builder as the live path.

2. **Shorts motion A/B control arm was being filled by the entire network.** `plan_variants` doubles as the render plan and returns `"stills"` for every show; run_show recorded it verbatim, so since 2026-07-30 every network Short (10 non-spacex rows already in the indexes) carries `variant: "stills"` and would enter the control arm with cross-show baselines ~10× apart — while GA4 campaigns gained spurious `-stills` suffixes network-wide. Fixed at the source (non-participants record no arm) **and** in the report (filters to enrolled shows, so the contaminated 07-30/31 rows can never poison a comparison; new drift guard). The $32/mo experiment now answers the question it asks.

## Audio (sounds-bad class)

- **Spoken-URL regression from #914's follow-up:** the rewrite dropped the trailing `\b` on the domain regex, so `.net` matched inside `.netlify.app` — MAB's demo links (10 committed occurrences) would ship half-converted: *"snake-awakening dot netlify dot app"* → *"snake-awakening dot netlify.app"* spoken with a literal "dot" mid-domain. Boundary restored; the promo-URL path handling is unaffected (verified against the corpus + 209 pronunciation tests).
- **Russian shows' milestone line was English:** Финансы Просто Ep100 would have opened with the Olya voice reading "That's episode one hundred…" mid-Russian intro. Localized.
- **Shorts SRT-fallback captions still grew off the top of the frame** — the July 30 cue-splitting fix covered only long-form; the windowed Shorts fallback kept the lossy wrap (at 24 chars × 2 lines, a normal Whisper segment overflowed upward into the hook overlay). Same split applied, timing shared per block.
- **Hook-failure crash guard:** the three Tesla memory placeholders had no default on the live path — the same `KeyError` class that took the network down on July 30. `setdefault`ed.

## Video (looks-bad class)

- **Ken Burns pans saturated at the image edge** for ~40% of every pan scene: the fixed 0.42→0.58 sweep exceeds the feasible centre window (±(1−1/z)/2, which is *zero* at zoom 1.0), so zoompan clamped and the "pan" rendered as an edge-anchored zoom — a milder reprise of the corner-drift defect the July 31 fix targeted. Pans now ramp from centre exactly as fast as the zoom makes room; verified feasible for every frame numerically.
- **A/B integrity in the renderer:** a "not enough clips" fallback kept its clip paths, so with `min_clips: 3` and 2 clips landed it would *record stills and ship video*; `min_clips` also floors at 2 to match the hybrid renderer (1 clip = record video, ship stills).
- **Dub-title clause trim never ran on short titles:** the 55%-of-budget floor was computed against the 70-char budget, so a 31-char FR title with a dangling "à" started below the floor and kept it. Floor now relative to the actual text length. (`"Le rover force les astronomes à"` → `"Le rover force les astronomes"`.)
- **3-Short cap now applies on the no-policy path too** — a YAML `shorts_per_episode: 10` previously flowed to run_show verbatim whenever the policy file was missing or `adaptive_publishing: false`.

## Tracking honesty (optimizing the right things)

- **The one flattering number is gone:** the dashboard's Click stage showed *total* GA4 sessions (organic included) labeled "attributed sessions" — up to 10× the truth, next to its own unattributed count — and `reach_to_click_pct` divided all site traffic by YouTube views. Both now use `attributed_sessions` (new explicit field).
- **Null-vs-0 fixed where it was inverted:** a *measured zero* numerator now reports 0%, not "not measured" — previously **0% attribution coverage (the honest launch state) was unrepresentable**. A failed GA4 conversions report now writes `null`, not `[]` ("couldn't read it" must not report as "nobody converted").
- **RU pilot rates compare like with like:** CTR is channel-scoped (EN spacex campaign traffic was about to inflate the RU pilot's number), and capture rate is windowed-signups ÷ windowed-landings (all-time ÷ windowed drifts upward forever and can pass 100%).
- **`campaign_id()`/`parse_campaign_id()` stay exact inverses:** an out-of-vocabulary `kind` now warns and coerces instead of building a campaign that parses to nothing (the "drift is SILENT" class). GA4 campaign row cap 200 → 2000 before the tail truncates.
- **RU weekly letter:** same-ISO-week double-send guard (exact-date compare would double-mail on a Monday re-dispatch), the "7-day" window no longer spans 8 days (last Sunday's episode was re-included), and the campaign string is built by `campaign_id()` per the funnel rule.

## Website / dashboard

- **Show-page `<title>`s clip through `engine/titles.py`** — the two raw slices in `generate_html.py` (which even disagreed, 67 vs 65) shipped mid-word cuts on live pages today ("…configuration na… | Nerra Network" on spacex.html). This was the repo's #1 rule; `thedppod.html` in this diff shows the before/after.
- Dashboard: Capture is no longer listed under "not yet measured" beside its own measured subscriber total; the multilingual card now renders the **per-language downloads-vs-cost rows** (the July 29 cost pass's "switch-off decision instrument" existed only in raw JSON); the YouTube policy legend reflects vpd-band Shorts counts (up to 3) instead of the retired tier-letter mapping.
- DP Pod's generated Story Tracker page (`thedppod-narrative.html`, sitemapped since July 24) was linked from nowhere — the custom template now links it.

## CI fix

`tests/test_dp_pod_show.py` was red on `main` before this branch: it hard-banned "heat-pump" in the previous-lever quote (a guard against a 2026-07 *invented* lever), and Ep024 aired a **genuine** heat-pump lever this morning. The verbatim-from-digest check is the real, data-independent guard; the token ban is removed with a comment recording why.

## ⚠️ Known items deliberately NOT fixed here (operator decisions / follow-ups)

- **SPCX audible fix** — the map is correct and the voice received "S P C X" on Ep051; the slip is in TTS rendering (transcript shows "S&P CX" vs weeks of "SPCX"). Candidates per #924: map to `"S.P.C.X."`, or drop the raw ticker from the LLM's mid-script market note. **A/B-listen required** — six weeks of clean daily output on the current form argues against a blind change.
- **`clean_digest` dead wire** (from #921): podcast-only cleaning, the Sunday week-in-review segment (landmine #19), and the duplicate-headline strip have never reached a podcast script. Wiring it is ~1 line but changes every podcast prompt's digest → **your A/B call**. Today's Tesla Ep558 thin-script skip (duplicated Giga Shanghai story ate two Top-12 slots) is a live example of what the duplicate-strip would mitigate.
- **Hybrid render failure can still mislabel the arm** (`build_short_video` swallows a failed hybrid render and ships stills while the index records `grok_video`) — needs the renderer to surface which background actually shipped; follow-up, probability = hybrid ffmpeg failure rate.
- **X teasers carry no funnel links at all** (both accounts, zero parseable campaigns — the largest untracked surface) and EN newsletters likewise; plus three legacy literal campaigns (`cross_promo`, `network_discovery`, `forward_subscribe`). Routing them through `engine/funnel.py` changes live post URLs — proposed as its own pass.
- **RU weekly cron timing**: `0 15 * * 0` runs before Sunday's multilingual track exists on cron-delay days, so the letter can silently ship 6 of 7 episodes — consider `workflow_run` on multilingual or a later slot.
- **`publish_ru_dubs` done-check** counts one uploaded Short as done under the new 3-Short band (a crash after Short #1 permanently ships 1/3). Minor, latent.
- Ep1-debut double-hook, stale internal 55s defaults in `engine/video.py` (all production callers pass explicit durations), `_TIME_BEFORE_TZ`'s digit anchor (zero live instances — monitor), ru_dub 3rd-Short cosmetics (duplicate fallback titles, single `short_error` key, thumbnail cycling with 2 scene images).
- **Funnel/dashboard JSONs**: `api/dashboard.json` predates the funnel merge, so the live funnel card shows its empty state until tonight's nightly rebuild (self-heals; re-run "Nightly maintenance" to see it sooner). `tts_speech_wrap_dropped` / `video_podcast_bytes` are recorded but not yet surfaced on any card.
- **Tesla Ep558 itself**: the skip was the floor working as designed on a stochastically-short script (first day on the cold-open prompt; digest carried a duplicated story + "1.2 million" ×5). If you want today's episode, re-run the Tesla job via workflow dispatch — nothing published today, so the duplicate guard won't block it.

## Verification

- 1,644 tests across every touched suite pass; full suite green apart from pre-existing env-dependent failures that pass once `google-api-python-client`/`yfinance` are installed (CI has them).
- `management.html` inline JS parses (`node` check); funnel builder runs end-to-end locally with honest nulls; Ken Burns feasibility verified per-frame numerically; caption cues verified bounded at 24×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_