### PR TITLE
48h performance review: verification fixes, real SpaceX footage path, motion A/B ended

### DIFF
--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -120,7 +120,11 @@ jobs:
         with:
           python-version: '3.12'
           requirements-file: 'requirements.txt'
-          # MIT monthly needs yfinance + engine deps for R2 + ffmpeg
+          # The comment above this line long CLAIMED ffmpeg but nothing
+          # installed it — the July 31 2026 scheduled run generated the
+          # whole episode then died at the mix step with
+          # FileNotFoundError: 'ffmpeg'. Same param run-show.yml uses.
+          system-packages: 'ffmpeg'
           skip-checkout: 'true'
 
       - name: Run MIT monthly episode

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -253,6 +253,9 @@ def record_youtube_outcomes(
         if youtube_urls.get("long_form_captions_path"):
             metrics.record("long_form_captions_path",
                            str(youtube_urls["long_form_captions_path"]))
+        if youtube_urls.get("shorts_ab_windows_swapped") is not None:
+            metrics.record("shorts_ab_windows_swapped",
+                           bool(youtube_urls["shorts_ab_windows_swapped"]))
         if "scene_fresh_count" in youtube_urls:
             metrics.record("scene_fresh_count", int(youtube_urls.get("scene_fresh_count", 0) or 0))
         if "scene_library_count" in youtube_urls:

--- a/run_show.py
+++ b/run_show.py
@@ -5689,6 +5689,15 @@ def _publish_youtube(
                     and episode_num % 2 == 1):
                 shorts_plan[0], shorts_plan[1] = (
                     shorts_plan[1], shorts_plan[0])
+                # The per-window Short TITLES were generated from the
+                # plan BEFORE this swap (the title bundle runs upstream)
+                # — swap them in lockstep or the two Shorts ship with
+                # each other's titles. Shipped live on spacex Ep053
+                # (2026-08-01): both Shorts published title-crossed.
+                if (isinstance(yt_short_titles, list)
+                        and len(yt_short_titles) >= 2):
+                    yt_short_titles[0], yt_short_titles[1] = (
+                        yt_short_titles[1], yt_short_titles[0])
                 result["shorts_ab_windows_swapped"] = True
                 result["shorts_start_offset"] = round(shorts_plan[0][0], 2)
                 result["shorts_start_offsets"] = [

--- a/scripts/fetch_nasa_broll.py
+++ b/scripts/fetch_nasa_broll.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Fetch public-domain NASA footage as b-roll candidates for curation.
+
+Why NASA and not SpaceX's own media (August 2026, operator request to use
+"real SpaceX videos" in SpaceX Daily renders):
+
+* **NASA-produced footage is public domain** (17 U.S.C. §105) — launches,
+  Crew Dragon arrivals/departures, ISS operations, mission coverage. Safe
+  in monetized YouTube videos; NASA asks only that its logo not imply
+  endorsement.
+* **SpaceX's Flickr photos are CC BY-NC 2.0** — the NC (non-commercial)
+  term is a problem for monetized channels. Operator judgment call, not a
+  default.
+* **SpaceX webcast video is SpaceX's copyright** with no reuse license —
+  wholesale b-roll reuse risks Content ID claims/strikes. Not fetched
+  here; if wanted, ask SpaceX media relations for written permission.
+
+This script only DOWNLOADS candidates into a local directory. The
+operator then curates (watch, delete duds, keep evergreen shots — pads,
+launches, stage separations; nothing dated) and publishes the keepers
+with the existing pool builder::
+
+    python scripts/fetch_nasa_broll.py --query "Falcon 9 launch" \
+        --out-dir nasa_broll/ --max 12
+    # ...watch + curate...
+    python scripts/build_broll_pool.py --show spacex \
+        --label "NASA launch b-roll" nasa_broll/keeper1.mp4 ...
+
+The NASA Image and Video Library API (images-api.nasa.gov) needs no key.
+Videos come as asset manifests; we pick the largest mp4 under the size
+cap (b-roll only needs a few seconds of each — the renderer trims).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("fetch_nasa_broll")
+
+_API = "https://images-api.nasa.gov/search"
+_MAX_BYTES_DEFAULT = 220 * 1024 * 1024  # skip multi-GB full-event videos
+
+
+def _get_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _search(query: str, page: int = 1) -> list:
+    q = urllib.parse.urlencode({
+        "q": query, "media_type": "video", "page": page,
+    })
+    data = _get_json(f"{_API}?{q}")
+    return ((data.get("collection") or {}).get("items")) or []
+
+
+def _best_mp4(asset_manifest_href: str, max_bytes: int) -> str:
+    """Pick the preferred mp4 rendition from an asset manifest.
+
+    Manifests list renditions like ``...~orig.mp4`` / ``~large.mp4`` /
+    ``~medium.mp4`` / ``~small.mp4``. Prefer large -> medium -> orig ->
+    small: 'orig' can be a multi-GB master, and b-roll only needs
+    1080p-ish quality.
+    """
+    data = _get_json(asset_manifest_href)
+    # The item's href points at a collection.json that is a BARE LIST of
+    # asset URLs (verified live 2026-08-01); some endpoints wrap it in
+    # the search-style {"collection": {"items": [{"href": ...}]}}
+    # envelope instead. Handle both.
+    if isinstance(data, list):
+        hrefs = [str(h) for h in data]
+    else:
+        hrefs = [i.get("href") or "" for i in
+                 ((data.get("collection") or {}).get("items")) or []]
+    mp4s = [h for h in hrefs if h.lower().endswith(".mp4")]
+    for marker in ("~large.mp4", "~medium.mp4", "~orig.mp4", "~small.mp4"):
+        for h in mp4s:
+            if h.lower().endswith(marker):
+                return h
+    return mp4s[0] if mp4s else ""
+
+
+def _content_length(url: str) -> int:
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return int(resp.headers.get("Content-Length") or 0)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def _safe_name(nasa_id: str, title: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", (title or nasa_id))[:60].strip("_")
+    return f"{nasa_id}__{slug}.mp4"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", required=True,
+                        help='e.g. "Falcon 9 launch", "Crew Dragon docking"')
+    parser.add_argument("--out-dir", default="nasa_broll")
+    parser.add_argument("--max", type=int, default=10,
+                        help="max videos to download")
+    parser.add_argument("--max-bytes", type=int, default=_MAX_BYTES_DEFAULT)
+    parser.add_argument("--pages", type=int, default=2,
+                        help="search pages to scan (100 results/page)")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded = 0
+    manifest_rows = []
+    for page in range(1, args.pages + 1):
+        if downloaded >= args.max:
+            break
+        try:
+            items = _search(args.query, page=page)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("search page %d failed: %s", page, exc)
+            break
+        for item in items:
+            if downloaded >= args.max:
+                break
+            data0 = (item.get("data") or [{}])[0]
+            nasa_id = data0.get("nasa_id") or ""
+            title = data0.get("title") or ""
+            center = data0.get("center") or ""
+            if not nasa_id:
+                continue
+            dest = out_dir / _safe_name(nasa_id, title)
+            if dest.exists():
+                logger.info("skip (exists): %s", dest.name)
+                continue
+            try:
+                mp4 = _best_mp4(item.get("href") or "", args.max_bytes)
+                if not mp4:
+                    continue
+                size = _content_length(mp4)
+                if size and size > args.max_bytes:
+                    logger.info("skip (too large, %.0f MB): %s",
+                                size / 1e6, title[:60])
+                    continue
+                logger.info("downloading %s (%.0f MB): %s",
+                            nasa_id, (size or 0) / 1e6, title[:70])
+                urllib.request.urlretrieve(mp4, dest)  # noqa: S310
+                downloaded += 1
+                manifest_rows.append({
+                    "nasa_id": nasa_id, "title": title, "center": center,
+                    "source_url": mp4, "file": dest.name,
+                    "license": "public domain (NASA, 17 U.S.C. 105)",
+                })
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("failed %s: %s", nasa_id, exc)
+                dest.unlink(missing_ok=True)
+
+    # Provenance sidecar so the curated keepers keep their attribution
+    # trail (which clip came from which NASA asset).
+    if manifest_rows:
+        (out_dir / "_provenance.json").write_text(
+            json.dumps(manifest_rows, indent=2), encoding="utf-8")
+    logger.info("downloaded %d video(s) to %s — now WATCH and curate, "
+                "then publish keepers with scripts/build_broll_pool.py",
+                downloaded, out_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_monthly_mit_episode.py
+++ b/scripts/run_monthly_mit_episode.py
@@ -593,9 +593,24 @@ def main() -> int:
         logger.info("Not the last trading day of the month — exiting without work.")
         return 0
 
+    month, year = args.month, args.year
+    if (args.require_last_trading_day
+            and (month, year) == (default_month, default_year)):
+        # The cron fires ON the month's last trading day (22:00 UTC,
+        # after close) to recap THAT month — but the CLI default is the
+        # PREVIOUS calendar month (for early-next-month manual runs).
+        # The July 31 2026 scheduled run therefore wrote
+        # Monthly_2026-06, re-recapping June. When the gate proves
+        # today IS the month-end, recap today's month; an explicit
+        # --month always wins (the equality check only overrides the
+        # untouched default).
+        month, year = today.month, today.year
+        logger.info("Last-trading-day run: recapping the CURRENT month "
+                    "(%04d-%02d).", year, month)
+
     return run(
-        month=args.month,
-        year=args.year,
+        month=month,
+        year=year,
         dry_run=args.dry_run,
         skip_audio=args.skip_audio,
         skip_rss=args.skip_rss,

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -433,6 +433,16 @@ youtube:
   # base (cover fallback); `thumbnail_variants` extra composites from
   # other scenes feed the operator's Studio "Test & Compare" A/B.
   long_form_thumbnail_from_scene: true
+  # Aug 1 2026: ON network-wide. The July 30 "captions from the track,
+  # not the pixels" change made burn-in opt-in — and no show opted in,
+  # so long-form shipped with NO on-screen captions at all and the July
+  # 31 per-word ASS work (transcript_to_ass_full) was dormant. The
+  # operator's video directive ("most enjoyable, visually appealing")
+  # wants the burned per-word treatment; the uploaded caption TRACK
+  # still ships alongside (YouTube CC defaults off, so no doubling for
+  # normal viewers). long_form_captions_path metric records ass vs
+  # srt_fallback per episode.
+  long_form_burn_in_captions: true
   thumbnail_variants: 2
   # Sunday recaps reuse the week's gallery scenes (both aspects) instead
   # of regenerating imagery for stories already illustrated this week.

--- a/shows/dp_pod.yaml
+++ b/shows/dp_pod.yaml
@@ -90,6 +90,14 @@ llm:
   # segment was added, July 2026). Floor sits just under it so the
   # expand-retry fires on anything short of a full episode.
   min_podcast_words: 1550
+  # Aug 1 2026: dp_pod's script slid 1533 -> 1199 -> 1089 -> 929 words
+  # across four episodes and Aug 1 SKIPPED at the hard floor — the only
+  # missed daily show. Its own digest/brief shrank in step (958 -> 718
+  # -> 740 words), and the July playbook says length levers are
+  # DIGEST-side only: the script can't say more than the brief gives
+  # it. Same lever env_intel got on July 31.
+  digest_expand_below_target: true
+  min_digest_words: 900
   min_podcast_word_floor: 1000
   # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
   # episodes: 81% still shipped BELOW target WITH this retry running (Tesla

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -413,13 +413,17 @@ youtube:
   # is ~$32/mo — real money against a ~$110-125/mo network, so the
   # experiment is meant to be READ AND ENDED, not left running. Revisit
   # once api/shorts_ab.json has >= 14 episodes per arm.
-  shorts_ab_enabled: true
-  # Hook-first Shorts (July 31 2026 network default) is PINNED OFF here
-  # until the motion A/B reads out: with it on, control (Short #1)
-  # would become the hook window while treatment (Short #2) stays a
-  # smart window — confounding motion with window position. Flip to
-  # true when the experiment ends (>= 14/arm, read api/shorts_ab.json).
-  shorts_first_is_hook: false
+  # ENDED 2026-08-01 (operator verdict supersedes the experiment): the
+  # operator reviewed the spacex videos and wants REAL footage (NASA
+  # public-domain b-roll via scripts/fetch_nasa_broll.py +
+  # build_broll_pool.py) instead of paid generated motion. The A/B had
+  # produced ZERO analytics-rated episodes in either arm (status
+  # not_started) at ~$1.05/ep, and staying enrolled was also pinning
+  # spacex to legacy Ken Burns (kb_extended=False) and smart-first
+  # Shorts. Config below retained for a one-line re-enable.
+  shorts_ab_enabled: false
+  # Hook-first now ON (was pinned off only to protect the experiment).
+  shorts_first_is_hook: true
   shorts_ab_video_indexes: [1]
   shorts_ab_clips: 3
   shorts_ab_clip_seconds: 5

--- a/tests/test_shorts_ab.py
+++ b/tests/test_shorts_ab.py
@@ -40,10 +40,15 @@ def spacex():
 # ---------------------------------------------------------------------------
 
 class TestPlanVariants:
-    def test_spacex_is_enrolled_with_short_2_as_the_treatment(self, spacex):
-        assert shorts_ab.is_enabled(spacex)
+    def test_spacex_enrollment_ended_by_operator_verdict(self, spacex):
+        """2026-08-01: the operator reviewed the spacex videos and chose
+        real NASA b-roll over paid generated motion — the experiment
+        ended with ZERO analytics-rated episodes in either arm. The
+        machinery stays (config retained for a one-line re-enable), but
+        no show is enrolled and spacex ships all-stills plans."""
+        assert shorts_ab.is_enabled(spacex) is False
         assert shorts_ab.plan_variants(spacex, 2) == [
-            shorts_ab.VARIANT_STILLS, shorts_ab.VARIANT_GROK_VIDEO,
+            shorts_ab.VARIANT_STILLS, shorts_ab.VARIANT_STILLS,
         ]
 
     def test_index_zero_is_always_the_control(self, spacex):
@@ -64,6 +69,7 @@ class TestPlanVariants:
             [shorts_ab.VARIANT_STILLS] * 2
 
     def test_junk_indexes_do_not_crash_a_publish(self, spacex):
+        spacex.youtube.shorts_ab_enabled = True  # machinery test
         spacex.youtube.shorts_ab_video_indexes = ["x", None, 1]
         assert shorts_ab.plan_variants(spacex, 2)[1] == \
             shorts_ab.VARIANT_GROK_VIDEO
@@ -75,17 +81,18 @@ class TestPlanVariants:
             assert shorts_ab.plan_variants(cfg, 2) == \
                 [shorts_ab.VARIANT_STILLS] * 2
 
-    def test_only_spacex_is_enrolled(self):
-        """One show at a time. Two enrolled shows would double the spend
-        and still not answer the question faster — the comparison is
-        within-show."""
+    def test_no_show_is_enrolled(self):
+        """The experiment ended 2026-08-01 (operator verdict: real
+        footage over generated motion). If it ever restarts: one show at
+        a time — two enrolled shows would double the spend and still not
+        answer the question faster; the comparison is within-show."""
         from engine.config import discover_show_slugs
 
         enrolled = [
             slug for slug in discover_show_slugs()
             if shorts_ab.is_enabled(load_config(ROOT / "shows" / f"{slug}.yaml"))
         ]
-        assert enrolled == ["spacex"]
+        assert enrolled == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shorts_selector.py
+++ b/tests/test_shorts_selector.py
@@ -717,17 +717,18 @@ class TestHookFirstWindows:
         from engine.shorts_selector import hook_first_windows
         assert hook_first_windows([], n=0, hook_start=0.0) == []
 
-    def test_network_default_is_on_and_spacex_pins_off(self):
-        """Default true (the directive applies network-wide); spacex is
-        pinned false until the Shorts motion A/B reads out — flipping it
-        mid-experiment would confound arm position with window choice."""
+    def test_hook_first_is_on_network_wide_including_spacex(self):
+        """Default true (the directive applies network-wide). spacex was
+        pinned false only to protect the motion A/B from a window-
+        position confound; the experiment ended 2026-08-01 (operator
+        verdict: real footage over generated motion), so the pin lifted
+        with it."""
         from engine.config import load_config
         from pathlib import Path
         root = Path(__file__).resolve().parent.parent
-        assert load_config(root / "shows" / "tesla.yaml").youtube \
-            .shorts_first_is_hook is True
-        assert load_config(root / "shows" / "spacex.yaml").youtube \
-            .shorts_first_is_hook is False
+        for slug in ("tesla", "spacex"):
+            assert load_config(root / "shows" / f"{slug}.yaml").youtube \
+                .shorts_first_is_hook is True, slug
 
     def test_run_show_and_both_dub_paths_are_wired(self):
         """All three publish paths must apply the directive — a channel

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -2127,14 +2127,31 @@ class TestLongFormCaptionLayer:
         assert "caption_track_uploaded" in src
         assert "shipped with NO captions" in src
 
-    def test_no_show_yaml_turns_burn_in_back_on(self):
+    def test_burn_in_decision_is_centralized_in_defaults(self):
+        """Aug 1 2026 reversal: burn-in is ON as the NETWORK default.
+
+        History: July 30 made burn-in opt-in ("captions from the track,
+        not the pixels") — and no show opted in, so long-form shipped
+        with no on-screen captions at all and the July-31 per-word ASS
+        layer was dormant. The operator's video directive turned it back
+        on network-wide. The decision lives in _defaults.yaml ONLY:
+        per-show files stay silent (a show wanting out sets false
+        explicitly, which this guard permits but none does today)."""
         import pathlib
         import yaml as _yaml
         root = pathlib.Path(__file__).resolve().parent.parent
+        defaults = _yaml.safe_load(
+            (root / "shows" / "_defaults.yaml").read_text(encoding="utf-8"))
+        assert (defaults.get("youtube") or {}).get(
+            "long_form_burn_in_captions") is True
         for path in sorted((root / "shows").glob("*.yaml")):
+            if path.name == "_defaults.yaml":
+                continue
             raw = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
             yt = raw.get("youtube") or {}
-            assert yt.get("long_form_burn_in_captions") is not True, path.name
+            assert yt.get("long_form_burn_in_captions") is not True, (
+                f"{path.name}: redundant per-show flip — the default is "
+                "already true; only explicit opt-OUTs belong in show YAMLs")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Mechanical review of how the last 48 hours' changes performed in production (evidence from committed Aug 1 artifacts — the first day through the full stack), plus the SpaceX real-footage request.

## Scorecard (verified against Aug 1 episodes)
| Change | Verdict | Evidence |
|---|---|---|
| Identity line (P0) | ✅ Working | All 10 Aug 1 episodes say "This is ⟨Show⟩, episode N" right after the hook; zero misses |
| Tic de-seeds | ✅ Working | 0 occurrences of every banned phrase in post-fix episodes; dp_pod Ep023→024 shows a clean generational break |
| Hook-first Shorts | ✅ Working | `hook_open` Short #1 on tesla/FF/OV; `window` labels flowing into the index on all channels |
| Render look v2 | ✅ Working | `render_look_version: 2` everywhere; 2/2 Shorts + long + video-podcast uploaded, no errors; renders +10–25% slower, no timeouts |
| A/B contamination fix | ✅ Holding | Non-enrolled shows record `variant: None` |
| Funnel honesty | ✅ Correct semantics | attributed 0 vs unattributed 132, coverage 0.0% — honest launch state, watch it climb as tagged videos age in |
| clean_digest | ⚠️ Partial | No network-wide length crater; dp_pod declined separately (fixed below) |
| MIT monthly | ❌ Was broken | Fixed below — two independent failures |
| CI on main | ✅ Green | test.yml success on the render-v2 merge |

## Fixes in this PR
1. **dp_pod digest-side length lever** (`min_digest_words: 900`) — its script slid 1533→1199→1089→929 words and Aug 1 **skipped at the hard floor** (the only missed daily show); its own brief shrank in step. Playbook-sanctioned substrate.
2. **A/B window-parity swap now carries the Short titles with it** — spacex Ep053's two live Shorts published with each other's titles (titles were generated from the plan upstream of the swap). *Operator note: the two live Ep053 Shorts can be title-swapped in Studio in ~1 min.*
3. **MIT monthly recap actually ships now**: the workflow never installed ffmpeg (the July 31 run generated the entire episode then died at the mix), and the scheduled month-end run was recapping the **previous** month (July 31 wrote `Monthly_2026-06`). Both fixed — re-dispatch "Monthly Reports" with `mit_monthly_force` to produce the July recap.
4. **Long-form burned captions ON network-wide** — the July 30 "track, not pixels" change left every long-form video with **no on-screen captions at all**, and the July 31 per-word ASS layer was dormant (surfaced by `long_form_captions_path` missing from every metrics file). The caption track still uploads alongside; decision centralized in `_defaults.yaml` and guarded.

## SpaceX: real footage instead of generated visuals — YES, and the pipeline is ready
- **The consuming half already exists** (`evergreen_broll: true` is the network default; the renderer interleaves ≤3 real clips into long-form) — it's been a no-op waiting for a curated pool.
- **New: `scripts/fetch_nasa_broll.py`** — downloads **public-domain NASA footage** (17 U.S.C. §105; verified live: Falcon 9 pad drone shots, Crew launch highlights at 1080p) for you to curate, then publish with the existing `build_broll_pool.py`. Provenance sidecar keeps the attribution trail.
- **Licensing honesty**: SpaceX's Flickr stills are **CC BY-NC** (non-commercial — your judgment call for a monetized channel); SpaceX **webcast video has no reuse license** (Content ID risk — not fetched; ask SpaceX media relations for written permission if you want it). NASA material is the safe default and covers Falcon 9/Dragon well; Starship coverage is thinner (mostly SpaceX's own).
- **The motion A/B is ENDED** (your verdict supersedes it): zero analytics-rated episodes in either arm after ~a week at ~$1.05/ep, and enrollment was actively pinning spacex to legacy camera motion and smart-first Shorts. spacex now gets hook-first + full render look v2 **starting tomorrow**, before any footage is even curated. Config retained for a one-line restart.
- **Follow-up available on request**: wiring the b-roll pool into *Shorts* backgrounds (16:9→9:16 crop handling) — a small render tranche now that the A/B no longer gates Shorts motion.

## Your 10-minute path to real-footage SpaceX videos
```
python scripts/fetch_nasa_broll.py --query "Falcon 9 launch" --out-dir nasa_broll --max 12
# watch the clips, delete the duds, keep evergreen shots
python scripts/build_broll_pool.py --show spacex --label "NASA launch b-roll" nasa_broll/<keepers>.mp4
```
Commit the resulting `digests/spacex/broll.json` and the next render interleaves real footage automatically.

## Remaining watch items (no code needed yet)
- spacex double-published July 31 (Ep051 scheduled + Ep052 via the retry/dispatch path) — same off-schedule class as the FP/PR cadence P0.
- MAB Ep119 flagged by the audit for fabricated product names (3/10) — worth an operator listen.
- The daily audit's intro-greeting check predates the cold-open shape — cosmetic false positive.
- Tonight's nightly gives the first funnel attribution read and the FR channel's second velocity day.

Tests: 1,181 green across the affected sweep; workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_