### PR TITLE
Video enhancement pass: hook-first Shorts everywhere, render look v2, learning loop closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,6 +709,46 @@ Three connected pieces answering the July 18 audit's central finding
   → `api/shorts_ab.json` refuses to compare below 14/arm and reports a
   95% CI (Welch), not a p-value. Render/metadata-only — outside landmine #17.
 
+### Video enhancement pass — hook-first Shorts + render look v2 (July 31 2026)
+
+Operator-directed ("enhance the videos 200%+; one Short per channel is
+the starting hook sequence"). Render/metadata-only — outside landmine
+#17. Drift guards: `tests/test_video_commands.py`,
+`tests/test_captions_ass.py`, `tests/test_scene_scheduler.py`,
+`tests/test_shorts_selector.py::TestHookFirstWindows`,
+`tests/test_shorts_ab.py::TestWindowParityDeconfound`,
+`tests/test_youtube_feedback_loop.py`.
+
+- **Hook-first Shorts:** Short #1 on every channel (EN/RU/FR) starts at
+  the episode opening (= the hook since the cold-open pass); smart
+  windows fill the rest (`engine.shorts_selector.hook_first_windows`,
+  one implementation, three call sites). Every Short records
+  `window="hook_open"|"qualified"|"filled"|"legacy_fallback"` in the
+  video index → analytics, so hook-vs-smart is attributable. Config:
+  `youtube.shorts_first_is_hook` (default true; **spacex pins false
+  until the motion A/B reads out** — flipping mid-experiment would
+  confound arm with window position).
+- **Render look v2** (`RENDER_LOOK_VERSION = 2`, recorded per episode so
+  analytics segment by visual era): network color grade
+  (`_GRADE_CHAIN`: eq + vignette + gradfun, no grain) on every [bg];
+  Shorts-only `unsharp`; long-form 0-4s fading hook title (autofit,
+  h*0.42); long-form per-word ASS captions
+  (`transcript_to_ass_full`, SRT fallback, `long_form_captions_path`
+  metric); Shorts hook alpha-fade + end-card fade-in; active-word
+  `\t` pop; 8-move episode-seeded Ken Burns at 1.06/1.09/1.12
+  (CRC32-of-stem seed; `kb_extended=False` keeps byte-identical legacy
+  for A/B-enrolled shows); accelerating open (<60s slots cap holds at
+  8s); supersampled v2/v3 pills. Deliberately HELD for the A/B verdict:
+  Shorts transition split, progress bar, punch-ins, long-form ending
+  beat (in `docs/…/video_render_plan` items A2/A3/E1/D2 — re-propose
+  after `api/shorts_ab.json` reads out).
+- **Learning loop:** title hints mined per-kind (Shorts retention no
+  longer steers long-form titles) with fragment/dateline exemplars
+  banned; gallery-retention flywheel CLOSED (bounded ±10 ranking prior
+  in `gallery_library._rank` — overlap stays primary, missing report =
+  legacy order); motion-A/B window-parity de-confound (top-two windows
+  swap by episode parity on enrolled shows).
+
 ### Adaptive YouTube publishing policy (July 2026)
 
 Publish volume/format now adapts to what each channel actually watches

--- a/engine/captions.py
+++ b/engine/captions.py
@@ -412,6 +412,13 @@ def transcript_to_srt_window(
 # (R=00, G=D4, B=FF) becomes &H00FFD400.
 _HIGHLIGHT_PRIMARY_BGR = "&H00FFD400&"
 
+# Active-word "pop" (July 31 2026 — B2): alongside the colour flip, the
+# highlighted word scales to 112% over its first 80 ms via a libass
+# animated transform (``\t`` + per-glyph ``\fscx``/``\fscy`` are core
+# libass). Reads as a beat-synced pulse — the TikTok-native look — and
+# the existing ``{\r}`` reset reverts everything for the other words.
+_HIGHLIGHT_POP = r"\t(0,80,\fscx112\fscy112)"
+
 # Inline override that resets the cue's primary colour to whatever
 # ``force_style`` set as the default (white in
 # ``_SHORTS_SUBTITLES_FORCE_STYLE``). ``\r`` without an argument reverts
@@ -459,6 +466,32 @@ YCbCr Matrix: TV.709
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Default,DejaVu Sans,48,&H00FFFFFF,&H00FFFFFF,&H00000000,&H80000000,-1,0,0,0,100,100,0,0,3,3,0,2,40,40,340,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+
+# Long-form (1920x1080) per-word header (July 31 2026 — B1). Mirrors the
+# long-form burn-in look pinned by ``engine.video._SUBTITLES_FORCE_STYLE``
+# (FontSize=26 in libass's 288-unit SRT space ≈ 98 real pixels on a 1080p
+# frame): white text, BorderStyle=1 outline 3 + shadow 1 (no card — the
+# slideshow imagery stays visible behind the words), Alignment=2 bottom-
+# centre, MarginV=50. Because this file declares PlayResX/Y 1920x1080,
+# every value here is in REAL pixels, so Fontsize is 98, not 26 — and the
+# render path deliberately does NOT apply the 288-unit ``force_style`` to
+# ``.ass`` inputs (see ``engine.video._long_form_subtitles_stage``).
+_ASS_HEADER_LONG_FORM = """[Script Info]
+ScriptType: v4.00+
+PlayResX: 1920
+PlayResY: 1080
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+YCbCr Matrix: TV.709
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,DejaVu Sans,98,&H00FFFFFF,&H00FFFFFF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,3,1,2,60,60,50,1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
@@ -550,7 +583,10 @@ def _render_chunk_dialogues(
         for j, t in enumerate(tokens):
             esc = _ass_escape(t)
             if j == idx:
-                parts.append(f"{{\\1c{_HIGHLIGHT_PRIMARY_BGR}}}{esc}{_HIGHLIGHT_RESET}")
+                parts.append(
+                    f"{{\\1c{_HIGHLIGHT_PRIMARY_BGR}{_HIGHLIGHT_POP}}}"
+                    f"{esc}{_HIGHLIGHT_RESET}"
+                )
             else:
                 parts.append(esc)
         cue_text = " ".join(parts)
@@ -681,6 +717,112 @@ def transcript_to_ass_window(
             "Wrote %d per-word Shorts caption events → %s (window=[%.1fs, %.1fs])",
             len(dialogue_lines), ass_path.name,
             window_start_seconds, window_end,
+        )
+    return ass_path
+
+
+def transcript_to_ass_full(
+    transcript_path: Path,
+    ass_path: Path,
+    *,
+    audio_offset_seconds: float = 0.0,
+    wrap_max_chars: int = 42,
+    max_words_per_chunk: int = 10,
+) -> Path:
+    """Emit a FULL-EPISODE per-word ASS caption file for the long-form
+    video (July 31 2026 — B1).
+
+    The full-frame sibling of :func:`transcript_to_ass_window`: no
+    window, no rebasing — every word of the episode gets a Dialogue
+    line on the final-audio timeline (``audio_offset_seconds`` shifts
+    the voice-only Whisper timestamps past any music intro, same
+    contract as the SRT path). Chunk budget is wider (~42 chars /
+    ≤10 words) because the 1920-wide frame fits more text per line
+    than the 1080-wide Shorts frame at the ~98 px long-form size.
+
+    The style block is the long-form look in REAL pixels (PlayRes
+    1920x1080, Fontsize 98, BorderStyle=1 outline — see
+    ``_ASS_HEADER_LONG_FORM``); the render path lets the file
+    self-style rather than forcing the 288-unit SRT style onto it.
+
+    A transcript without word-level data writes only the header —
+    the caller treats a Dialogue-less file the same way the Shorts
+    path does (fall back to the segment-level SRT).
+    """
+    if audio_offset_seconds < 0:
+        raise ValueError(
+            f"audio_offset_seconds must be >= 0, got {audio_offset_seconds}"
+        )
+
+    try:
+        data = json.loads(transcript_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.error("Transcript not found: %s", transcript_path)
+        raise
+    except json.JSONDecodeError as exc:
+        logger.error("Transcript JSON malformed (%s): %s", transcript_path, exc)
+        raise
+
+    segments = data.get("segments", []) if isinstance(data, dict) else []
+
+    # The "window" is the whole episode: end = transcript duration (or
+    # the last word/segment end when the header field is missing),
+    # shifted by the music-intro offset, with slack for rounding.
+    total = 0.0
+    try:
+        total = float(data.get("duration") or 0.0)
+    except (TypeError, ValueError):
+        total = 0.0
+    if total <= 0:
+        for seg in segments:
+            if isinstance(seg, dict):
+                try:
+                    total = max(total, float(seg.get("end") or 0.0))
+                except (TypeError, ValueError):
+                    continue
+    window_end = total + audio_offset_seconds + 5.0 if total > 0 else 1e7
+
+    dialogue_lines: List[str] = []
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        words = [w for w in (seg.get("words") or []) if isinstance(w, dict)]
+        if not words:
+            continue
+        for chunk in _chunk_words(
+            words,
+            max_chars=wrap_max_chars,
+            max_words_per_chunk=max_words_per_chunk,
+        ):
+            dialogue_lines.extend(
+                _render_chunk_dialogues(
+                    chunk,
+                    window_start=0.0,
+                    window_end=window_end,
+                    audio_offset=audio_offset_seconds,
+                )
+            )
+
+    body = (_ASS_HEADER_LONG_FORM + "\n".join(dialogue_lines)
+            + ("\n" if dialogue_lines else ""))
+    try:
+        ass_path.parent.mkdir(parents=True, exist_ok=True)
+        ass_path.write_text(body, encoding="utf-8")
+    except OSError as exc:
+        logger.error(
+            "Failed to write long-form ASS to %s (%s): %s",
+            ass_path, type(exc).__name__, exc,
+        )
+        raise
+    if not dialogue_lines:
+        logger.info(
+            "Transcript %s carries no word-level data — long-form ASS "
+            "written empty (caller falls back to SRT)", transcript_path,
+        )
+    else:
+        logger.info(
+            "Wrote %d per-word long-form caption events → %s",
+            len(dialogue_lines), ass_path.name,
         )
     return ass_path
 

--- a/engine/config.py
+++ b/engine/config.py
@@ -611,6 +611,16 @@ class YouTubeConfig:
     # instead of shipping fewer Shorts. The requested count is a policy
     # decision; before this, FF shipped 1-of-2 on every July episode.
     shorts_fill_to_requested: bool = True
+    # July 31 2026 (operator directive): the FIRST Short on every channel
+    # is the episode's opening hook sequence (since the July-30 cold-open
+    # pass, t~=0 IS the hook — the strongest editorially-chosen beat).
+    # Remaining Shorts keep the smart selector's windows. The hook Short
+    # is labeled window="hook" in the video index so the analytics loop
+    # can compare it against smart windows. False = pre-directive
+    # behavior (spacex pins false until the Shorts motion A/B reads out —
+    # flipping it mid-experiment would confound arm position with window
+    # choice).
+    shorts_first_is_hook: bool = True
     # ``always`` | ``alternate_episodes`` — skip Shorts on odd episode
     # numbers to halve upload quota during phased rollout.
     shorts_upload_schedule: str = "always"

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -145,18 +145,77 @@ def _candidate_entries(
     return out
 
 
-def _rank(entries: List[dict], context_text: str) -> List[dict]:
+_RETENTION_PRIOR_PATH = Path(__file__).resolve().parent.parent / "api" / "gallery_retention.json"
+_RETENTION_PRIOR_CACHE: dict = {}
+
+
+def _retention_tag_scores(show_slug: str) -> dict:
+    """Per-tag mean-retention map for one show, from the nightly
+    ``api/gallery_retention.json`` flywheel report.
+
+    July 31 2026: the flywheel had been a DEAD END — the report was built
+    nightly since June and consumed only by a dashboard card, while scene
+    ranking stayed pure token-overlap + recency. This closes the loop:
+    tags that measurably held viewers get a bounded ranking nudge.
+    Fail-open: missing file/show → {} → ranking identical to legacy.
+    Cached per process (the manifest loader already sets that precedent).
+    """
+    if show_slug in _RETENTION_PRIOR_CACHE:
+        return _RETENTION_PRIOR_CACHE[show_slug]
+    scores: dict = {}
+    try:
+        import json as _json
+        data = _json.loads(_RETENTION_PRIOR_PATH.read_text(encoding="utf-8"))
+        summary = ((data.get("shows") or {}).get(show_slug) or {}).get(
+            "summary") or {}
+        rows = list(summary.get("top_tags") or []) + list(
+            summary.get("bottom_tags") or [])
+        vals = [float(r.get("mean_retention") or 0.0) for r in rows]
+        if rows and vals:
+            mid = sorted(vals)[len(vals) // 2]
+            for r in rows:
+                tag = str(r.get("tag") or "").strip().lower()
+                if tag:
+                    scores[tag] = float(r.get("mean_retention") or 0.0) - mid
+    except Exception:  # noqa: BLE001 — the prior is a nudge, never a gate
+        scores = {}
+    _RETENTION_PRIOR_CACHE[show_slug] = scores
+    return scores
+
+
+def _retention_score(entry: dict, tag_scores: dict) -> float:
+    """Mean centered-retention of the entry's known tags, clipped to
+    ±10 points so the prior can shuffle near-ties but never outrank a
+    real context-overlap difference (overlap stays the primary key)."""
+    if not tag_scores:
+        return 0.0
+    vals = [tag_scores[t] for t in
+            (str(x).strip().lower() for x in entry.get("tags") or [])
+            if t in tag_scores]
+    if not vals:
+        return 0.0
+    return max(-10.0, min(10.0, sum(vals) / len(vals)))
+
+
+def _rank(entries: List[dict], context_text: str,
+          show_slug: str = "") -> List[dict]:
     """Deterministic best-first ordering.
 
-    Primary: token overlap with the context. Ties: newer ``episode_date``
-    first, then ``image_id`` — so identical inputs always yield identical
-    output regardless of manifest document order. Implemented as three
-    stable sorts (least- to most-significant key); Python's sort is stable
-    even with ``reverse=True``.
+    Primary: token overlap with the context. Secondary (July 31 2026):
+    the bounded retention prior — among equal-overlap candidates, images
+    whose tags historically held viewers rank first. Ties after that:
+    newer ``episode_date`` first, then ``image_id`` — so identical inputs
+    always yield identical output regardless of manifest document order.
+    Implemented as stable sorts (least- to most-significant key);
+    Python's sort is stable even with ``reverse=True``.
     """
     ctx = _tokenize(context_text)
+    tag_scores = _retention_tag_scores(show_slug) if show_slug else {}
     ranked = sorted(entries, key=lambda e: e.get("image_id") or "")
     ranked.sort(key=lambda e: e.get("episode_date") or "", reverse=True)
+    if tag_scores:
+        ranked.sort(key=lambda e: _retention_score(e, tag_scores),
+                    reverse=True)
     if ctx:
         ranked.sort(key=lambda e: len(ctx & _entry_tokens(e)), reverse=True)
     return ranked
@@ -367,7 +426,7 @@ def select_library_scenes(
         paths: List[Path] = []
         failures: List[str] = []
         consecutive_failures = 0
-        for entry in _rank(entries, context_text):
+        for entry in _rank(entries, context_text, show_slug):
             if len(paths) >= limit:
                 break
             if consecutive_failures >= _MAX_CONSECUTIVE_DOWNLOAD_FAILURES:

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -498,12 +498,27 @@ def publish_lang_dub(
                                "(%s) — voice-start short without captions",
                                lang.code, exc)
 
+            # Hook-first (July 31 2026 operator directive, all channels):
+            # Short #1 is the dub's opening hook sequence — same rule as
+            # the EN + RU paths (the dub track translates the same
+            # cold-open script, so t~=0 is the hook here too).
+            if bool(getattr(yt, "shorts_first_is_hook", True)):
+                from engine.shorts_selector import hook_first_windows
+                windows = hook_first_windows(
+                    list(windows or []), n=max(1, n_shorts),
+                    hook_start=base_offset, window_duration=short_dur,
+                )
+
             if windows:
-                short_plan = [(w.start_seconds,
-                               (w.opening_text or "").strip())
-                              for w in windows[:n_shorts]]
+                short_plan = [
+                    (w.start_seconds, (w.opening_text or "").strip(),
+                     ("hook_open" if w.score == float("inf")
+                      else "qualified" if getattr(w, "qualified", True)
+                      else "filled"))
+                    for w in windows[:n_shorts]
+                ]
             else:
-                short_plan = [(base_offset, "")]
+                short_plan = [(base_offset, "", "legacy_fallback")]
 
             end_card_png = None
             try:
@@ -521,8 +536,8 @@ def publish_lang_dub(
                                lang.code, exc)
 
             short_urls_out: List[str] = []
-            for short_idx, (start_offset, opening_text) in enumerate(
-                    short_plan):
+            for short_idx, (start_offset, opening_text,
+                            window_label) in enumerate(short_plan):
                 try:
                     suffix = "" if short_idx == 0 else f"_{short_idx + 1}"
                     short_mp4 = (tmp / f"{lang.code}_short_ep"
@@ -600,7 +615,8 @@ def publish_lang_dub(
                         episode=episode_num, kind="short", title=st,
                         hook=title, published=date_str,
                         watch_url=sup.watch_url,
-                        channel=lang.channel, index_path=idx_path)
+                        channel=lang.channel, window=window_label,
+                        index_path=idx_path)
                     if playlist:
                         try:
                             add_video_to_playlist(credentials=creds,

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -243,6 +243,16 @@ def record_youtube_outcomes(
         # episode's imagery was fresh vs recycled from the gallery.
         if youtube_urls.get("visual_mode"):
             metrics.record("visual_mode", str(youtube_urls["visual_mode"]))
+        # Visual-era counter (July 31 2026 render pass) — segments
+        # retention analytics by render look, alongside visual_mode.
+        if youtube_urls.get("render_look_version") is not None:
+            metrics.record("render_look_version",
+                           int(youtube_urls["render_look_version"]))
+        # Long-form burn-in caption mode (per-word ASS vs SRT fallback);
+        # present only when youtube.long_form_burn_in_captions is on.
+        if youtube_urls.get("long_form_captions_path"):
+            metrics.record("long_form_captions_path",
+                           str(youtube_urls["long_form_captions_path"]))
         if "scene_fresh_count" in youtube_urls:
             metrics.record("scene_fresh_count", int(youtube_urls.get("scene_fresh_count", 0) or 0))
         if "scene_library_count" in youtube_urls:

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -698,13 +698,29 @@ def publish_ru_dub(
                 logger.warning("ru_dub: RU transcript/selection failed (%s) — "
                                "voice-start short without captions", exc)
 
-            # Plan: (offset, opening_text) per Short; legacy single
-            # voice-start fallback when the selector yields nothing.
+            # Hook-first (July 31 2026 operator directive, all channels):
+            # Short #1 is the dub's opening hook sequence — the RU/FR
+            # track translates the same cold-open script, so t~=0 is the
+            # hook there too. Smart windows fill the remaining slots.
+            if bool(getattr(yt, "shorts_first_is_hook", True)):
+                from engine.shorts_selector import hook_first_windows
+                windows = hook_first_windows(
+                    list(windows or []), n=max(1, ru_shorts),
+                    hook_start=base_offset, window_duration=short_dur,
+                )
+
+            # Plan: (offset, opening_text, window_label) per Short; legacy
+            # single voice-start fallback when the selector yields nothing.
             if windows:
-                short_plan = [(w.start_seconds, (w.opening_text or "").strip())
-                              for w in windows[:ru_shorts]]
+                short_plan = [
+                    (w.start_seconds, (w.opening_text or "").strip(),
+                     ("hook_open" if w.score == float("inf")
+                      else "qualified" if getattr(w, "qualified", True)
+                      else "filled"))
+                    for w in windows[:ru_shorts]
+                ]
             else:
-                short_plan = [(base_offset, "")]
+                short_plan = [(base_offset, "", "legacy_fallback")]
 
             # End-card CTA (Russian) — shared across Shorts; reuse the RU
             # long-form thumbnail.
@@ -722,7 +738,8 @@ def publish_ru_dub(
                 logger.warning("ru_dub: end-card render failed (%s)", exc)
 
             short_urls_out: list = []
-            for short_idx, (start_offset, opening_text) in enumerate(short_plan):
+            for short_idx, (start_offset, opening_text,
+                            window_label) in enumerate(short_plan):
                 try:
                     suffix = "" if short_idx == 0 else f"_{short_idx + 1}"
                     short_mp4 = tmp / f"ru_short_ep{episode_num:03d}{suffix}.mp4"
@@ -844,6 +861,7 @@ def publish_ru_dub(
                         hook=ru_title, published=date_str,
                         watch_url=sup.watch_url,
                         channel="ru",
+                        window=window_label,
                         index_path=PROJECT_ROOT / config.episode.output_dir
                         / "youtube_videos.ru.json")
                     pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()

--- a/engine/scene_scheduler.py
+++ b/engine/scene_scheduler.py
@@ -72,6 +72,15 @@ _SENTENCE_END_CHARS = (".", "!", "?")
 # sub-second "chapters" would produce unwatchable flicker.
 _MIN_CHAPTER_GAP_S = 1.0
 
+# Accelerating open (July 31 2026 — D1): chapter windows starting inside
+# the first minute subdivide with a tighter max hold, so the opening —
+# where long-form retention is decided (10.7% EN median, 18-85 s average
+# view duration) — gets ~2x the scene-change rate before the plan
+# settles into the normal [min_hold_s, max_hold_s] cruise. Slot count
+# stays bounded by _MAX_SLIDESHOW_SLOTS via the existing cap merge.
+_OPEN_FAST_WINDOW_S = 60.0
+_OPEN_MAX_HOLD_S = 8.0
+
 # Hard cap on ffmpeg slideshow inputs. The xfade+zoompan filter graph
 # scales poorly past ~30–40 scenes; Tesla Ep537 (1044 s @ 15 s hold →
 # 74 slots, only 4 unique images after gallery CDN 403s) timed out the
@@ -304,7 +313,14 @@ def plan_chapter_schedule(
     last_pick: Optional[Path] = None
     for start, end, title in windows:
         title_tokens = _tokenize(title)
-        for slot_duration in _subdivide(end - start, max_hold_s, min_hold_s):
+        # Accelerating open (D1): windows starting inside the first
+        # minute subdivide with the tighter opening max hold, so slots
+        # starting < ~60 s never hold longer than _OPEN_MAX_HOLD_S.
+        effective_max = (
+            min(max_hold_s, _OPEN_MAX_HOLD_S)
+            if start < _OPEN_FAST_WINDOW_S else max_hold_s
+        )
+        for slot_duration in _subdivide(end - start, effective_max, min_hold_s):
             pick = _pick_scene(
                 pool, fresh, context, title_tokens, use_counts, last_pick,
             )

--- a/engine/shorts_selector.py
+++ b/engine/shorts_selector.py
@@ -508,3 +508,48 @@ def _overlaps_any(
         ):
             return True
     return False
+
+
+def hook_first_windows(
+    windows: List[ScoredWindow],
+    *,
+    n: int,
+    hook_start: float,
+    window_duration: float = 35.0,
+    hook_text: str = "",
+    min_gap_seconds: float = 10.0,
+) -> List[ScoredWindow]:
+    """Make the episode's OPENING the first window; smart windows follow.
+
+    July 31 2026 (operator directive): one Short per channel is the
+    episode's "starting hook sequence". Since the July-30 retention pass
+    every episode opens on its hook (cold open at t~=0, median long-form
+    retention 10.7% vs ~42% on Shorts that skip housekeeping), so the
+    first ``window_duration`` seconds ARE the hook sequence — the single
+    strongest, editorially-chosen beat of the episode. The hook window
+    ships FIRST on every channel; the remaining slots keep the smart
+    selector's top windows, minus any that overlap the opening.
+
+    The hook window carries ``qualified=True`` and ``score=inf`` — it is
+    a policy decision, not a scored candidate — and its opening_text is
+    the episode hook so titles/thumbnails describe it correctly.
+
+    Returns a NEW list, never mutates the input. ``n <= 0`` returns [].
+    """
+    if n <= 0:
+        return []
+    hook_window = ScoredWindow(
+        start_seconds=max(0.0, float(hook_start)),
+        end_seconds=max(0.0, float(hook_start)) + float(window_duration),
+        score=float("inf"),
+        opening_text=(hook_text or "").strip(),
+        qualified=True,
+    )
+    kept: List[ScoredWindow] = [hook_window]
+    for w in windows:
+        if len(kept) >= n:
+            break
+        if _overlaps_any(w, [hook_window], min_gap_seconds):
+            continue
+        kept.append(w)
+    return kept[:n]

--- a/engine/video.py
+++ b/engine/video.py
@@ -37,10 +37,18 @@ import logging
 import math
 import os
 import subprocess
+import zlib
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
+
+# Visual-era counter (July 31 2026 render pass). Bumped whenever the
+# shipped look changes materially (grade chain, KB vocabulary, caption
+# treatment, hook titles) so analytics can segment retention by visual
+# era. Recorded as the ``render_look_version`` metric alongside
+# ``visual_mode`` in run_show.
+RENDER_LOOK_VERSION = 2
 
 
 def _run_ffmpeg(cmd: List[str], *, label: str) -> None:
@@ -360,6 +368,14 @@ _BRAND_PILL_TEXT = "Nerra Network"
 _NETWORK_URL_PILL_TEXT = "nerranetwork.com"
 
 
+# Nerra cyan (#00D4FF) — the caption-highlight accent colour, reused
+# as a 2 px left-edge accent inside the pill for brand cohesion.
+_PILL_ACCENT_RGBA = (0, 212, 255, 235)
+# Width of the visible accent strip at DELIVERY size (px). Rendered at
+# 2x supersample, so the internal clip is twice this.
+_PILL_ACCENT_WIDTH = 6
+
+
 def _make_brand_pill(output_path: Path,
                      *, text: str = _BRAND_PILL_TEXT,
                      width: int = 220, height: int = 60) -> Path:
@@ -370,6 +386,13 @@ def _make_brand_pill(output_path: Path,
     margin). Show names up to ~30 chars fit comfortably at the
     default 220 × 60; longer names get the smaller font, still
     legible against the cover background.
+
+    July 31 2026 (B5): rendered at 2x and LANCZOS-downscaled for
+    supersampled text edges, plus a 2 px Nerra-cyan left-edge accent
+    inside the rounded rect. The cache is path-keyed, so the version
+    lives in the FILENAMES the builders use (``_show_pill_v2_*`` /
+    ``_url_pill_v2`` / ``_brand_pill_v3``) — a persistent work dir
+    regenerates rather than reusing a stale 1x pill.
     """
     if output_path.exists():
         return output_path
@@ -377,28 +400,44 @@ def _make_brand_pill(output_path: Path,
 
     from PIL import Image, ImageDraw, ImageFont
 
-    img = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    # 2x supersample: every geometry/font value below is doubled, then
+    # the finished pill is LANCZOS-downscaled to the requested size.
+    w2, h2 = width * 2, height * 2
+    img = Image.new("RGBA", (w2, h2), (0, 0, 0, 0))
     draw = ImageDraw.Draw(img)
 
-    radius = height // 2
+    radius = h2 // 2
     draw.rounded_rectangle(
-        [(0, 0), (width - 1, height - 1)],
+        [(0, 0), (w2 - 1, h2 - 1)],
         radius=radius,
         fill=(0, 0, 0, 140),
     )
+
+    # Cyan left-edge accent: a rounded rect with the same geometry,
+    # clipped to the leftmost strip so only the leading edge shows.
+    accent = Image.new("RGBA", (w2, h2), (0, 0, 0, 0))
+    ImageDraw.Draw(accent).rounded_rectangle(
+        [(0, 0), (w2 - 1, h2 - 1)],
+        radius=radius,
+        fill=_PILL_ACCENT_RGBA,
+    )
+    accent_strip = accent.crop((0, 0, _PILL_ACCENT_WIDTH * 2, h2))
+    img.alpha_composite(accent_strip, (0, 0))
 
     font_path = _find_font()
     font = None
     # Wider top range than legacy (was 22 → 12) to accommodate longer
     # show names that previously got clamped to the smallest font even
-    # when more horizontal room was available.
-    for size in range(28, 11, -1):
+    # when more horizontal room was available. Doubled for the 2x
+    # canvas (56 → 24 ≙ 28 → 12 at delivery size), stepping by 2 so
+    # the delivery-size ladder is unchanged.
+    for size in range(56, 23, -2):
         try:
             candidate = ImageFont.truetype(font_path, size)
         except (IOError, OSError):
             continue
         bbox = candidate.getbbox(text)
-        if bbox[2] - bbox[0] <= width - 32:
+        if bbox[2] - bbox[0] <= w2 - 64:
             font = candidate
             break
     if font is None:
@@ -407,10 +446,11 @@ def _make_brand_pill(output_path: Path,
     bbox = font.getbbox(text)
     text_w = bbox[2] - bbox[0]
     text_h = bbox[3] - bbox[1]
-    x = (width - text_w) // 2 - bbox[0]
-    y = (height - text_h) // 2 - bbox[1]
+    x = (w2 - text_w) // 2 - bbox[0]
+    y = (h2 - text_h) // 2 - bbox[1]
     draw.text((x, y), text, font=font, fill=(255, 255, 255, 235))
 
+    img = img.resize((width, height), Image.LANCZOS)
     img.save(output_path, "PNG")
     return output_path
 
@@ -493,6 +533,40 @@ _PRESCALE = 2.0
 _ZOOM_MAX = 1.09
 
 # ---------------------------------------------------------------------------
+# Network color grade (July 31 2026 render pass — C1)
+# ---------------------------------------------------------------------------
+# One gentle chain applied wherever the composite forms its ``[bg]``
+# (long-form both branches, Shorts, and the fused single-pass graph) so
+# every Grok Imagine scene on the network shares a unified, produced
+# look instead of shipping raw flat pixels:
+#
+#   * ``eq``       — gentle contrast/saturation lift + tiny gamma dip;
+#     Grok stills ship flat.
+#   * ``vignette`` — soft default vignette (angle=PI/5): depth + an
+#     eye-to-center pull that unifies mismatched scenes.
+#   * ``gradfun``  — de-bands the gradient skies that slow Ken Burns
+#     zooms make shimmer.
+#
+# Deliberately NO ``noise`` grain: grain fights the encoder (the 4 Mbps
+# ``-maxrate`` ceiling in ``_VIDEO_ENCODE`` exists precisely for
+# near-noise pathologies). The chain is applied ONCE per delivered
+# pixel — at composite/[bg] time, never inside the stage-1 slideshow —
+# so the two-stage path cannot double-grade.
+_GRADE_CHAIN = (
+    "eq=contrast=1.05:saturation=1.08:gamma=0.98,"
+    "vignette=angle=PI/5,"
+    "gradfun=3.5:8"
+)
+
+# Shorts-only output sharpen (C2). The 9:16 Grok sources come back
+# below delivery resolution, so every vertical pixel shipped is an
+# upsample; lanczos preserves detail but a mild luma-only unsharp
+# restores perceived crispness on phone screens. Amount stays at 0.5 —
+# halos appear above ~0.8. Long-form skips this (the 2.0 prescale +
+# lanczos was measured as the knee there).
+_SHORTS_SHARPEN = "unsharp=5:5:0.5:5:5:0.0"
+
+# ---------------------------------------------------------------------------
 # Ken Burns (July 30 2026 motion pass — measured, not guessed)
 # ---------------------------------------------------------------------------
 # Three defects were found by rendering the shipping filter graph at
@@ -539,7 +613,35 @@ _ZOOM_MAX = 1.09
 # Gentle, deterministic move per scene index — varied enough not to feel
 # mechanical, never so much that it draws attention to itself. Index, not
 # randomness, so a re-render of the same episode is identical.
-_KB_MOVES = ("in_centre", "out_centre", "in_pan_x", "out_pan_y")
+#
+# July 31 2026 (A1): widened from 4 to 8 moves. The FIRST FOUR entries
+# are the legacy vocabulary in the legacy order — the Shorts motion A/B
+# control arm renders with ``extended=False`` which indexes only into
+# that prefix, so the ordering here is load-bearing. The new moves
+# reuse the same feasible-window travel math; the diagonals ramp BOTH
+# cx and cy (each axis is independently bounded, so feasibility holds).
+_KB_MOVES = ("in_centre", "out_centre", "in_pan_x", "out_pan_y",
+             "in_pan_y", "out_pan_x", "in_pan_xy", "out_pan_xy")
+# How many of the leading moves make up the legacy (pre-A1) vocabulary.
+_KB_LEGACY_MOVE_COUNT = 4
+
+# Per-slot zoom amplitude alternation (A1) — rhythm without randomness.
+# 1.12 was the pre-July-2026 network value, so sharpness at that
+# ceiling is a known-acceptable quantity; 1.06 is a calmer breath
+# between the stronger pushes. The legacy path stays pinned at
+# ``_ZOOM_MAX`` (1.09).
+_KB_ZOOM_AMPLITUDES = (1.06, 1.09, 1.12)
+
+
+def _kb_seed_from_stem(stem) -> int:
+    """Deterministic per-episode Ken Burns seed from an output filename.
+
+    CRC32 of the stem — stable across processes and re-renders of the
+    same episode (unlike ``hash()``, which is salted per interpreter),
+    varied across episodes/files, and no date/random involvement so a
+    re-render is byte-identical.
+    """
+    return zlib.crc32(str(stem).encode("utf-8")) & 0xFFFFFFFF
 
 
 def _ken_burns(frames: int, move: str, *,
@@ -571,11 +673,26 @@ def _ken_burns(frames: int, move: str, *,
     # zoom makes room: in-pans start centred and drift as they tighten,
     # out-pans return to centre as they widen, and the requested centre
     # stays inside the feasible window for every frame.
-    travel = round((1.0 - 1.0 / zoom_max) / 2.0, 6)
+    # FLOOR to 6 decimals (not round): rounding up by half an ulp can
+    # push the requested centre a hair past the feasible window at
+    # p=1, where zoompan clamps — flooring keeps every frame strictly
+    # inside. (The legacy 1.09 value is identical either way, so the
+    # A/B control arm's graph is unchanged.)
+    travel = math.floor(((1.0 - 1.0 / zoom_max) / 2.0) * 1e6) / 1e6
+    ramp_in = f"(0.5+{travel}*{p})"          # centre → offset as zoom tightens
+    ramp_out = f"(0.5+{travel}-{travel}*{p})"  # offset → centre as zoom widens
     if move == "in_pan_x":
-        cx, cy = f"(0.5+{travel}*{p})", "0.5"
+        cx, cy = ramp_in, "0.5"
     elif move == "out_pan_y":
-        cx, cy = "0.5", f"(0.5+{travel}-{travel}*{p})"
+        cx, cy = "0.5", ramp_out
+    elif move == "in_pan_y":
+        cx, cy = "0.5", ramp_in
+    elif move == "out_pan_x":
+        cx, cy = ramp_out, "0.5"
+    elif move == "in_pan_xy":
+        cx, cy = ramp_in, ramp_in
+    elif move == "out_pan_xy":
+        cx, cy = ramp_out, ramp_out
     else:
         cx, cy = "0.5", "0.5"
 
@@ -587,10 +704,28 @@ def _ken_burns(frames: int, move: str, *,
 def _ken_burns_chain(src: str, out_label: str, *, frames: int, index: int,
                      width: int, height: int, fps: int,
                      prescale: float = _PRESCALE,
-                     trim_seconds: Optional[float] = None) -> str:
-    """The full scale -> crop -> zoompan chain for one still."""
+                     trim_seconds: Optional[float] = None,
+                     kb_seed: int = 0,
+                     kb_extended: bool = True) -> str:
+    """The full scale -> crop -> zoompan chain for one still.
+
+    ``kb_extended=True`` (July 31 2026, A1) uses the widened 8-move
+    vocabulary offset by ``kb_seed`` (per-episode, derived from the
+    output filename stem) and alternates the zoom amplitude per slot
+    (1.06 / 1.09 / 1.12). ``kb_extended=False`` reproduces the legacy
+    behaviour byte-for-byte — first 4 moves in index order at
+    ``_ZOOM_MAX``, seed ignored — which the Shorts motion A/B control
+    arm depends on (upgrading the control mid-flight would bias the
+    experiment).
+    """
     pre_w, pre_h = int(width * prescale), int(height * prescale)
-    z, x, y = _ken_burns(frames, _KB_MOVES[index % len(_KB_MOVES)])
+    if kb_extended:
+        move = _KB_MOVES[(index + kb_seed) % len(_KB_MOVES)]
+        zoom_max = _KB_ZOOM_AMPLITUDES[(index + kb_seed) % len(_KB_ZOOM_AMPLITUDES)]
+    else:
+        move = _KB_MOVES[index % _KB_LEGACY_MOVE_COUNT]
+        zoom_max = _ZOOM_MAX
+    z, x, y = _ken_burns(frames, move, zoom_max=zoom_max)
     chain = (
         f"{src}"
         f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase"
@@ -614,7 +749,9 @@ def _slideshow_filter_graph(scene_count: int, *,
                             scene_durations: Optional[Sequence[float]] = None,
                             width: int = 1920, height: int = 1080,
                             fps: int = 30,
-                            crossfade: float = _SLIDESHOW_XFADE_S) -> str:
+                            crossfade: float = _SLIDESHOW_XFADE_S,
+                            kb_seed: int = 0,
+                            kb_extended: bool = True) -> str:
     """Build the filter_complex for a Ken Burns slideshow.
 
     Each scene gets a 1.00 → 1.12 zoom over its window. When *crossfade* > 0
@@ -660,6 +797,7 @@ def _slideshow_filter_graph(scene_count: int, *,
             frames=frames_per_scene, index=i,
             width=width, height=height, fps=fps,
             trim_seconds=clip_len,
+            kb_seed=kb_seed, kb_extended=kb_extended,
         ))
 
     if not use_xfade:
@@ -689,7 +827,9 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                    scene_durations: Optional[Sequence[float]] = None,
                    width: int = 1920, height: int = 1080,
                    fps: int = 30,
-                   crossfade: float = _SLIDESHOW_XFADE_S) -> List[str]:
+                   crossfade: float = _SLIDESHOW_XFADE_S,
+                   kb_seed: int = 0,
+                   kb_extended: bool = True) -> List[str]:
     """ffmpeg command for stage 1 (slideshow render).
 
     *width* and *height* default to 1920x1080 for the long-form path;
@@ -724,7 +864,8 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                                 scene_duration=scene_duration,
                                 scene_durations=scene_durations,
                                 width=width, height=height, fps=fps,
-                                crossfade=crossfade),
+                                crossfade=crossfade,
+                                kb_seed=kb_seed, kb_extended=kb_extended),
         "-map", "[v]",
         "-r", str(fps),
         *_VIDEO_ENCODE_FAST,
@@ -738,7 +879,9 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                       *, scene_duration: float = _SCENE_DURATION_SECONDS,
                       scene_durations: Optional[Sequence[float]] = None,
                       width: int = 1920, height: int = 1080,
-                      fps: int = 30) -> Path:
+                      fps: int = 30,
+                      kb_seed: int = 0,
+                      kb_extended: bool = True) -> Path:
     """Render the stage-1 slideshow MP4. Idempotent (skips if output exists).
 
     Tries the crossfade graph first; if ffmpeg rejects it for any reason,
@@ -757,7 +900,8 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
         cmd = _slideshow_cmd(scene_paths, output,
                              scene_duration=scene_duration,
                              scene_durations=scene_durations,
-                             width=width, height=height, fps=fps)
+                             width=width, height=height, fps=fps,
+                             kb_seed=kb_seed, kb_extended=kb_extended)
         _run_ffmpeg(cmd, label="slideshow render (crossfade)")
     except (subprocess.CalledProcessError, RuntimeError) as exc:
         logger.warning(
@@ -769,7 +913,8 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                              scene_duration=scene_duration,
                              scene_durations=scene_durations,
                              width=width, height=height, fps=fps,
-                             crossfade=0.0)
+                             crossfade=0.0,
+                             kb_seed=kb_seed, kb_extended=kb_extended)
         _run_ffmpeg(cmd, label="slideshow render (hard cut fallback)")
     return output
 
@@ -780,7 +925,9 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
 
 def _hybrid_filter_graph(visuals: Sequence[tuple], *,
                          width: int = 1920, height: int = 1080,
-                         fps: int = 30) -> str:
+                         fps: int = 30,
+                         kb_seed: int = 0,
+                         kb_extended: bool = True) -> str:
     """filter_complex mixing Ken-Burns stills with native video clips.
 
     *visuals* is an ordered list of ``(path, is_video, duration)`` tuples.
@@ -810,6 +957,7 @@ def _hybrid_filter_graph(visuals: Sequence[tuple], *,
                 frames=frames, index=i,
                 width=width, height=height, fps=fps,
                 trim_seconds=float(duration),
+                kb_seed=kb_seed, kb_extended=kb_extended,
             ))
     concat_in = "".join(f"[s{i}]" for i in range(len(visuals)))
     chains.append(f"{concat_in}concat=n={len(visuals)}:v=1:a=0[v]")
@@ -818,7 +966,9 @@ def _hybrid_filter_graph(visuals: Sequence[tuple], *,
 
 def _hybrid_slideshow_cmd(visuals: Sequence[tuple], output: Path, *,
                           width: int = 1920, height: int = 1080,
-                          fps: int = 30) -> List[str]:
+                          fps: int = 30,
+                          kb_seed: int = 0,
+                          kb_extended: bool = True) -> List[str]:
     """ffmpeg command for a stills+clips hybrid slideshow."""
     inputs: List[str] = []
     for path, is_video, duration in visuals:
@@ -835,7 +985,8 @@ def _hybrid_slideshow_cmd(visuals: Sequence[tuple], output: Path, *,
         "ffmpeg", "-y", "-threads", "0",
         *inputs,
         "-filter_complex",
-        _hybrid_filter_graph(visuals, width=width, height=height, fps=fps),
+        _hybrid_filter_graph(visuals, width=width, height=height, fps=fps,
+                             kb_seed=kb_seed, kb_extended=kb_extended),
         "-map", "[v]",
         "-r", str(fps),
         *_VIDEO_ENCODE,
@@ -847,12 +998,15 @@ def _hybrid_slideshow_cmd(visuals: Sequence[tuple], output: Path, *,
 
 def _render_hybrid_slideshow(visuals: Sequence[tuple], output: Path, *,
                              width: int = 1920, height: int = 1080,
-                             fps: int = 30) -> Path:
+                             fps: int = 30,
+                             kb_seed: int = 0,
+                             kb_extended: bool = True) -> Path:
     """Render the stage-1 hybrid (stills + clips) MP4. Idempotent."""
     if output.exists():
         return output
     cmd = _hybrid_slideshow_cmd(visuals, output,
-                                width=width, height=height, fps=fps)
+                                width=width, height=height, fps=fps,
+                                kb_seed=kb_seed, kb_extended=kb_extended)
     n_clips = sum(1 for _p, is_v, _d in visuals if is_v)
     logger.info("Rendering hybrid slideshow (%d segments, %d clips, %dx%d) → %s",
                 len(visuals), n_clips, width, height, output.name)
@@ -1195,11 +1349,97 @@ def _shorts_subtitle_style(margin_v: Optional[int] = None) -> str:
     return _SHORTS_SUBTITLES_FORCE_STYLE.replace("MarginV=340", f"MarginV={int(margin_v)}")
 
 
+# Long-form opening hook title (July 31 2026 — B4). The July 30
+# retention pass made the AUDIO open on its hook; the VIDEO first
+# seconds were still a photo + two pills. This stage burns the hook as
+# an on-screen title for the first ~4 s so the viewer READS the hook
+# while the cold open SPEAKS it. Alpha ramps in over 0.3 s and out over
+# the last 0.6 s (ending t=4) instead of popping.
+_LONG_HOOK_ALPHA = "clip(t/0.3,0,1)*clip((4-t)/0.6,0,1)"
+_LONG_HOOK_ENABLE = "between(t,0,4.05)"
+
+
+def _long_form_hook_stage(post_label: str, hook: str, *,
+                          width: int = 1920,
+                          has_subtitles: bool = False) -> Tuple[str, str]:
+    """Per-line drawtext chain for the long-form opening hook title.
+
+    Returns ``(chain_fragment, new_post_label)``. Mirrors the Shorts
+    graph's proven per-line label-chaining pattern (one drawtext per
+    wrapped line — the ``\\n``-in-text path is the Tesla Ep485 "letter
+    n" landmine). Autofit at 16:9: safe margin 140, max 2 lines,
+    candidates 64/56/48/40 px. Lines are centred around ``h*0.42`` —
+    above frame centre, clear of the bottom caption zone.
+
+    An empty/unrenderable hook returns ``("", post_label)`` so the
+    caller's terminal logic is untouched.
+    """
+    font_path_raw = _find_font()
+    font_path = _drawtext_escape(font_path_raw)
+    hook_fontsize, wrapped = autofit_hook_overlay(
+        hook,
+        frame_width=width,
+        safe_margin=140,
+        max_lines=2,
+        font_path=font_path_raw,
+        candidates=(64, 56, 48, 40),
+    )
+    wrapped_lines = [ln for ln in (wrapped.split("\n") if wrapped else []) if ln]
+    if not wrapped_lines:
+        return "", post_label
+    n_lines = len(wrapped_lines)
+    line_spacing = 14
+    line_h = hook_fontsize + line_spacing
+    terminal = "[lfhooked]" if has_subtitles else "[v]"
+    chain = ""
+    for i, line in enumerate(wrapped_lines):
+        escaped_line = _drawtext_escape(line)
+        offset_px = (i - (n_lines - 1) / 2.0) * line_h
+        sign = "+" if offset_px >= 0 else "-"
+        y_expr = f"h*0.42{sign}{abs(offset_px):.0f}"
+        is_last = (i == n_lines - 1)
+        line_label = terminal if is_last else f"[lfhookln{i}]"
+        chain += (
+            f";{post_label}drawtext=fontfile='{font_path}':"
+            f"text='{escaped_line}':"
+            f"fontsize={hook_fontsize}:fontcolor=white:"
+            f"x=(w-text_w)/2:y={y_expr}:"
+            f"borderw=4:bordercolor=black:"
+            f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
+            f"alpha='{_LONG_HOOK_ALPHA}':"
+            f"enable='{_LONG_HOOK_ENABLE}'"
+            f"{line_label}"
+        )
+        post_label = line_label
+    return chain, post_label
+
+
+def _long_form_subtitles_stage(post_label: str,
+                               subtitles_path: str) -> str:
+    """The terminal subtitles stage for the long-form composite.
+
+    SRT goes through libass at the ASS default PlayRes (288 units), so
+    the legacy ``force_style`` (FontSize=26 ≈ 98 px on screen) applies.
+    A per-word ``.ass`` file (July 31 2026 — B1) declares its OWN
+    PlayRes 1920x1080 and carries the equivalent long-form style in
+    real pixels (Fontsize 98) — forcing the 288-unit style onto it
+    would render ~26 px captions, so the ASS file's self-styling wins.
+    """
+    escaped = _subtitles_path_escape(subtitles_path)
+    if subtitles_path.lower().endswith(".ass"):
+        return f";{post_label}subtitles='{escaped}'[v]"
+    return (
+        f";{post_label}subtitles='{escaped}'"
+        f":force_style='{_SUBTITLES_FORCE_STYLE}'[v]"
+    )
+
+
 def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
                             fps: int = 30,
                             bg_is_video: bool = False,
                             subtitles_path: Optional[str] = None,
-                            with_url_pill: bool = False) -> str:
+                            with_url_pill: bool = False,
+                            hook: Optional[str] = None) -> str:
     """filter_complex for stage 2.
 
     Inputs:
@@ -1230,7 +1470,7 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
         bg_chain = (
             f"[0:v]scale={width}:{height}:force_original_aspect_ratio=increase"
             f":{_SCALE_FLAGS},"
-            f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
+            f"crop={width}:{height},setsar=1,{_GRADE_CHAIN},format=yuv420p[bg]"
         )
     else:
         # Degraded path: one static cover behind the whole episode, with a
@@ -1250,7 +1490,8 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
             f"crop={pre_w}:{pre_h},setsar=1,"
             f"zoompan=z='{zoom_expr}'"
             f":x='iw/2-(iw/zoom/2)':y='ih/2-(ih/zoom/2)'"
-            f":d=1:s={width}x{height}:fps={fps}"
+            f":d=1:s={width}x{height}:fps={fps},"
+            f"{_GRADE_CHAIN}"
             f"[bg]"
         )
 
@@ -1275,12 +1516,18 @@ def _long_form_filter_graph(*, width: int = 1920, height: int = 1080,
     else:
         post_brand_label = "[branded]"
 
-    if subtitles_path:
-        escaped = _subtitles_path_escape(subtitles_path)
-        graph += (
-            f";{post_brand_label}subtitles='{escaped}'"
-            f":force_style='{_SUBTITLES_FORCE_STYLE}'[v]"
+    # Opening hook title (B4) — chains after the pills, before captions.
+    if hook:
+        frag, post_brand_label = _long_form_hook_stage(
+            post_brand_label, hook, width=width,
+            has_subtitles=bool(subtitles_path),
         )
+        graph += frag
+        if not subtitles_path and post_brand_label == "[v]":
+            return graph  # hook stage terminated the graph
+
+    if subtitles_path:
+        graph += _long_form_subtitles_stage(post_brand_label, subtitles_path)
     else:
         graph += f";{post_brand_label}null[v]"
     return graph
@@ -1320,7 +1567,8 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
     bg_chain = (
         f"[0:v]"
         f"scale={width}:{height}:force_original_aspect_ratio=increase,"
-        f"crop={width}:{height},setsar=1,format=yuv420p[bg]"
+        f"crop={width}:{height},setsar=1,"
+        f"{_GRADE_CHAIN},{_SHORTS_SHARPEN},format=yuv420p[bg]"
     )
 
     # Show brand pill goes top-right (anchor point for vertical Shorts).
@@ -1403,6 +1651,11 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             y_expr = f"h*0.55{sign}{abs(offset_px):.0f}"
             is_last = (i == n_lines - 1)
             line_label = hook_label if is_last else f"[hookln{i}]"
+            # July 31 2026 (B3): fade the hook in over 250 ms and out
+            # over 400 ms instead of the single-frame pop the bare
+            # ``enable='between(t,0,3)'`` produced. The enable window
+            # extends to 3.05 s so the alpha ramp reaches 0 on screen
+            # rather than being cut off by the gate.
             chain += (
                 f";{post_brand_label}drawtext=fontfile='{font_path}':"
                 f"text='{escaped_line}':"
@@ -1410,7 +1663,8 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
                 f"x=(w-text_w)/2:y={y_expr}:"
                 f"borderw=4:bordercolor=black:"
                 f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
-                f"enable='between(t,0,3)'"
+                f"alpha='clip(t/0.25,0,1)*clip((3-t)/0.4,0,1)':"
+                f"enable='between(t,0,3.05)'"
                 f"{line_label}"
             )
             post_brand_label = line_label
@@ -1466,14 +1720,27 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             # PNG path. The input is added as a video stream
             # upstream (in _short_form_cmd) and labelled with
             # whatever index the caller assigned, e.g. ``[4:v]``.
+            #
+            # July 31 2026 (C4): alpha fade-in on the card's input
+            # chain — ``fade`` with ``alpha=1`` ramps only the alpha
+            # plane, so the card materialises over the last still in
+            # 0.45 s instead of guillotining it in one frame. The
+            # looped PNG input has running timestamps, so ``st=`` on
+            # the card's own timeline lines up with the overlay's
+            # enable window.
             chain += (
-                f";{end_card_image_input_label}format=rgba[endcard];"
+                f";{end_card_image_input_label}format=rgba,"
+                f"fade=t=in:st={end_card_start:.2f}:d=0.45:alpha=1[endcard];"
                 f"{post_brand_label}[endcard]overlay="
                 f"x=0:y=0:enable='{enable_clause}'[v]"
             )
             return chain
 
-        # Drawtext fallback path.
+        # Drawtext fallback path. July 31 2026 (C4): the two drawtext
+        # stages gain an alpha fade-in so the copy materialises rather
+        # than popping; the drawbox backdrop stays hard (drawbox has no
+        # alpha expression — acceptable on the degraded path).
+        end_card_alpha = f"clip((t-{end_card_start:.2f})/0.45,0,1)"
         font_path = _drawtext_escape(_find_font())
         escaped_main = _drawtext_escape(end_card_main_text)
         escaped_sub = _drawtext_escape(end_card_sub_text)
@@ -1489,6 +1756,7 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             f"x=(w-text_w)/2:y=(h-text_h)/2-100:"
             f"borderw=4:bordercolor=black:"
             f"shadowx=2:shadowy=2:shadowcolor=black@0.7:"
+            f"alpha='{end_card_alpha}':"
             f"enable='{enable_clause}'"
             # 3. Sub-line — smaller, accent colour (cyan, matches
             # the per-word caption highlight from PR #415).
@@ -1497,6 +1765,7 @@ def _short_form_filter_graph(width: int = 1080, height: int = 1920,
             f"fontsize=56:fontcolor=0x00D4FF:"
             f"x=(w-text_w)/2:y=(h+text_h)/2+40:"
             f"borderw=3:bordercolor=black:"
+            f"alpha='{end_card_alpha}':"
             f"enable='{enable_clause}'"
             f"[v]"
         )
@@ -1665,6 +1934,9 @@ def _single_pass_long_form_filter_graph(
     crossfade: float = _SLIDESHOW_XFADE_S,
     subtitles_path: Optional[str] = None,
     with_url_pill: bool = False,
+    hook: Optional[str] = None,
+    kb_seed: int = 0,
+    kb_extended: bool = True,
 ) -> str:
     """One filter graph for slideshow + overlays + captions (P1-2).
 
@@ -1694,14 +1966,17 @@ def _single_pass_long_form_filter_graph(
         scene_durations=scene_durations,
         width=width, height=height, fps=fps,
         crossfade=crossfade,
+        kb_seed=kb_seed, kb_extended=kb_extended,
     )
     # The slideshow graph's terminal label is always ``[v]``; the
     # composite needs it as ``[bg]``. Only the final occurrence is the
     # output (intermediate labels are [s0], [x1], ...), so replace from
-    # the right.
+    # the right. The network grade (C1) attaches here — the fused
+    # path's [bg] formation — matching the two-stage composite's
+    # bg_is_video branch so the two render paths ship the same look.
     if not slideshow.endswith("[v]"):
         raise ValueError("slideshow graph did not end with [v]")
-    graph = slideshow[: -len("[v]")] + "[bg]"
+    graph = slideshow[: -len("[v]")] + f",{_GRADE_CHAIN}[bg]"
 
     # Scenes consume inputs 0..n-1, so audio/brand/pill shift up.
     brand_idx = scene_count + 1
@@ -1720,12 +1995,18 @@ def _single_pass_long_form_filter_graph(
     else:
         post_brand_label = "[branded]"
 
-    if subtitles_path:
-        escaped = _subtitles_path_escape(subtitles_path)
-        graph += (
-            f";{post_brand_label}subtitles='{escaped}'"
-            f":force_style='{_SUBTITLES_FORCE_STYLE}'[v]"
+    # Opening hook title (B4) — same stage as the two-stage composite.
+    if hook:
+        frag, post_brand_label = _long_form_hook_stage(
+            post_brand_label, hook, width=width,
+            has_subtitles=bool(subtitles_path),
         )
+        graph += frag
+        if not subtitles_path and post_brand_label == "[v]":
+            return graph  # hook stage terminated the graph
+
+    if subtitles_path:
+        graph += _long_form_subtitles_stage(post_brand_label, subtitles_path)
     else:
         graph += f";{post_brand_label}null[v]"
     return graph
@@ -1742,6 +2023,9 @@ def _single_pass_long_form_cmd(
     subtitles_path: Optional[str] = None,
     url_pill_in: Optional[str] = None,
     chapter_metadata_in: Optional[str] = None,
+    hook: Optional[str] = None,
+    kb_seed: int = 0,
+    kb_extended: bool = True,
 ) -> List[str]:
     """Full ffmpeg command for the fused single-pass long-form render.
 
@@ -1796,6 +2080,8 @@ def _single_pass_long_form_cmd(
             crossfade=crossfade,
             subtitles_path=subtitles_path,
             with_url_pill=bool(url_pill_in),
+            hook=hook,
+            kb_seed=kb_seed, kb_extended=kb_extended,
         ),
         "-map", "[v]", "-map", f"{n}:a",
         *meta_map,
@@ -1814,7 +2100,8 @@ def _long_form_cmd(audio_in: str, bg_in: str, brand_in: str,
                    bg_is_video: bool = False,
                    subtitles_path: Optional[str] = None,
                    url_pill_in: Optional[str] = None,
-                   chapter_metadata_in: Optional[str] = None) -> List[str]:
+                   chapter_metadata_in: Optional[str] = None,
+                   hook: Optional[str] = None) -> List[str]:
     """Full ffmpeg command for stage 2.
 
     When *bg_is_video* is True, *bg_in* is a pre-rendered slideshow
@@ -1864,6 +2151,7 @@ def _long_form_cmd(audio_in: str, bg_in: str, brand_in: str,
             bg_is_video=bg_is_video,
             subtitles_path=subtitles_path,
             with_url_pill=bool(url_pill_in),
+            hook=hook,
         ),
         "-map", "[v]", "-map", "1:a",
         *meta_map,
@@ -1987,6 +2275,7 @@ def build_long_form_video(
     scene_schedule: Optional[Sequence[Tuple[Path, float]]] = None,
     broll_clips: Optional[Sequence[Path]] = None,
     chapters_path: Optional[Path] = None,
+    hook: Optional[str] = None,
 ) -> Path:
     """Render a 1920x1080 long-form podcast video.
 
@@ -2037,6 +2326,12 @@ def build_long_form_video(
         track, so Apple's video player can scrub by section and the
         chapters survive a download. Any problem reading it degrades to
         a video with no chapter track.
+    hook:
+        Optional episode hook (July 31 2026 — B4). When provided, the
+        first ~4 s burn an on-screen hook title (autofit at 16:9,
+        max 2 lines, alpha fade in/out) so the video's opening carries
+        the same hook the cold-open audio speaks. ``None`` keeps the
+        legacy title-less opening.
 
     Returns
     -------
@@ -2065,23 +2360,27 @@ def build_long_form_video(
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
     work_dir = output_path.parent
-    # Bumped filename when the pill text changed (was
-    # "Nerra Network · AI-narrated", now per-show name). The new
-    # filename forces regeneration even on persistent work dirs that
-    # still hold an old cached pill.
+    # Pill cache is path-keyed, so the version lives in the FILENAME.
+    # v2/v3 (July 31 2026 — B5): 2x supersampled render + cyan accent;
+    # the bumped names force regeneration on persistent work dirs that
+    # still hold a stale 1x pill.
     if show_name:
         # Per-show pill — sluggified so different shows get distinct
         # cached PNGs (otherwise the pill from the first show to run
         # on a persistent work dir would be reused for everyone).
         slug = "".join(c if c.isalnum() else "_" for c in show_name.lower()).strip("_")
-        brand_path = work_dir / f"_show_pill_{slug}.png"
+        brand_path = work_dir / f"_show_pill_v2_{slug}.png"
         _make_show_pill(show_name, brand_path)
-        url_pill_path = work_dir / "_url_pill_v1.png"
+        url_pill_path = work_dir / "_url_pill_v2.png"
         _make_url_pill(url_pill_path)
     else:
-        brand_path = work_dir / "_brand_pill_v2.png"
+        brand_path = work_dir / "_brand_pill_v3.png"
         _make_brand_pill(brand_path)
         url_pill_path = None
+
+    # Per-episode Ken Burns seed (A1) — derived from the output stem so
+    # a re-render is identical and different episodes de-synchronize.
+    kb_seed = _kb_seed_from_stem(output_path.stem)
 
     # Chapter-aware schedule (June 2026): an explicit per-scene plan wins
     # over the uniform timer. Normalized once so every branch below sees
@@ -2138,7 +2437,8 @@ def build_long_form_video(
                         audio_duration_s=audio_duration_s,
                     )
                 hybrid_path = work_dir / f"{output_path.stem}_hybrid.mp4"
-                _render_hybrid_slideshow(visuals, hybrid_path, fps=fps)
+                _render_hybrid_slideshow(visuals, hybrid_path, fps=fps,
+                                         kb_seed=kb_seed)
                 bg_path = hybrid_path
                 bg_is_video = True
             except subprocess.CalledProcessError as exc:
@@ -2158,6 +2458,7 @@ def build_long_form_video(
                 subtitles_path=str(subtitles_path) if subtitles_path else None,
                 url_pill_in=str(url_pill_path) if url_pill_path else None,
                 chapter_metadata_in=chapter_meta,
+                hook=hook,
             )
             logger.info(
                 "Building long-form video → %s (hybrid clips=%d, captions=%s)",
@@ -2191,6 +2492,8 @@ def build_long_form_video(
                         url_pill_in=(
                             str(url_pill_path) if url_pill_path else None),
                         chapter_metadata_in=chapter_meta,
+                        hook=hook,
+                        kb_seed=kb_seed,
                     )
                     logger.info(
                         "Building long-form video → %s (SINGLE-PASS, "
@@ -2219,6 +2522,7 @@ def build_long_form_video(
                 _render_slideshow(
                     [p for p, _ in schedule], slideshow_path,
                     scene_durations=[d for _, d in schedule], fps=fps,
+                    kb_seed=kb_seed,
                 )
                 bg_path = slideshow_path
                 bg_is_video = True
@@ -2245,6 +2549,7 @@ def build_long_form_video(
                 _render_slideshow(
                     slideshow_scenes, slideshow_path,
                     scene_duration=scene_duration_s, fps=fps,
+                    kb_seed=kb_seed,
                 )
                 bg_path = slideshow_path
                 bg_is_video = True
@@ -2262,6 +2567,7 @@ def build_long_form_video(
         subtitles_path=str(subtitles_path) if subtitles_path else None,
         url_pill_in=str(url_pill_path) if url_pill_path else None,
         chapter_metadata_in=chapter_meta,
+        hook=hook,
     )
     logger.info("Building long-form video → %s (slideshow=%s, captions=%s)",
                 output_path.name, bg_is_video, bool(subtitles_path))
@@ -2287,7 +2593,8 @@ def build_short_video(audio_path: Path, cover_path: Path,
                       caption_margin_v: Optional[int] = None,
                       scene_change_times: Optional[Sequence[float]] = None,
                       clip_paths: Optional[Sequence[Path]] = None,
-                      clip_seconds: float = 5.0) -> Path:
+                      clip_seconds: float = 5.0,
+                      kb_extended: bool = True) -> Path:
     """Render a 1080x1920 vertical YouTube Shorts video.
 
     ``drop_url_pill`` / ``caption_margin_v`` support the multi-platform
@@ -2351,6 +2658,15 @@ def build_short_video(audio_path: Path, cover_path: Path,
         Nominal seconds of each entry in *clip_paths*; the real
         duration is measured per file and this is only the fallback
         when a probe fails.
+    kb_extended:
+        Ken Burns vocabulary gate (July 31 2026 — A1). ``True``
+        (default) uses the widened 8-move / 3-amplitude, per-episode-
+        seeded motion. ``False`` pins the legacy 4-move / 1.09
+        behaviour byte-for-byte — run_show passes
+        ``kb_extended=not shorts_ab.is_enabled(config)`` so a show
+        running the Shorts motion A/B does not have its CONTROL arm
+        upgraded mid-experiment (which would bias the test toward
+        "motion isn't worth paying for").
     """
     if duration >= 60:
         raise ValueError(
@@ -2362,11 +2678,14 @@ def build_short_video(audio_path: Path, cover_path: Path,
         raise FileNotFoundError(f"cover not found: {cover_path}")
 
     work_dir = output_path.parent
+    # Per-episode Ken Burns seed (A1) — per-Short stems (_short_1/_2)
+    # de-synchronize the two Shorts of one episode too.
+    kb_seed = _kb_seed_from_stem(output_path.stem)
     if show_name:
         slug = "".join(c if c.isalnum() else "_" for c in show_name.lower()).strip("_")
-        brand_path = work_dir / f"_show_pill_{slug}.png"
+        brand_path = work_dir / f"_show_pill_v2_{slug}.png"
         _make_show_pill(show_name, brand_path)
-        url_pill_path = work_dir / "_url_pill_v1.png"
+        url_pill_path = work_dir / "_url_pill_v2.png"
         _make_url_pill(url_pill_path)
         if drop_url_pill:
             # Social safe-zone variant: keep the top brand pill, drop the
@@ -2374,7 +2693,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
             # bottom band is covered by IG/TikTok UI anyway).
             url_pill_path = None
     else:
-        brand_path = work_dir / "_brand_pill_v2.png"
+        brand_path = work_dir / "_brand_pill_v3.png"
         _make_brand_pill(brand_path)
         url_pill_path = None
 
@@ -2398,6 +2717,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
             hybrid_path = work_dir / f"{output_path.stem}_short_hybrid.mp4"
             _render_hybrid_slideshow(
                 visuals, hybrid_path, width=1080, height=1920, fps=fps,
+                kb_seed=kb_seed, kb_extended=kb_extended,
             )
             bg_path = hybrid_path
             bg_is_video = True
@@ -2435,6 +2755,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
                         seg_scenes, slideshow_path,
                         scene_durations=seg_durations,
                         width=1080, height=1920, fps=fps,
+                        kb_seed=kb_seed, kb_extended=kb_extended,
                     )
                     bg_path = slideshow_path
                     bg_is_video = True
@@ -2452,6 +2773,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
                     scene_paths, slideshow_path,
                     scene_duration=_SHORT_SCENE_DURATION_SECONDS,
                     width=1080, height=1920, fps=fps,
+                    kb_seed=kb_seed, kb_extended=kb_extended,
                 )
                 bg_path = slideshow_path
                 bg_is_video = True

--- a/engine/youtube_index.py
+++ b/engine/youtube_index.py
@@ -97,6 +97,7 @@ def record_video(
     watch_url: str = "",
     channel: str = "en",
     variant: str = "",
+    window: str = "",
     index_path: Optional[Path] = None,
 ) -> bool:
     """Append (or update) one published-video record. Best-effort.
@@ -127,6 +128,13 @@ def record_video(
         # its exact existing shape.
         if variant:
             row["variant"] = variant
+        # Which window the Short came from (July 31 2026 hook-first
+        # directive): "hook_open" | "qualified" | "filled" |
+        # "legacy_fallback". Only written when set, same back-compat
+        # contract as ``variant`` — analytics reads this to compare the
+        # hook Short's performance against smart windows.
+        if window:
+            row["window"] = window
         # Idempotent upsert keyed on video_id.
         for i, existing in enumerate(videos):
             if existing.get("video_id") == video_id:

--- a/run_show.py
+++ b/run_show.py
@@ -4537,11 +4537,30 @@ def _publish_youtube(
                 fill_to_n=bool(getattr(
                     config.youtube, "shorts_fill_to_requested", True)),
             )
+            # Hook-first (July 31 2026 operator directive): Short #1 is
+            # the episode's opening hook sequence on every channel; the
+            # smart windows fill the remaining slots (overlaps dropped).
+            # window="hook" flows into metrics + the video index so the
+            # analytics loop can score the change against smart windows.
+            if (bool(getattr(config.youtube, "shorts_first_is_hook", True))
+                    and getattr(config.youtube, "shorts_start_offset",
+                                None) is None):
+                from engine.shorts_selector import hook_first_windows
+                _early_windows = hook_first_windows(
+                    _early_windows,
+                    n=_policy_shorts_count,
+                    hook_start=_voice_off,
+                    window_duration=float(
+                        config.youtube.short_duration_seconds or 35.0),
+                    hook_text=hook or "",
+                )
             _early_shorts_plan = [
                 (
                     w.start_seconds,
                     (w.opening_text or hook).strip() or hook,
-                    "qualified" if getattr(w, "qualified", True) else "filled",
+                    ("hook_open" if w.score == float("inf")
+                     else "qualified" if getattr(w, "qualified", True)
+                     else "filled"),
                 )
                 for w in _early_windows
             ]
@@ -5578,16 +5597,28 @@ def _publish_youtube(
                 _early_shorts_plan)
 
             if not shorts_plan:
-                # Single-Short fallback: legacy resolved offset + the
-                # episode-level hook. Same code path as before
-                # ``shorts_per_episode`` existed.
-                fallback_offset = resolve_shorts_start_offset(
-                    config,
-                    chapters_path if chapters_path.exists() else None,
-                    audio_duration=_ep_duration,
-                    transcript_path=transcript_path,
-                )
-                shorts_plan = [(fallback_offset, hook, "legacy_fallback")]
+                if (bool(getattr(config.youtube, "shorts_first_is_hook",
+                                 True))
+                        and getattr(config.youtube, "shorts_start_offset",
+                                    None) is None):
+                    # Hook-first single Short (July 31 2026): the episode
+                    # opens on its hook since the cold-open pass, so the
+                    # opening IS the strongest window — no selector or
+                    # chapter resolution needed.
+                    _hook_off = float(getattr(
+                        config.audio, "voice_intro_delay", 0.0) or 0.0)
+                    shorts_plan = [(_hook_off, hook, "hook_open")]
+                else:
+                    # Single-Short fallback: legacy resolved offset + the
+                    # episode-level hook. Same code path as before
+                    # ``shorts_per_episode`` existed.
+                    fallback_offset = resolve_shorts_start_offset(
+                        config,
+                        chapters_path if chapters_path.exists() else None,
+                        audio_duration=_ep_duration,
+                        transcript_path=transcript_path,
+                    )
+                    shorts_plan = [(fallback_offset, hook, "legacy_fallback")]
 
             # Surface the resolved plan on the result dict. Single-
             # Short fields stay for backwards compatibility with the
@@ -5934,6 +5965,10 @@ def _publish_youtube(
                             # Empty for non-participating shows so the
                             # control arm stays same-show, same-channel.
                             variant=(_variant.variant if _ab_on else ""),
+                            # Which window this Short came from (hook-
+                            # first directive) — hook_open | qualified |
+                            # filled | legacy_fallback.
+                            window=_fill_mode,
                             index_path=digests_dir / "youtube_videos.json",
                         )
                     except Exception as _exc:

--- a/run_show.py
+++ b/run_show.py
@@ -4458,6 +4458,7 @@ def _publish_youtube(
 
     from engine.captions import (
         find_transcript_for_episode,
+        transcript_to_ass_full,
         transcript_to_ass_window,
         transcript_to_srt,
         transcript_to_srt_window,
@@ -4638,6 +4639,7 @@ def _publish_youtube(
     # ---- Build captions SRT (optional — falls back to no captions) ----
     # (transcript_path was found above the title-bundle call.)
     srt_path = None
+    long_ass_path = None
     if transcript_path is not None:
         try:
             srt_candidate = work_dir / f"{base_name}.srt"
@@ -4659,6 +4661,39 @@ def _publish_youtube(
             srt_path = srt_candidate
         except Exception as exc:  # pragma: no cover — best-effort
             logger.warning("Caption generation failed: %s", exc)
+        # Long-form burn-in prefers per-word ASS (July 31 2026 — B1),
+        # mirroring the Shorts ASS-first/SRT-fallback pattern. Only
+        # built when the burn-in flag is on (the default long-form
+        # caption layer is the uploaded track, which stays SRT — the
+        # YouTube captions API doesn't take ASS).
+        if getattr(config.youtube, "long_form_burn_in_captions", False):
+            try:
+                _lf_offset = float(
+                    getattr(config.audio, "voice_intro_delay", 0.0) or 0.0
+                )
+                ass_candidate = work_dir / f"{base_name}.ass"
+                transcript_to_ass_full(
+                    transcript_path,
+                    ass_candidate,
+                    audio_offset_seconds=_lf_offset,
+                )
+                if (ass_candidate.exists()
+                        and ass_candidate.stat().st_size > 0
+                        and "Dialogue:" in ass_candidate.read_text(
+                            encoding="utf-8", errors="replace")):
+                    long_ass_path = ass_candidate
+                    result["long_form_captions_path"] = "ass"
+                    logger.info("Long-form captions: per-word ASS path")
+                else:
+                    result["long_form_captions_path"] = "srt_fallback"
+                    logger.info(
+                        "Long-form captions: SRT fallback (no word-level "
+                        "cues in transcript)",
+                    )
+            except Exception as exc:  # pragma: no cover — best-effort
+                result["long_form_captions_path"] = "srt_fallback"
+                logger.warning("Long-form ASS caption generation failed: "
+                               "%s — SRT fallback", exc)
 
     # ---- Video generation (June 2026 Grok Video experiment) ----
     # When ``video_provider`` is set to "grok", generate full videos from the
@@ -5363,11 +5398,16 @@ def _publish_youtube(
                 #
                 # Per-show escape hatch for a surface that will not render
                 # a track: youtube.long_form_burn_in_captions: true.
+                # When burn-in is on, the per-word ASS (B1) wins over the
+                # segment-level SRT — same preference order as Shorts.
                 subtitles_path=(
-                    srt_path
+                    (long_ass_path or srt_path)
                     if getattr(config.youtube, "long_form_burn_in_captions", False)
                     else None
                 ),
+                # Opening hook title (B4): the video's first ~4 s show
+                # the hook the cold-open audio speaks.
+                hook=hook or None,
                 show_name=config.name,
                 scene_schedule=_visual_plan.get("scene_schedule"),
                 broll_clips=_visual_plan.get("broll_clips"),
@@ -5636,6 +5676,26 @@ def _publish_youtube(
             # >= 2 Shorts, so index 0 is always the control.
             from engine import shorts_ab as _shorts_ab
 
+            # Window-parity de-confound (July 31 2026 learning-loop
+            # review): treatment is pinned to Short INDEX 1, which was
+            # always the SECOND-best smart window — so the experiment
+            # measured motion + weaker-window combined. For enrolled
+            # shows, alternate the top-two window assignment by episode
+            # parity: over N episodes each arm sees ~equal window
+            # quality, deterministically (re-render identical). Caught
+            # with only 2 treatment Shorts published, so the confounded
+            # rows are noise once 14/arm accrue.
+            if (_shorts_ab.is_enabled(config) and len(shorts_plan) >= 2
+                    and episode_num % 2 == 1):
+                shorts_plan[0], shorts_plan[1] = (
+                    shorts_plan[1], shorts_plan[0])
+                result["shorts_ab_windows_swapped"] = True
+                result["shorts_start_offset"] = round(shorts_plan[0][0], 2)
+                result["shorts_start_offsets"] = [
+                    round(o, 2) for o, _, _ in shorts_plan]
+                result["shorts_fill_modes"] = [
+                    m for _, _, m in shorts_plan]
+
             _short_variant_plan = _shorts_ab.plan_variants(
                 config, len(shorts_plan),
             )
@@ -5895,6 +5955,10 @@ def _publish_youtube(
                         clip_paths=_variant.clip_paths or None,
                         clip_seconds=float(getattr(
                             config.youtube, "shorts_ab_clip_seconds", 5) or 5),
+                        # A1 guard: a show running the Shorts motion A/B
+                        # keeps the LEGACY Ken Burns on both arms so the
+                        # control arm isn't upgraded mid-experiment.
+                        kb_extended=not _ab_on,
                         start_offset=this_offset,
                         duration=duration,
                         hook=this_hook or None,
@@ -6142,6 +6206,11 @@ def _publish_youtube(
         result["visual_mode"] = "library_fallback"
     else:
         result["visual_mode"] = str(_visual_plan.get("mode") or "cover")
+    # Visual-era counter (July 31 2026): lets analytics segment
+    # retention by render look. Bumped in engine.video whenever the
+    # shipped look changes materially.
+    from engine.video import RENDER_LOOK_VERSION as _render_look_version
+    result["render_look_version"] = int(_render_look_version)
     result["scene_fresh_count"] = len(fresh_long_scenes) + len(fresh_short_scenes)
     # Measure the shorts-only scene saving rather than assuming it: this is
     # 3 fewer paid Grok Imagine images on every such episode.

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -475,6 +475,9 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
             # rather than as the control — an unenrolled Short was never
             # eligible to be the treatment.
             "variant": (v.get("variant") or ""),
+            # Hook-first window label (July 31 2026): lets reports compare
+            # the hook-opening Short against smart-window Shorts.
+            "window": (v.get("window") or ""),
             "title": v.get("title", ""),
             "hook": v.get("hook", ""),
             "published": v.get("published", ""),

--- a/scripts/update_youtube_performance.py
+++ b/scripts/update_youtube_performance.py
@@ -55,7 +55,32 @@ _STOP = frozenset({
     "january", "february", "march", "april", "may", "june", "july",
     "august", "september", "october", "november", "december",
     "2024", "2025", "2026", "2027",
+    # July 31 2026: plain function words that were passing the list and
+    # shipping as "topics that retained best" ("while", "just").
+    "while", "just", "about", "after", "over", "more", "been", "their",
+    "them", "they", "were", "have", "has", "had", "not", "into", "than",
+    "when", "where", "which", "there", "here", "some", "most", "also",
 })
+
+# Exemplar quality gate (July 31 2026): live performance files were
+# quoting FRAGMENT titles ("prove adequate, the architecture could…")
+# and DATE titles ("Today is July 16th, 2026") as high-retention
+# exemplars — teaching the title generator the exact shapes the July 18
+# title bundle exists to eliminate. A title is quotable only when it
+# doesn't look like a transcript fragment or a dateline.
+_BAD_EXEMPLAR = re.compile(
+    r"(?:…|\.\.\.)\s*$"                       # trailing ellipsis = fragment
+    r"|(?i:^\s*(?:today is|it's|its)\s)"      # dateline / spoken opener
+    # Case-sensitivity is load-bearing on the next branch: a global
+    # IGNORECASE made [a-z] match "T" and rejected every title.
+    r"|^\s*[a-z]"                             # starts lowercase = mid-sentence
+    r"|^\s*\S+\s*,"                           # "word," opener = clause tail
+)
+
+
+def _quotable(title: str) -> bool:
+    t = (title or "").strip()
+    return bool(t) and not _BAD_EXEMPLAR.search(t)
 
 
 def _keywords(text: str) -> List[str]:
@@ -63,18 +88,26 @@ def _keywords(text: str) -> List[str]:
     return [t for t in toks if t.lower() not in _STOP]
 
 
-def _build_hint(videos: List[dict], *, channel: str = "en") -> str:
+def _build_hint(videos: List[dict], *, channel: str = "en",
+                kind: str = "") -> str:
     """Compose a short natural-language steer from the best performers.
 
     ``channel`` selects EN (@NerraNetwork) or RU (@NerraRU) rows. Mixing
     channels skews the median and can quote the wrong language as exemplars.
     Rows without a ``channel`` field predate the split and count as EN.
+
+    ``kind`` ("long" | "short" | "" for all) scopes the pool. July 31
+    2026: the blended pool's "top quartile" was structurally all-Shorts
+    (~42% retention vs ~10% long-form), so Shorts exemplars and a
+    Shorts-inflated median were steering LONG-FORM titles too. Kinds are
+    now mined separately and composed into a labeled hint.
     """
     channel = (channel or "en").lower()
     rated = [
         v for v in videos
         if v.get("average_view_percentage")
         and (v.get("channel") or "en").lower() == channel
+        and (not kind or (v.get("kind") or "") == kind)
     ]
     if len(rated) < _MIN_VIDEOS:
         return ""
@@ -105,15 +138,18 @@ def _build_hint(videos: List[dict], *, channel: str = "en") -> str:
             "Topics/keywords that retained best recently: "
             + ", ".join(common[:8]) + "."
         )
-    # Show the operator/LLM 2-3 concrete high-retention titles as exemplars.
-    examples = [v["title"] for v in top[:3] if v.get("title")]
+    # Show the operator/LLM 2-3 concrete high-retention titles as
+    # exemplars — quotable ones only (no fragments/datelines: quoting a
+    # broken title as an exemplar teaches the generator the exact shapes
+    # the title bundle exists to eliminate).
+    examples = [v["title"] for v in top if _quotable(v.get("title"))][:3]
     if examples:
         parts.append("Highest-retention titles so far: "
                      + " | ".join(f'"{t}"' for t in examples) + ".")
     # Subscriber-converting titles are the strongest possible exemplars.
     converters = [v["title"] for v in rated
                   if float(v.get("subscribers_gained", 0) or 0) > 0
-                  and v.get("title")][:2]
+                  and _quotable(v.get("title"))][:2]
     if converters:
         parts.append("Titles that converted subscribers: "
                      + " | ".join(f'"{t}"' for t in converters) + ".")
@@ -122,6 +158,26 @@ def _build_hint(videos: List[dict], *, channel: str = "en") -> str:
         "concrete and front-load the strongest entity."
     )
     return " ".join(parts)
+
+
+def _compose_kind_hints(videos: List[dict], *, channel: str = "en") -> str:
+    """Labeled per-kind hint: long-form and Shorts mined SEPARATELY.
+
+    Falls back to the blended pool only when neither kind alone clears
+    the minimum sample — small channels keep getting a hint, but a show
+    with real data never has Shorts retention steering long-form titles
+    again.
+    """
+    hint_long = _build_hint(videos, channel=channel, kind="long")
+    hint_short = _build_hint(videos, channel=channel, kind="short")
+    parts: List[str] = []
+    if hint_long:
+        parts.append("LONG-FORM: " + hint_long)
+    if hint_short:
+        parts.append("SHORTS: " + hint_short)
+    if parts:
+        return " ".join(parts)
+    return _build_hint(videos, channel=channel)
 
 
 def main() -> int:
@@ -147,8 +203,8 @@ def main() -> int:
     # perf file lands next to that show's index file.
     for dir_name, payload in shows.items():
         videos = payload.get("videos") or []
-        hint_en = _build_hint(videos, channel="en")
-        hint_ru = _build_hint(videos, channel="ru")
+        hint_en = _compose_kind_hints(videos, channel="en")
+        hint_ru = _compose_kind_hints(videos, channel="ru")
         # Primary title_hint: EN for English shows; RU natives (finansy /
         # privet) often have only @NerraRU rows — fall back so they aren't
         # permanently hint-starved.

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -363,6 +363,10 @@ youtube:
   # Override with shorts_start_offset (seconds) or shorts_start_mode:
   # first_chapter (jumps to 2nd chapter marker for a stronger hook).
   shorts_start_mode: voice
+  # July 31 2026 (operator directive): Short #1 on every channel is the
+  # episode's opening hook sequence; smart windows fill the rest. The
+  # hook Short records window="hook" so analytics can score the change.
+  shorts_first_is_hook: true
   shorts_upload_schedule: always   # alternate_episodes = Shorts on even ep nums only
   # 35s (was 55). Measured over 348 Shorts with >=5 views in the 90-day
   # analytics window: the median Short holds a viewer for 21 seconds

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -414,6 +414,12 @@ youtube:
   # experiment is meant to be READ AND ENDED, not left running. Revisit
   # once api/shorts_ab.json has >= 14 episodes per arm.
   shorts_ab_enabled: true
+  # Hook-first Shorts (July 31 2026 network default) is PINNED OFF here
+  # until the motion A/B reads out: with it on, control (Short #1)
+  # would become the hook window while treatment (Short #2) stays a
+  # smart window — confounding motion with window position. Flip to
+  # true when the experiment ends (>= 14/arm, read api/shorts_ab.json).
+  shorts_first_is_hook: false
   shorts_ab_video_indexes: [1]
   shorts_ab_clips: 3
   shorts_ab_clip_seconds: 5

--- a/tests/test_captions_ass.py
+++ b/tests/test_captions_ass.py
@@ -177,9 +177,20 @@ def test_emits_header_and_one_dialogue_per_word(tmp_path):
     assert len(dialogues) == 4  # one per word
 
 
+# The full highlight override tag: colour flip + the July 31 2026 (B2)
+# active-word "pop" — a libass animated transform scaling the word to
+# 112% over its first 80 ms. Shared by the Shorts window builder and the
+# long-form full builder (they render through the same chunk code).
+HIGHLIGHT_TAG = "{\\1c&H00FFD400&\\t(0,80,\\fscx112\\fscy112)}"
+HIGHLIGHT_RE = re.compile(
+    r"\{\\1c&H00FFD400&\\t\(0,80,\\fscx112\\fscy112\)\}([^{]+)\{\\r\}"
+)
+
+
 def test_active_word_is_color_flipped(tmp_path):
-    """Each Dialogue line should highlight exactly one word; the rest
-    of the chunk text appears at the style default."""
+    """Each Dialogue line should highlight exactly one word (colour
+    flip + B2 pop transform); the rest of the chunk text appears at
+    the style default."""
     seg = _seg(
         0.0, 1.2, [
             ("alpha", 0.0, 0.3),
@@ -194,15 +205,17 @@ def test_active_word_is_color_flipped(tmp_path):
         window_start_seconds=0.0, window_duration_seconds=10.0,
     )
     dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
-    # Highlight color appears exactly once per line.
+    # Highlight override (colour + pop) appears exactly once per line.
     for start, end, text in dialogues:
-        assert text.count("{\\1c&H00FFD400&}") == 1, (
+        assert text.count(HIGHLIGHT_TAG) == 1, (
             f"line should have one highlight: {text!r}"
         )
         assert text.count("{\\r}") == 1
+        # The pop is an animated transform, never a bare colour flip.
+        assert "\\t(0,80,\\fscx112\\fscy112)" in text
     # The highlighted words progress: alpha, beta, gamma.
-    highlight_re = re.compile(r"\{\\1c&H00FFD400&\}([^{]+)\{\\r\}")
-    highlighted = [highlight_re.search(t).group(1).strip() for _, _, t in dialogues]
+    highlighted = [HIGHLIGHT_RE.search(t).group(1).strip()
+                   for _, _, t in dialogues]
     assert highlighted == ["alpha", "beta", "gamma"]
 
 
@@ -352,11 +365,113 @@ def test_ass_escape_strips_braces(tmp_path):
     )
     body = out.read_text(encoding="utf-8")
     # ASS tag delimiter (`{`) must only appear inside our highlight
-    # tags, never as part of a token. Strip our known good tags and
-    # check no `{` remains in any Dialogue text.
+    # tags, never as part of a token. Strip our known good tags (colour
+    # flip + B2 pop transform) and check no `{` remains in any Dialogue
+    # text.
     for _, _, text in _parse_dialogue_lines(body):
-        without_tags = re.sub(r"\{\\1c&H[0-9A-F]+&\}", "", text)
+        without_tags = re.sub(
+            r"\{\\1c&H[0-9A-F]+&(?:\\t\([^)]*\))?\}", "", text)
         without_tags = without_tags.replace(r"{\r}", "")
         assert "{" not in without_tags, (
             f"raw brace leaked into dialogue: {text!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# transcript_to_ass_full — long-form per-word captions (July 31 2026, B1)
+# ---------------------------------------------------------------------------
+
+
+from engine.captions import transcript_to_ass_full  # noqa: E402
+
+
+def test_full_header_declares_long_form_playres_and_style(tmp_path):
+    """The long-form ASS is self-styled in REAL pixels: PlayRes
+    1920x1080 and the long-form burn-in look (~98 px white text,
+    BorderStyle=1 outline 3 + shadow 1, bottom-centre MarginV=50) —
+    the equivalent of _SUBTITLES_FORCE_STYLE's FontSize=26 in libass's
+    288-unit SRT space. The render path lets this file self-style."""
+    seg = _seg(0.0, 1.0, [("Hello", 0.0, 0.5), ("world", 0.5, 1.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "long.ass"
+    transcript_to_ass_full(tp, out)
+    body = out.read_text(encoding="utf-8")
+    assert "PlayResX: 1920" in body
+    assert "PlayResY: 1080" in body
+    style = [ln for ln in body.splitlines()
+             if ln.startswith("Style: Default")][0]
+    fields = style.split(",")
+    assert fields[2] == "98"              # Fontsize (real px)
+    assert fields[15] == "1"              # BorderStyle=1 (outline, no card)
+    assert fields[16] == "3"              # Outline
+    assert fields[17] == "1"              # Shadow
+    assert fields[18] == "2"              # Alignment=2 bottom-centre
+    assert fields[21] == "50"             # MarginV
+    assert "&H80000000" not in style      # no Shorts caption card
+
+
+def test_full_emits_one_dialogue_per_word_on_absolute_timeline(tmp_path):
+    """No window, no rebase: word times land verbatim (plus offset)."""
+    seg = _seg(10.0, 11.0, [("only", 10.0, 11.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "long.ass"
+    transcript_to_ass_full(tp, out)
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert len(dialogues) == 1
+    start, end, text = dialogues[0]
+    assert start == "0:00:10.00"
+    assert end == "0:00:11.00"
+    # Shared highlight machinery: colour flip + B2 pop.
+    assert HIGHLIGHT_TAG in text
+
+
+def test_full_applies_music_intro_offset(tmp_path):
+    seg = _seg(1.0, 2.0, [("hello", 1.0, 2.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "long.ass"
+    transcript_to_ass_full(tp, out, audio_offset_seconds=4.5)
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    start, end, _ = dialogues[0]
+    assert start == "0:00:05.50"
+    assert end == "0:00:06.50"
+
+
+def test_full_uses_wider_long_form_chunk_budget(tmp_path):
+    """~42 chars / <=10 words per chunk (the 1920-wide frame fits more
+    than the Shorts 24/8 card) — and never more than 10 words."""
+    words = [(f"word{i}", i * 0.4, i * 0.4 + 0.35) for i in range(24)]
+    seg = _seg(0.0, 10.0, words)
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "long.ass"
+    transcript_to_ass_full(tp, out)
+    dialogues = _parse_dialogue_lines(out.read_text(encoding="utf-8"))
+    assert len(dialogues) == 24  # one per word
+    for _, _, text in dialogues:
+        plain = re.sub(r"\{[^}]*\}", "", text).strip()
+        assert len(plain.split()) <= 10
+        assert len(plain) <= 42 + 8  # chunk budget (+ small slack)
+
+
+def test_full_without_word_data_writes_header_only(tmp_path):
+    """Older transcripts: no words[] → no Dialogue lines; run_show
+    treats that as 'fall back to the segment-level SRT'."""
+    seg = {"start": 0.0, "end": 2.0, "text": "no words here"}
+    tp = _write_transcript(tmp_path, [seg])
+    out = tmp_path / "long.ass"
+    transcript_to_ass_full(tp, out)
+    body = out.read_text(encoding="utf-8")
+    assert "[Script Info]" in body
+    assert "Dialogue:" not in body
+
+
+def test_full_invalid_offset_raises(tmp_path):
+    seg = _seg(0.0, 1.0, [("hi", 0.0, 1.0)])
+    tp = _write_transcript(tmp_path, [seg])
+    with pytest.raises(ValueError):
+        transcript_to_ass_full(tp, tmp_path / "long.ass",
+                               audio_offset_seconds=-1.0)
+
+
+def test_full_missing_transcript_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        transcript_to_ass_full(tmp_path / "nope.json", tmp_path / "out.ass")

--- a/tests/test_scene_scheduler.py
+++ b/tests/test_scene_scheduler.py
@@ -113,18 +113,21 @@ class TestChapterAlignment:
         assert abs(math.fsum(d for _, d in plan) - 90.0) < 1e-6
 
     def test_long_chapter_subdivides_within_bounds(self):
-        """A 40 s chapter with max_hold=15 splits into 3 equal ~13.3 s
-        slots — every slot within [min_hold, max_hold]."""
+        """A 40 s opening chapter subdivides with the ACCELERATING-OPEN
+        max hold (July 31 2026 — D1: windows starting < 60 s clamp to
+        8 s) → 5 equal 8 s slots. Every slot stays within
+        [min_hold, effective max]."""
         pool = _scenes("fresh", 6)
         chapters = _chapters((0.0, "Intro"), (40.0, "Closing"))
         plan = plan_chapter_schedule(pool, [], chapters, 55.0,
                                      max_hold_s=15.0, min_hold_s=6.0)
-        # First chapter (40 s) contributes 3 slots of 40/3 s.
-        first_three = [d for _, d in plan[:3]]
-        assert all(abs(d - 40.0 / 3) < 1e-9 for d in first_three)
+        # First chapter (40 s, start < 60 s) contributes 5 slots of 8 s.
+        first_five = [d for _, d in plan[:5]]
+        assert all(abs(d - 8.0) < 1e-9 for d in first_five)
         for _, dur in plan:
             assert dur <= 15.0 + 1e-9
             assert dur >= 6.0 - 1e-9
+        assert abs(math.fsum(d for _, d in plan) - 55.0) < 1e-6
 
     def test_sixteen_second_chapter_splits_into_two_eights(self):
         pool = _scenes("fresh", 4)
@@ -171,6 +174,76 @@ class TestChapterAlignment:
 
 
 # ---------------------------------------------------------------------------
+# Accelerating open (July 31 2026 — D1)
+# ---------------------------------------------------------------------------
+
+
+class TestAcceleratingOpen:
+    def test_slots_starting_in_first_minute_hold_at_most_eight_seconds(self):
+        """The first minute is where long-form retention is decided
+        (10.7% EN median). Chapter windows starting < 60 s subdivide at
+        an 8 s max hold — ~2x the scene-change rate — before the plan
+        settles into the normal 6-15 s cruise."""
+        pool = _scenes("fresh", 6)
+        chapters = _chapters((0.0, "Intro"), (30.0, "Body"),
+                             (90.0, "Deep Dive"))
+        # 4 + 8 + 10 = 22 slots — under the 24-slot cap, so the merge
+        # never coarsens the opening (an over-cap plan may: the ffmpeg
+        # input cap outranks the pacing preference by design — see
+        # test_open_acceleration_respects_slot_cap).
+        plan = plan_chapter_schedule(pool, [], chapters, 240.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        acc = 0.0
+        for _, dur in plan:
+            if acc < 60.0 - 1e-9:
+                assert dur <= 8.0 + 1e-9, (
+                    f"slot starting at {acc:.1f}s holds {dur:.1f}s "
+                    f"(> 8 s inside the first minute)"
+                )
+            acc += dur
+        assert abs(math.fsum(d for _, d in plan) - 240.0) < 1e-6
+
+    def test_cruise_holds_return_after_the_first_minute(self):
+        """Chapters starting past 60 s keep the normal max hold — the
+        acceleration is an OPENING treatment, not a global re-pace."""
+        pool = _scenes("fresh", 6)
+        chapters = _chapters((0.0, "Intro"), (60.0, "Body"))
+        plan = plan_chapter_schedule(pool, [], chapters, 120.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        # The [60, 120) window subdivides at max_hold 15 → 4 x 15 s.
+        tail = [d for _, d in plan[-4:]]
+        assert all(abs(d - 15.0) < 1e-9 for d in tail)
+
+    def test_open_acceleration_respects_slot_cap(self):
+        """More opening slots must never push the plan past the ffmpeg
+        input cap — the existing merge absorbs the extra slots."""
+        from engine.scene_scheduler import _MAX_SLIDESHOW_SLOTS
+        pool = _scenes("fresh", 4)
+        starts = [0, 20, 40, 60, 150, 250, 350, 450, 550, 650, 750, 900]
+        chapters = _chapters(*[(float(s), f"Ch{i}")
+                               for i, s in enumerate(starts)])
+        plan = plan_chapter_schedule(pool, [], chapters, 1044.0,
+                                     max_hold_s=15.0, min_hold_s=6.0)
+        assert len(plan) <= _MAX_SLIDESHOW_SLOTS
+        assert abs(math.fsum(d for _, d in plan) - 1044.0) < 1e-6
+
+    def test_chapter_boundaries_still_hit_exactly(self):
+        """The opening acceleration subdivides WITHIN windows, so the
+        cumulative plan still passes exactly through every boundary."""
+        pool = _scenes("fresh", 5)
+        chapters = _chapters((0.0, "Intro"), (30.0, "Deep Dive"),
+                             (60.0, "Closing"))
+        plan = plan_chapter_schedule(pool, [], chapters, 90.0)
+        cumulative = set()
+        acc = 0.0
+        for _, dur in plan:
+            acc += dur
+            cumulative.add(round(acc, 6))
+        assert 30.0 in cumulative
+        assert 60.0 in cumulative
+
+
+# ---------------------------------------------------------------------------
 # Scene selection — token overlap, fresh tie-break, reuse variety
 # ---------------------------------------------------------------------------
 
@@ -188,8 +261,10 @@ class TestSceneSelection:
         )
         plan = plan_chapter_schedule([cyber, star], [], chapters, 40.0,
                                      scene_context=context)
-        # 2 chapters × 20 s → 2 slots each of 10 s.
-        assert [p for p, _ in plan] == [cyber, cyber, star, star]
+        # 2 chapters × 20 s, both inside the accelerating-open window
+        # (D1: max hold 8 s) → 3 slots each of ~6.67 s; the topical
+        # scene still wins every slot of its own chapter.
+        assert [p for p, _ in plan] == [cyber, cyber, cyber, star, star, star]
 
     def test_fresh_scene_wins_tie_over_library(self):
         fresh = _scenes("fresh", 1)
@@ -200,12 +275,14 @@ class TestSceneSelection:
 
     def test_reuse_penalty_yields_rotation_variety(self):
         """With a context-less pool of 3, the plan should rotate
-        through all three scenes with no back-to-back repeat."""
+        through all three scenes with no back-to-back repeat. (D1: both
+        chapters start < 60 s, so they subdivide at the 8 s opening max
+        hold → 6 slots each = 12 picks.)"""
         pool = _scenes("fresh", 3)
         chapters = _chapters((0.0, "Intro"), (45.0, "Closing"))
         plan = plan_chapter_schedule(pool, [], chapters, 90.0)
         picks = [p for p, _ in plan]
-        assert len(picks) == 6
+        assert len(picks) == 12
         assert set(picks) == set(pool)
         for a, b in zip(picks, picks[1:]):
             assert a != b, f"back-to-back repeat of {a}"

--- a/tests/test_shorts_ab.py
+++ b/tests/test_shorts_ab.py
@@ -481,3 +481,20 @@ class TestReport:
         data = self._build(tmp_path, [])
         assert data["status"] == "not_started"
         assert data["arms"]["grok_video"]["n"] == 0
+
+
+class TestWindowParityDeconfound:
+    """July 31 2026: treatment was pinned to Short index 1 = always the
+    SECOND-best smart window, so the experiment measured motion + weaker
+    window combined. run_show now alternates the top-two window
+    assignment by episode parity for enrolled shows — each arm sees
+    ~equal window quality over time, deterministically."""
+
+    def test_run_show_swaps_windows_on_odd_episodes_for_enrolled_shows(self):
+        src = (ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "episode_num % 2 == 1" in src
+        assert "shorts_ab_windows_swapped" in src
+        # The swap is gated on enrollment — non-enrolled shows must keep
+        # their plan order untouched.
+        swap_block = src.split("Window-parity de-confound")[1][:800]
+        assert "_shorts_ab.is_enabled(config)" in swap_block

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -673,3 +673,73 @@ class TestShortsClipLength:
         for fn in (pick_engaging_window, pick_top_n_engaging_windows):
             default = inspect.signature(fn).parameters["window_duration"].default
             assert default == 35.0, f"{fn.__name__} defaults to {default}s"
+
+
+class TestHookFirstWindows:
+    """July 31 2026 operator directive: Short #1 on every channel is the
+    episode's opening hook sequence (since the cold-open pass, t~=0 IS
+    the hook); smart windows fill the remaining slots, overlaps dropped.
+    The hook window records window="hook_open" so the analytics loop can
+    score the directive against smart windows."""
+
+    def _w(self, start, end, score=6.0, text="w", qualified=True):
+        from engine.shorts_selector import ScoredWindow
+        return ScoredWindow(start_seconds=start, end_seconds=end,
+                            score=score, opening_text=text,
+                            qualified=qualified)
+
+    def test_hook_window_is_always_first(self):
+        from engine.shorts_selector import hook_first_windows
+        smart = [self._w(120, 155), self._w(300, 335)]
+        out = hook_first_windows(smart, n=3, hook_start=0.0,
+                                 window_duration=35.0, hook_text="The hook")
+        assert out[0].start_seconds == 0.0
+        assert out[0].opening_text == "The hook"
+        assert out[0].score == float("inf")
+        assert [w.start_seconds for w in out[1:]] == [120, 300]
+
+    def test_overlapping_smart_windows_are_dropped(self):
+        from engine.shorts_selector import hook_first_windows
+        smart = [self._w(20, 55), self._w(200, 235)]  # 20s overlaps hook
+        out = hook_first_windows(smart, n=3, hook_start=0.0,
+                                 window_duration=35.0)
+        assert [w.start_seconds for w in out] == [0.0, 200]
+
+    def test_count_is_respected(self):
+        from engine.shorts_selector import hook_first_windows
+        smart = [self._w(120, 155), self._w(300, 335), self._w(500, 535)]
+        out = hook_first_windows(smart, n=2, hook_start=0.0,
+                                 window_duration=35.0)
+        assert len(out) == 2
+        assert out[0].score == float("inf")
+
+    def test_zero_count_returns_empty(self):
+        from engine.shorts_selector import hook_first_windows
+        assert hook_first_windows([], n=0, hook_start=0.0) == []
+
+    def test_network_default_is_on_and_spacex_pins_off(self):
+        """Default true (the directive applies network-wide); spacex is
+        pinned false until the Shorts motion A/B reads out — flipping it
+        mid-experiment would confound arm position with window choice."""
+        from engine.config import load_config
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        assert load_config(root / "shows" / "tesla.yaml").youtube \
+            .shorts_first_is_hook is True
+        assert load_config(root / "shows" / "spacex.yaml").youtube \
+            .shorts_first_is_hook is False
+
+    def test_run_show_and_both_dub_paths_are_wired(self):
+        """All three publish paths must apply the directive — a channel
+        that silently keeps smart-only Shorts would look like the
+        directive failing when it was never wired."""
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        for f in ("run_show.py", "engine/ru_dub.py", "engine/lang_dub.py"):
+            src = (root / f).read_text(encoding="utf-8")
+            assert "hook_first_windows" in src, f
+            assert "shorts_first_is_hook" in src, f
+        # And the index records the window label for the learning loop.
+        idx = (root / "engine" / "youtube_index.py").read_text(
+            encoding="utf-8")
+        assert 'row["window"] = window' in idx

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -83,11 +83,17 @@ def test_long_form_filter_graph_drops_visual_distractions():
     Compliance is now covered by the API ``containsSyntheticMedia``
     flag + description disclosure footer (no on-screen AI-narration
     reminder). Pin the absence of the dropped pieces so a future
-    refactor doesn't quietly re-introduce them."""
+    refactor doesn't quietly re-introduce them.
+
+    July 31 2026 note: the OPENING HOOK TITLE (B4) is a deliberate,
+    opt-in exception — ``hook=`` adds a 0-4 s drawtext title (see
+    TestLongFormHookTitle). The DEFAULT graph (no hook) must stay
+    clean, and the disclosure line specifically must never return."""
     graph = _long_form_filter_graph()
     assert "showcqt" not in graph
     assert "showwaves" not in graph
     assert "drawbox" not in graph
+    assert "drawtext" not in graph  # hook is opt-in; default stays clean
     # Centered first-4s disclosure burn-in is gone.
     assert "AI-narrated content" not in graph
     assert "between(t,0,4)" not in graph
@@ -123,8 +129,13 @@ def test_short_form_filter_graph_with_hook_burns_caption():
         hook="Tesla just unveiled a Virtual Queue for Superchargers."
     )
     assert "drawtext" in graph
-    # Hook caption shows for the first 3s only.
-    assert r"enable='between(t,0,3)'" in graph
+    # July 31 2026 (B3): the hook FADES in (250 ms) and out (400 ms)
+    # instead of popping on/off in one frame. The enable window extends
+    # to 3.05 s so the alpha ramp completes on screen.
+    assert r"alpha='clip(t/0.25,0,1)*clip((3-t)/0.4,0,1)'" in graph
+    assert r"enable='between(t,0,3.05)'" in graph
+    # The bare single-frame gate must not come back.
+    assert r"enable='between(t,0,3)'" not in graph
     # Some text from the hook appears (escaped) in the graph.
     assert "Tesla" in graph
     assert graph.endswith("[v]")
@@ -202,8 +213,8 @@ def test_short_form_filter_graph_subtitles_compose_with_hook():
     graph = _short_form_filter_graph(
         hook="Today's market.", subtitles_path="/tmp/short.srt",
     )
-    # Hook is wired through with its 0-3s gate.
-    assert "between(t,0,3)" in graph
+    # Hook is wired through with its 0-3s gate (B3: 3.05 fade window).
+    assert "between(t,0,3.05)" in graph
     # Subtitles filter is wired through.
     assert "subtitles=" in graph
     # Single final [v] output (no double-terminated graph).
@@ -309,7 +320,9 @@ def test_short_form_cmd_threads_hook_into_filter_graph():
     graph = cmd[cmd.index("-filter_complex") + 1]
     assert "drawtext" in graph
     assert "A short headline" in graph
-    assert r"enable='between(t,0,3)'" in graph
+    # B3 fade window (in 0.25 s / out 0.4 s, gate to 3.05 s).
+    assert r"enable='between(t,0,3.05)'" in graph
+    assert r"alpha='clip(t/0.25,0,1)*clip((3-t)/0.4,0,1)'" in graph
 
 
 def test_short_form_rejects_60s_duration(tmp_path):
@@ -346,7 +359,9 @@ def test_short_form_accepts_under_60s(tmp_path, monkeypatch):
     assert captured["cmd"][0] == "ffmpeg"
     assert "55.00" in captured["cmd"]
     # Brand pill PNG should have been generated alongside the output.
-    brand_pill = out.parent / "_brand_pill_v2.png"
+    # v3 (July 31 2026 — B5): 2x supersampled render + cyan accent; the
+    # bumped filename forces regeneration on persistent work dirs.
+    brand_pill = out.parent / "_brand_pill_v3.png"
     assert brand_pill.exists()
 
 
@@ -408,7 +423,8 @@ def test_build_long_form_video_generates_brand_pill(tmp_path, monkeypatch):
     monkeypatch.setattr("engine.video.subprocess.run",
                         lambda cmd, **kwargs: type("R", (), {"returncode": 0})())
     build_long_form_video(audio, cover, out)
-    assert (out.parent / "_brand_pill_v2.png").exists()
+    # v3 filename (B5) — see test_short_form_accepts_under_60s.
+    assert (out.parent / "_brand_pill_v3.png").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -1131,8 +1147,8 @@ def test_short_form_filter_graph_end_card_composes_with_hook_only():
     graph = _short_form_filter_graph(
         end_card=True, hook="Today on the show.", total_duration=55.0,
     )
-    # Hook still gates on first 3 s.
-    assert "between(t,0,3)" in graph
+    # Hook still gates on first 3 s (B3: fade window ends at 3.05).
+    assert "between(t,0,3.05)" in graph
     # End card gates on last 3 s.
     assert "between(t,52.00,55.00)" in graph
     assert graph.endswith("[v]")
@@ -1309,13 +1325,18 @@ def test_short_form_filter_graph_long_hook_uses_smaller_font():
 
 def test_short_form_filter_graph_end_card_image_uses_overlay():
     """When ``end_card_image_input_label`` is provided, the filter
-    graph must overlay that image (NOT emit drawbox + drawtext)."""
+    graph must overlay that image (NOT emit drawbox + drawtext).
+
+    July 31 2026 (C4): the card's input chain carries an alpha
+    fade-in (``fade=...:alpha=1`` ramps only the alpha plane), so the
+    card materialises over the last still in 0.45 s instead of
+    guillotining it in a single frame."""
     graph = _short_form_filter_graph(
         end_card=True, total_duration=55.0,
         end_card_image_input_label="[3:v]",
     )
-    # Overlay filter sourcing the image label.
-    assert "[3:v]format=rgba[endcard]" in graph
+    # Overlay filter sourcing the image label, with the alpha fade-in.
+    assert "[3:v]format=rgba,fade=t=in:st=52.00:d=0.45:alpha=1[endcard]" in graph
     assert "[endcard]overlay=x=0:y=0:enable='between(t,52.00,55.00)'[v]" in graph
     # Drawtext fallback is NOT emitted.
     assert "drawbox" not in graph
@@ -1344,7 +1365,7 @@ def test_short_form_filter_graph_end_card_image_composes_with_captions():
         end_card_image_input_label="[4:v]",
     )
     assert "[capted]" in graph
-    assert "[4:v]format=rgba[endcard]" in graph
+    assert "[4:v]format=rgba,fade=t=in:st=52.00:d=0.45:alpha=1[endcard]" in graph
     assert "[capted][endcard]overlay" in graph
     assert graph.endswith("[v]")
     assert graph.count("[v]") == 1
@@ -1381,7 +1402,8 @@ def test_short_form_cmd_adds_end_card_image_as_input(tmp_path, monkeypatch):
     # Filter graph references the right index. With show_name=Tesla
     # the URL pill takes [3:v], so the end-card lands at [4:v].
     graph = cmd[cmd.index("-filter_complex") + 1]
-    assert "[4:v]format=rgba[endcard]" in graph
+    assert "[4:v]format=rgba,fade=" in graph
+    assert "[endcard]" in graph
 
 
 def test_short_form_cmd_end_card_image_index_when_no_url_pill(tmp_path, monkeypatch):
@@ -1411,7 +1433,8 @@ def test_short_form_cmd_end_card_image_index_when_no_url_pill(tmp_path, monkeypa
     assert captured
     cmd = captured[-1]
     graph = cmd[cmd.index("-filter_complex") + 1]
-    assert "[3:v]format=rgba[endcard]" in graph
+    assert "[3:v]format=rgba,fade=" in graph
+    assert "[endcard]" in graph
 
 
 def test_short_form_cmd_missing_end_card_image_falls_back_to_drawtext(
@@ -2112,3 +2135,432 @@ class TestLongFormCaptionLayer:
             raw = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
             yt = raw.get("youtube") or {}
             assert yt.get("long_form_burn_in_captions") is not True, path.name
+
+
+# ---------------------------------------------------------------------------
+# July 31 2026 render pass — network grade (C1) + Shorts sharpen (C2)
+# ---------------------------------------------------------------------------
+#
+# One grade chain (_GRADE_CHAIN) applied wherever the composite forms
+# its [bg]: long-form both branches, Shorts, and the fused single-pass
+# graph. Applied ONCE per delivered pixel — never inside the stage-1
+# slideshow graph, or the two-stage path would grade twice.
+
+class TestNetworkGrade:
+    def _grade(self):
+        from engine.video import _GRADE_CHAIN
+        return _GRADE_CHAIN
+
+    def test_grade_chain_constant_shape(self):
+        grade = self._grade()
+        assert "eq=contrast=1.05:saturation=1.08:gamma=0.98" in grade
+        assert "vignette=angle=PI/5" in grade
+        assert "gradfun=3.5:8" in grade
+        # Deliberately NO noise grain — it fights the 4 Mbps maxrate
+        # ceiling (see _VIDEO_ENCODE).
+        assert "noise" not in grade
+
+    def test_long_form_video_bg_branch_is_graded(self):
+        graph = _long_form_filter_graph(bg_is_video=True)
+        assert self._grade() in graph
+        # Grade lands on the [bg] formation, before the pill overlays.
+        assert graph.index(self._grade()) < graph.index("[bg]")
+
+    def test_long_form_degraded_cover_branch_is_graded(self):
+        graph = _long_form_filter_graph(bg_is_video=False)
+        assert self._grade() in graph
+
+    def test_short_form_bg_is_graded_and_sharpened(self):
+        from engine.video import _SHORTS_SHARPEN
+        graph = _short_form_filter_graph()
+        assert self._grade() in graph
+        # C2: mild luma-only output sharpen for the 9:16 upsample.
+        assert _SHORTS_SHARPEN in graph
+        assert "unsharp=5:5:0.5:5:5:0.0" in graph
+        # Sharpen follows the grade in the bg chain.
+        assert graph.index(self._grade()) < graph.index(_SHORTS_SHARPEN)
+
+    def test_single_pass_graph_is_graded_once(self):
+        from engine.video import _single_pass_long_form_filter_graph
+        graph = _single_pass_long_form_filter_graph(3)
+        assert graph.count(self._grade()) == 1
+        assert graph.index(self._grade()) < graph.index("[bg]")
+
+    def test_stage_one_slideshow_graph_is_not_graded(self):
+        """The two-stage path grades at composite time; grading the
+        intermediate too would double-apply the look."""
+        graph = _slideshow_filter_graph(scene_count=3)
+        assert self._grade() not in graph
+        assert "vignette" not in graph
+
+    def test_long_form_sharpen_is_shorts_only(self):
+        """Long-form skips the unsharp stage — 2.0x lanczos prescale
+        was measured as the knee there; sharpening a 16:9 slideshow
+        would halo the Grok imagery for no phone-screen payoff."""
+        assert "unsharp" not in _long_form_filter_graph(bg_is_video=True)
+        assert "unsharp" not in _long_form_filter_graph(bg_is_video=False)
+
+
+class TestRenderLookVersion:
+    def test_constant_is_two(self):
+        from engine.video import RENDER_LOOK_VERSION
+        assert RENDER_LOOK_VERSION == 2
+
+    def test_run_show_records_it_next_to_visual_mode(self):
+        import pathlib
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "run_show.py").read_text(encoding="utf-8")
+        assert 'result["render_look_version"]' in src
+
+    def test_pipeline_metric_recorded(self):
+        from engine.pipeline import record_youtube_outcomes
+
+        class _M:
+            def __init__(self):
+                self.data = {}
+
+            def record(self, key, value):
+                self.data[key] = value
+
+        from types import SimpleNamespace
+        m = _M()
+        record_youtube_outcomes(
+            m, {"render_look_version": 2,
+                "long_form_captions_path": "ass"}, 1.0,
+            config=SimpleNamespace(youtube=None),
+        )
+        assert m.data["render_look_version"] == 2
+        assert m.data["long_form_captions_path"] == "ass"
+
+
+# ---------------------------------------------------------------------------
+# July 31 2026 render pass — long-form opening hook title (B4)
+# ---------------------------------------------------------------------------
+
+class TestLongFormHookTitle:
+    HOOK = "Tesla just unveiled a Virtual Queue for Superchargers."
+
+    def test_hook_burns_title_with_fade(self):
+        graph = _long_form_filter_graph(hook=self.HOOK)
+        assert "drawtext" in graph
+        assert "Tesla" in graph
+        # Centred around h*0.42 (above centre, clear of captions).
+        assert "y=h*0.42" in graph
+        # Alpha fade: in 0.3 s, out 0.6 s ending t=4; gate to 4.05 so
+        # the ramp completes on screen.
+        assert r"alpha='clip(t/0.3,0,1)*clip((4-t)/0.6,0,1)'" in graph
+        assert r"enable='between(t,0,4.05)'" in graph
+        assert graph.endswith("[v]")
+
+    def test_no_hook_keeps_legacy_graph(self):
+        assert _long_form_filter_graph() == _long_form_filter_graph(hook=None)
+        assert "drawtext" not in _long_form_filter_graph(hook=None)
+
+    def test_hook_composes_with_subtitles(self):
+        graph = _long_form_filter_graph(
+            hook=self.HOOK, subtitles_path="/tmp/captions.srt",
+        )
+        assert "subtitles=" in graph
+        # Hook chains INTO the subtitle stage (per-line labels), never
+        # double-terminates the graph.
+        assert "[lfhooked]subtitles=" in graph
+        assert graph.count("[v]") == 1
+        assert graph.endswith("[v]")
+
+    def test_long_hook_stacks_one_drawtext_per_line(self):
+        """Per-line drawtext (the Tesla Ep485 'letter n' landmine —
+        never a \\n inside text=), max 2 lines at 16:9."""
+        long_hook = (
+            "California regulators just disclosed the Tesla Semi's "
+            "battery sizes at 822 kWh and 548 kWh in a filing."
+        )
+        graph = _long_form_filter_graph(hook=long_hook)
+        import re as _re
+        text_values = _re.findall(r"text='([^']*)'", graph)
+        assert text_values
+        for tv in text_values:
+            assert "\n" not in tv
+            assert r"\n" not in tv
+
+    def test_hook_autofit_uses_16x9_candidates(self):
+        """Autofit ladder at 1920 starts at 64 px — a short hook gets
+        the biggest size, and every candidate stays in 64..40."""
+        import re as _re
+        graph = _long_form_filter_graph(hook="Tesla wins.")
+        m = _re.search(r"fontsize=(\d+)", graph)
+        assert m and int(m.group(1)) == 64
+        long_graph = _long_form_filter_graph(hook=self.HOOK * 3)
+        m2 = _re.search(r"fontsize=(\d+)", long_graph)
+        assert m2 and 40 <= int(m2.group(1)) < 64
+
+    def test_long_form_cmd_threads_hook(self):
+        cmd = _long_form_cmd("voice.mp3", "cover.jpg", "brand.png",
+                             "out.mp4", hook=self.HOOK)
+        graph = cmd[cmd.index("-filter_complex") + 1]
+        assert "Tesla" in graph and "y=h*0.42" in graph
+
+    def test_single_pass_graph_threads_hook(self):
+        from engine.video import _single_pass_long_form_filter_graph
+        graph = _single_pass_long_form_filter_graph(3, hook=self.HOOK)
+        assert "y=h*0.42" in graph
+        assert r"enable='between(t,0,4.05)'" in graph
+        assert graph.endswith("[v]")
+
+    def test_build_long_form_video_threads_hook(self, tmp_path, monkeypatch):
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"\x00")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xFF\xD8")
+        out = tmp_path / "out.mp4"
+        captured = []
+        monkeypatch.setattr(
+            "engine.video.subprocess.run",
+            lambda cmd, **kw: (captured.append(list(cmd)),
+                               type("R", (), {"returncode": 0})())[1],
+        )
+        build_long_form_video(audio, cover, out, hook=self.HOOK)
+        graph = captured[-1][captured[-1].index("-filter_complex") + 1]
+        assert "y=h*0.42" in graph
+
+    def test_run_show_passes_hook_to_long_form(self):
+        import pathlib
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "run_show.py").read_text(encoding="utf-8")
+        assert "hook=hook or None," in src
+
+
+# ---------------------------------------------------------------------------
+# July 31 2026 render pass — long-form per-word ASS captions (B1)
+# ---------------------------------------------------------------------------
+
+class TestLongFormAssSubtitles:
+    def test_ass_path_skips_the_288_unit_force_style(self):
+        """A per-word .ass declares its own PlayRes 1920x1080 and
+        carries the long-form style in REAL pixels (Fontsize 98).
+        Forcing the SRT force_style (FontSize=26 in 288-unit space)
+        onto it would render ~26 px captions."""
+        graph = _long_form_filter_graph(subtitles_path="/tmp/captions.ass")
+        assert "subtitles=" in graph
+        assert "captions.ass" in graph
+        assert "force_style" not in graph
+        assert graph.endswith("[v]")
+
+    def test_srt_path_keeps_legacy_force_style(self):
+        graph = _long_form_filter_graph(subtitles_path="/tmp/captions.srt")
+        assert "force_style=" in graph
+        assert "FontSize=26" in graph
+
+    def test_single_pass_graph_matches(self):
+        from engine.video import _single_pass_long_form_filter_graph
+        ass_graph = _single_pass_long_form_filter_graph(
+            3, subtitles_path="/tmp/captions.ass")
+        assert "force_style" not in ass_graph
+        srt_graph = _single_pass_long_form_filter_graph(
+            3, subtitles_path="/tmp/captions.srt")
+        assert "force_style=" in srt_graph
+
+    def test_run_show_prefers_ass_with_srt_fallback(self):
+        """The burn-in path mirrors the Shorts ASS-first/SRT-fallback
+        pattern and records which layer shipped."""
+        import pathlib
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "run_show.py").read_text(encoding="utf-8")
+        assert "transcript_to_ass_full" in src
+        assert "(long_ass_path or srt_path)" in src
+        assert 'result["long_form_captions_path"] = "ass"' in src
+        assert 'result["long_form_captions_path"] = "srt_fallback"' in src
+
+
+# ---------------------------------------------------------------------------
+# July 31 2026 render pass — Ken Burns vocabulary + per-episode seed (A1)
+# ---------------------------------------------------------------------------
+
+def _eval_kb_expr(expr: str, *, on: float, n_zoom: float) -> float:
+    """Numerically evaluate a zoompan x/y expression with iw=ih=1."""
+    e = expr.replace("iw", "1.0").replace("ih", "1.0")
+    e = e.replace("zoom", repr(float(n_zoom)))
+    e = e.replace("on", repr(float(on)))
+    return eval(e)  # noqa: S307 — controlled arithmetic-only expression
+
+
+class TestKenBurnsVocabulary:
+    def test_eight_moves_with_legacy_prefix(self):
+        from engine.video import _KB_LEGACY_MOVE_COUNT, _KB_MOVES
+        assert len(_KB_MOVES) == 8
+        # The FIRST FOUR entries are the legacy vocabulary in the
+        # legacy order — the A/B control arm indexes into this prefix.
+        assert _KB_MOVES[:4] == ("in_centre", "out_centre",
+                                 "in_pan_x", "out_pan_y")
+        assert _KB_MOVES[4:] == ("in_pan_y", "out_pan_x",
+                                 "in_pan_xy", "out_pan_xy")
+        assert _KB_LEGACY_MOVE_COUNT == 4
+
+    def test_zoom_amplitudes(self):
+        from engine.video import _KB_ZOOM_AMPLITUDES
+        assert _KB_ZOOM_AMPLITUDES == (1.06, 1.09, 1.12)
+
+    def test_pan_feasibility_all_moves_all_amplitudes(self):
+        """Numeric feasibility: for every move x amplitude, the
+        requested window origin stays inside [0, 1 - 1/zoom] on both
+        axes for every frame — i.e. zoompan never has to clamp, which
+        is the edge-anchored-zoom defect the July 30 pass fixed."""
+        from engine.video import _KB_MOVES, _KB_ZOOM_AMPLITUDES, _ken_burns
+        frames = 90
+        for move in _KB_MOVES:
+            for amp in _KB_ZOOM_AMPLITUDES:
+                z_expr, x_expr, y_expr = _ken_burns(
+                    frames, move, zoom_max=amp)
+                for on in range(frames):
+                    z = _eval_kb_expr(z_expr, on=on, n_zoom=1.0)
+                    assert 1.0 - 1e-9 <= z <= amp + 1e-9, (
+                        f"{move}@{amp}: zoom {z} out of band at on={on}")
+                    for axis, expr in (("x", x_expr), ("y", y_expr)):
+                        origin = _eval_kb_expr(expr, on=on, n_zoom=z)
+                        upper = 1.0 - 1.0 / z
+                        assert -1e-9 <= origin <= upper + 1e-9, (
+                            f"{move}@{amp} {axis}: origin {origin:.6f} "
+                            f"outside [0, {upper:.6f}] at on={on} (zoom {z:.4f})"
+                        )
+
+    def test_diagonals_ramp_both_axes(self):
+        from engine.video import _ken_burns
+        _z, x, y = _ken_burns(60, "in_pan_xy", zoom_max=1.12)
+        # Both axes carry the same travel ramp (not a static 0.5).
+        assert "0.5+" in x and "0.5+" in y
+
+    def test_seed_offsets_the_rotation_deterministically(self):
+        from engine.video import _kb_seed_from_stem
+        s1 = _kb_seed_from_stem("Tesla_Pod_Ep042_20260731")
+        s2 = _kb_seed_from_stem("Tesla_Pod_Ep042_20260731")
+        s3 = _kb_seed_from_stem("Tesla_Pod_Ep043_20260801")
+        assert s1 == s2          # re-render identical
+        assert s1 != s3          # episodes de-synchronize
+        assert isinstance(s1, int) and s1 >= 0
+
+    def test_seed_changes_the_graph(self):
+        g0 = _slideshow_filter_graph(scene_count=4, kb_seed=0)
+        g1 = _slideshow_filter_graph(scene_count=4, kb_seed=1)
+        assert g0 != g1
+
+    def test_extended_graph_alternates_amplitudes(self):
+        """Three consecutive slots at seed 0 carry the 1.06/1.09/1.12
+        alternation (rounded amps appear in the zoom expressions)."""
+        graph = _slideshow_filter_graph(scene_count=3, kb_seed=0)
+        assert "0.06" in graph and "0.09" in graph and "0.12" in graph
+
+    def test_legacy_mode_pins_four_moves_at_109(self):
+        """kb_extended=False must reproduce the pre-A1 graph: first 4
+        moves in index order at the single 1.09 amplitude, seed
+        ignored — this IS the Shorts A/B control arm's render."""
+        from engine.video import _ZOOM_MAX
+        legacy = _slideshow_filter_graph(scene_count=4, kb_extended=False)
+        assert str(_ZOOM_MAX) in legacy
+        assert "1.06" not in legacy and "1.12" not in legacy
+        # Seed is ignored in legacy mode — byte-identical either way.
+        assert legacy == _slideshow_filter_graph(
+            scene_count=4, kb_extended=False, kb_seed=12345)
+
+    def test_build_short_video_kb_extended_defaults_true(self):
+        import inspect
+        params = inspect.signature(build_short_video).parameters
+        assert "kb_extended" in params
+        assert params["kb_extended"].default is True
+
+    def test_run_show_gates_shorts_kb_on_the_ab(self):
+        """run_show must pass kb_extended=not <A/B enabled> so an
+        enrolled show's control arm is not upgraded mid-experiment."""
+        import pathlib
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "run_show.py").read_text(encoding="utf-8")
+        assert "kb_extended=not _ab_on," in src
+
+    def test_build_short_video_legacy_kb_when_not_extended(self, tmp_path,
+                                                           monkeypatch):
+        """End-to-end: kb_extended=False keeps the stage-1 vertical
+        slideshow on the legacy vocabulary (no 1.06/1.12 amplitudes)."""
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"\x00")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xFF\xD8")
+        scenes = []
+        for i in range(3):
+            s = tmp_path / f"scene{i}.jpg"
+            s.write_bytes(b"\xFF\xD8")
+            scenes.append(s)
+        out = tmp_path / "short.mp4"
+
+        captured = []
+
+        def fake_run(cmd, **kw):
+            captured.append(list(cmd))
+            if "-an" in cmd:
+                Path(cmd[-1]).write_bytes(b"\x00")
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr("engine.video.subprocess.run", fake_run)
+        build_short_video(audio, cover, out, duration=55.0,
+                          scene_paths=scenes, kb_extended=False)
+        stage1 = captured[0]
+        graph = stage1[stage1.index("-filter_complex") + 1]
+        assert "1.09" in graph
+        assert "1.06" not in graph and "1.12" not in graph
+
+
+# ---------------------------------------------------------------------------
+# July 31 2026 render pass — crisper pills (B5)
+# ---------------------------------------------------------------------------
+
+class TestPillV2:
+    def test_pill_is_delivered_at_requested_size(self, tmp_path):
+        """2x supersample is internal — the saved PNG is the requested
+        delivery size (LANCZOS-downscaled)."""
+        from PIL import Image
+        target = tmp_path / "pill.png"
+        _make_brand_pill(target, width=220, height=60)
+        with Image.open(target) as img:
+            assert img.size == (220, 60)
+
+    def test_pill_has_cyan_left_edge_accent(self, tmp_path):
+        """A ~2 px Nerra-cyan accent inside the left edge of the
+        rounded rect — brand cohesion with the caption highlight."""
+        from PIL import Image
+        target = tmp_path / "pill.png"
+        _make_brand_pill(target, width=220, height=60)
+        with Image.open(target) as img:
+            r, g, b, a = img.convert("RGBA").getpixel((1, 30))
+        assert a > 0
+        # Cyan-dominant: blue and green well above red.
+        assert b > 150 and g > 100 and b > r + 60, (r, g, b, a)
+
+    def test_pill_centre_is_still_the_dark_field(self, tmp_path):
+        from PIL import Image
+        target = tmp_path / "pill.png"
+        _make_brand_pill(target, width=220, height=60, text="")
+        with Image.open(target) as img:
+            r, g, b, a = img.convert("RGBA").getpixel((110, 30))
+        assert a > 0 and max(r, g, b) < 60
+
+    def test_pill_v2_idempotent(self, tmp_path):
+        target = tmp_path / "pill.png"
+        _make_brand_pill(target)
+        first = target.stat().st_mtime_ns
+        _make_brand_pill(target)
+        assert target.stat().st_mtime_ns == first
+
+    def test_builders_use_versioned_filenames(self, tmp_path, monkeypatch):
+        """The cache is path-keyed, so the supersampled look only ships
+        if the builders use the bumped names."""
+        audio = tmp_path / "voice.mp3"
+        audio.write_bytes(b"\x00")
+        cover = tmp_path / "cover.jpg"
+        cover.write_bytes(b"\xFF\xD8")
+        monkeypatch.setattr(
+            "engine.video.subprocess.run",
+            lambda cmd, **kw: type("R", (), {"returncode": 0})())
+        build_short_video(audio, cover, tmp_path / "short.mp4",
+                          duration=55.0, show_name="Tesla Shorts Time")
+        assert (tmp_path / "_show_pill_v2_tesla_shorts_time.png").exists()
+        assert (tmp_path / "_url_pill_v2.png").exists()
+        # Stale v1 names must not be written.
+        assert not (tmp_path / "_show_pill_tesla_shorts_time.png").exists()
+        assert not (tmp_path / "_url_pill_v1.png").exists()

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -357,3 +357,95 @@ class TestEveryDubChannelEntersTheLoop:
         if (_ROOT / "digests").glob("*/youtube_videos.fr.json"):
             assert "fr" in channels or not any(
                 (_ROOT / "digests").glob("*/youtube_videos.fr.json"))
+
+
+class TestTitleHintHygiene:
+    """July 31 2026 learning-loop review: the blended pool's "top
+    quartile" was structurally all-Shorts (~42% retention vs ~10%
+    long-form), so Shorts exemplars and a Shorts-inflated median steered
+    LONG-FORM titles; live perf files also quoted fragment titles
+    ("prove adequate, the architecture could…") and datelines ("Today is
+    July 16th, 2026") as exemplars — teaching the generator the shapes
+    the title bundle exists to eliminate."""
+
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "uyp", str(_ROOT / "scripts" / "update_youtube_performance.py"))
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    @staticmethod
+    def _v(kind, pct, title, subs=0):
+        return {"kind": kind, "average_view_percentage": pct,
+                "title": title, "hook": title, "channel": "en",
+                "subscribers_gained": subs}
+
+    def test_fragment_and_dateline_titles_are_never_exemplars(self):
+        m = self._mod()
+        assert not m._quotable("prove adequate, the architecture could…")
+        assert not m._quotable("Today is July 16th, 2026")
+        assert not m._quotable("and then the rocket landed")
+        assert not m._quotable("However, the outcome was different")
+        assert m._quotable("Tesla Opens 500-Stall Supercharger Hub")
+
+    def test_kinds_are_mined_separately(self):
+        m = self._mod()
+        vids = ([self._v("short", 45, f"Short Winner {i} Reveals Numbers")
+                 for i in range(6)]
+                + [self._v("long", 11, f"Long Steady {i} Covers Topic")
+                   for i in range(6)])
+        hint = m._compose_kind_hints(vids, channel="en")
+        assert "LONG-FORM:" in hint and "SHORTS:" in hint
+        long_part = hint.split("SHORTS:")[0]
+        assert "Short Winner" not in long_part
+        assert "Median retention is 11%" in long_part
+
+    def test_small_channels_fall_back_to_blended(self):
+        m = self._mod()
+        small = ([self._v("long", 12, f"Only Long {i} Title")
+                  for i in range(2)]
+                 + [self._v("short", 40, f"Only Short {i} Title")
+                    for i in range(2)])
+        fb = m._compose_kind_hints(small, channel="en")
+        assert fb and "LONG-FORM:" not in fb
+
+
+class TestGalleryRetentionPrior:
+    """July 31 2026: the gallery-retention flywheel was a dead end (built
+    nightly, consumed only by a dashboard card). Scene ranking now takes
+    a BOUNDED retention prior — overlap stays primary, the prior only
+    shuffles near-ties, and a missing report is a byte-identical no-op."""
+
+    def test_prior_is_fail_open(self):
+        from engine.gallery_library import _retention_tag_scores
+        assert _retention_tag_scores("show_that_never_existed") == {}
+
+    def test_prior_is_bounded(self):
+        from engine.gallery_library import _retention_score
+        entry = {"tags": ["hot tag"]}
+        assert _retention_score(entry, {"hot tag": 500.0}) == 10.0
+        assert _retention_score(entry, {"hot tag": -500.0}) == -10.0
+        assert _retention_score(entry, {}) == 0.0
+
+    def test_overlap_still_outranks_retention(self):
+        from engine.gallery_library import _rank, _RETENTION_PRIOR_CACHE
+        _RETENTION_PRIOR_CACHE["__test_show__"] = {"great tag": 10.0}
+        overlap_entry = {"image_id": "a", "episode_date": "2026-07-01",
+                         "tags": [], "prompt": "starship booster catch",
+                         "caption": ""}
+        retention_entry = {"image_id": "b", "episode_date": "2026-07-01",
+                           "tags": ["great tag"], "prompt": "", "caption": ""}
+        out = _rank([retention_entry, overlap_entry],
+                    "starship booster catch", "__test_show__")
+        assert out[0]["image_id"] == "a", (
+            "retention prior must never outrank a real context match")
+
+    def test_no_slug_is_legacy_order(self):
+        from engine.gallery_library import _rank
+        a = {"image_id": "a", "episode_date": "2026-07-02", "tags": [],
+             "prompt": "", "caption": ""}
+        b = {"image_id": "b", "episode_date": "2026-07-01", "tags": [],
+             "prompt": "", "caption": ""}
+        assert [e["image_id"] for e in _rank([b, a], "")] == ["a", "b"]


### PR DESCRIPTION
Operator-directed video pass, complete. Three tranches, all render/metadata-side (outside landmine #17, no audio touched), $0/episode added cost.

## 1. Hook-first Shorts — "one Short per channel is the starting hook sequence"
Short #1 on **every channel** (EN @NerraNetwork, RU @NerraRU, FR @NerraFR) now opens on the episode's hook sequence (t≈0 is the hook since the July 30 cold-open pass); the smart selector's windows fill Shorts #2/#3 with overlaps dropped. One shared helper (`hook_first_windows`) across all three publish paths. Every Short records its window provenance (`hook_open`/`qualified`/`filled`/`legacy_fallback`) through the video index into `api/youtube_stats.json` — **hook-vs-smart performance is attributable from day one**. spacex pins the feature off until the motion A/B reads out (flipping mid-experiment would confound arm with window position).

## 2. Render look v2 — the "200%+" visual tranche
From a second-by-second audit of what viewers actually see (plan in the PR branch history):
- **Network color grade** (contrast/saturation lift + vignette + de-banding) on every background, both formats — one produced look instead of raw mismatched Grok stills.
- **Long-form opening hook title** (fading 2-line autofit at 0–4s) — the spoken cold open finally has an on-screen counterpart, aimed squarely at the 10.7%-median-retention cliff.
- **Long-form per-word highlighted captions** — the TikTok-style treatment Shorts already had, now on long-form (the word timestamps were already free), with SRT fallback + path metric.
- **Ken Burns vocabulary 4 → 8 moves**, per-episode seeded order, three zoom amplitudes — no two episodes share the same camera sequence anymore (previously every video on all 13 shows used identical moves in identical order). Feasibility verified numerically per-frame; A/B-enrolled shows keep byte-identical legacy motion.
- **Accelerating open** — 2× scene-change rate in the first 60 seconds, calm cruise after.
- **Shorts polish**: hook fades in/out (was a single-frame pop), end-card fades in (was a hard cut mid-sentence), active caption word pops, output sharpening for the 9:16 upsample, supersampled pills with a cyan accent.
- `RENDER_LOOK_VERSION = 2` recorded per episode so every retention metric can be segmented by visual era.

**Held for the motion-A/B verdict** (documented in CLAUDE.md): Shorts transition-vocabulary split, progress bar, punch-in cuts, long-form ending beat — shipping them now would upgrade the control arm mid-experiment.

## 3. Recursive learning loop — closed and de-confounded
- **Gallery-retention flywheel finally consumed**: scene ranking takes a bounded ±10 retention prior (context overlap stays primary; missing report = byte-identical legacy). The nightly report had been a dashboard-card dead end since June.
- **Title-hint hygiene**: long-form and Shorts mined separately (the blended "top quartile" was structurally all-Shorts at ~42% retention steering ~10%-retention long-form titles), and fragment/dateline titles can no longer be quoted as exemplars.
- **Motion A/B de-confounded**: treatment was pinned to always-the-second-best window; enrolled shows now alternate the top-two window assignment by episode parity. Caught at 2 published treatment Shorts.

## Verification
483 tests green across render/selector/AB/feedback/integration suites; 1,186-test broad smoke green; every previously-pinned filter-graph behavior updated deliberately with new guards (KB feasibility across 8 moves × 3 amplitudes, grade presence in all graphs and absence from the stage-1 slideshow, legacy byte-identity under `kb_extended=False`, hook-first semantics, retention-prior boundedness).

## What to watch
- First post-merge episodes: the long-form hook title, per-word captions, and grade are the visible changes — eyeball one render.
- In ~2 weeks: `window` labels in `api/youtube_stats.json` answer "do hook Shorts outperform smart windows"; `render_look_version` segments retention before/after; the A/B report reads out and unlocks the held Shorts-energy items + the spacex hook-first flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr