### PR TITLE
SpaceX CC-licensed footage fetcher + b-roll attribution chain

### DIFF
--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -34,7 +34,7 @@ import logging
 import re
 import tempfile
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 
 import requests
 
@@ -549,6 +549,38 @@ def load_broll_entries(digests_dir: Path) -> List[dict]:
     if not isinstance(clips, list):
         return []
     return [c for c in clips if isinstance(c, dict) and c.get("url")]
+
+
+def broll_attributions_for(
+    clip_paths: Optional[Sequence] = None,
+    *,
+    digests_dir: Path,
+) -> List[str]:
+    """Footage credit lines for the b-roll clips a render actually used.
+
+    Matches the local cached Paths (whose file names are the pool URL
+    basenames — see ``select_broll_clips``) back to ``broll.json``
+    entries and returns their ``attribution`` strings, deduped, in pool
+    order. CC BY-sourced clips (SpaceX YouTube back-catalog) make this
+    load-bearing: the license requires the credit wherever the footage
+    ships. Entries without an attribution (e.g. the recovered Grok Video
+    clips — network-owned) contribute nothing. Never raises.
+    """
+    try:
+        if not clip_paths:
+            return []
+        used = {Path(p).name for p in clip_paths}
+        out: List[str] = []
+        for entry in load_broll_entries(Path(digests_dir)):
+            name = str(entry.get("url", "")).rstrip("/").rsplit("/", 1)[-1]
+            credit = str(entry.get("attribution") or "").strip()
+            if name in used and credit and credit not in out:
+                out.append(credit)
+        return out
+    except Exception as exc:  # noqa: BLE001 — credits must never block
+        logger.warning("gallery_library: b-roll attribution lookup "
+                       "failed: %s", exc)
+        return []
 
 
 def select_broll_clips(

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -318,6 +318,7 @@ def build_long_form_metadata(
     audio_url: str,
     chapters_path: Optional[Path] = None,
     photo_attribution: Optional[List[str]] = None,
+    footage_attribution: Optional[List[str]] = None,
     optimized_title: Optional[str] = None,
     channel: str = "en",
 ) -> Dict:
@@ -334,6 +335,12 @@ def build_long_form_metadata(
         Optional list of one-line photographer credits (e.g. from the
         Pexels slideshow). When non-empty, a "Photos:" block is
         appended to the description above the AI disclosure footer.
+    footage_attribution:
+        Optional list of one-line b-roll credits (from
+        ``engine.gallery_library.broll_attributions_for``). NOT
+        cosmetic when present: CC BY-licensed footage (SpaceX YouTube
+        back-catalog) legally requires the credit wherever the video
+        ships, so this block must survive any description refactor.
 
     Returns
     -------
@@ -484,6 +491,11 @@ def build_long_form_metadata(
         cleaned = [line.strip() for line in photo_attribution if line.strip()]
         if cleaned:
             pieces.append("Photos via Pexels:\n" + "\n".join(cleaned))
+    if footage_attribution:
+        cleaned = [line.strip() for line in footage_attribution
+                   if line.strip()]
+        if cleaned:
+            pieces.append("Footage:\n" + "\n".join(cleaned))
     disclosure = (config.youtube.synthetic_disclosure or "").strip()
     if disclosure:
         pieces.append(disclosure)

--- a/run_show.py
+++ b/run_show.py
@@ -5462,6 +5462,18 @@ def _publish_youtube(
             # still rendered (for the video feed) but must not upload,
             # touch the video index, the playlist, comments or captions.
             if _policy_publish_long:
+                # Footage credits for any b-roll the render used. CC BY
+                # sources (SpaceX YouTube back-catalog) require the
+                # credit; empty list for unattributed pools = today's
+                # description byte-for-byte.
+                try:
+                    from engine.gallery_library import broll_attributions_for
+                    _broll_credits = broll_attributions_for(
+                        _visual_plan.get("broll_clips"),
+                        digests_dir=digests_dir,
+                    )
+                except Exception:  # noqa: BLE001 — never block an upload
+                    _broll_credits = []
                 meta = build_long_form_metadata(
                     config,
                     episode_num=episode_num,
@@ -5471,6 +5483,7 @@ def _publish_youtube(
                     audio_url=audio_url,
                     chapters_path=chapters_path if chapters_path.exists() else None,
                     photo_attribution=pexels_attribution,
+                    footage_attribution=_broll_credits,
                     optimized_title=yt_title,
                 )
                 upload = upload_video(

--- a/scripts/build_broll_pool.py
+++ b/scripts/build_broll_pool.py
@@ -79,6 +79,34 @@ _VIDEO_CONTENT_TYPES = {
 }
 
 
+def attribution_for(clip: Path, explicit: str | None) -> str:
+    """Resolve a clip's footage credit line.
+
+    Precedence: the ``--attribution`` flag, then the ``attribution``
+    field of a ``_provenance.json`` beside the clip (written by
+    ``fetch_spacex_broll.py`` / ``fetch_nasa_broll.py``, keyed by file
+    name), else empty. CC BY-sourced clips (SpaceX YouTube) NEED this to
+    reach ``broll.json`` — the description credit the license requires
+    is built from it.
+    """
+    if explicit:
+        return explicit.strip()
+    prov_path = clip.parent / "_provenance.json"
+    if not prov_path.exists():
+        return ""
+    try:
+        rows = json.loads(prov_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("%s unreadable (%s) — no attribution", prov_path, exc)
+        return ""
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, dict) and row.get("file") == clip.name:
+            return str(row.get("attribution") or "").strip()
+    return ""
+
+
 def _load_pool(path: Path) -> dict:
     if not path.exists():
         return {}
@@ -101,6 +129,10 @@ def main() -> int:
                     help="Curated local clip files (.mp4/.mov/.webm)")
     ap.add_argument("--label", default=None,
                     help="Label for the uploaded clips (default: file stem)")
+    ap.add_argument("--attribution", default=None,
+                    help="Footage credit line for the uploaded clips "
+                         "(default: looked up per clip in a sibling "
+                         "_provenance.json from the fetch scripts)")
     args = ap.parse_args()
 
     try:
@@ -162,6 +194,9 @@ def main() -> int:
             "label": args.label or clip.stem,
             "key": key,
         }
+        credit = attribution_for(clip, args.attribution)
+        if credit:
+            entry["attribution"] = credit
         if url in by_url:
             by_url[url].update(entry)  # refresh label/duration in place
         else:

--- a/scripts/fetch_nasa_broll.py
+++ b/scripts/fetch_nasa_broll.py
@@ -11,9 +11,13 @@ Why NASA and not SpaceX's own media (August 2026, operator request to use
 * **SpaceX's Flickr photos are CC BY-NC 2.0** — the NC (non-commercial)
   term is a problem for monetized channels. Operator judgment call, not a
   default.
-* **SpaceX webcast video is SpaceX's copyright** with no reuse license —
-  wholesale b-roll reuse risks Content ID claims/strikes. Not fetched
-  here; if wanted, ask SpaceX media relations for written permission.
+* **SpaceX's own video is usable ONLY per-video**: parts of the YouTube
+  back-catalog are marked "Creative Commons Attribution (reuse allowed)"
+  (CC BY — monetized reuse OK with credit), but it's a per-video flag,
+  never channel-wide, and 2024+ streams live on X with no license grant.
+  ``fetch_spacex_broll.py`` handles that path with a hard CC gate +
+  attribution plumbing; anything not CC-marked stays off limits without
+  written permission from SpaceX media relations.
 
 This script only DOWNLOADS candidates into a local directory. The
 operator then curates (watch, delete duds, keep evergreen shots — pads,
@@ -158,6 +162,11 @@ def main() -> int:
                     "nasa_id": nasa_id, "title": title, "center": center,
                     "source_url": mp4, "file": dest.name,
                     "license": "public domain (NASA, 17 U.S.C. 105)",
+                    # Attribution isn't legally required for public-domain
+                    # NASA footage, but NASA asks for a courtesy credit —
+                    # build_broll_pool.py copies this into broll.json and
+                    # the render appends it to the YouTube description.
+                    "attribution": "NASA (public domain)",
                 })
             except Exception as exc:  # noqa: BLE001
                 logger.warning("failed %s: %s", nasa_id, exc)

--- a/scripts/fetch_spacex_broll.py
+++ b/scripts/fetch_spacex_broll.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Fetch SpaceX footage b-roll candidates — ONLY from CC-licensed videos.
+
+The licensing reality (verified 2026-08-01), because "SpaceX is open
+access" is only partly true and the differences are load-bearing for a
+monetized channel:
+
+* **SpaceX Flickr photos are CC BY-NC 2.0** since December 2019 (they
+  were CC0/public domain 2015-2019; SpaceX quietly relicensed). The NC
+  term fails a monetized YouTube channel. Photos are out regardless —
+  this pipeline wants video.
+* **SpaceX's YouTube back-catalog is the usable slice.** Videos a
+  channel marks with YouTube's "Creative Commons Attribution (reuse
+  allowed)" option are licensed CC BY (3.0 before YouTube's Aug 2025
+  switch, 4.0 after) — commercial reuse is allowed WITH attribution.
+  This is per-video, not per-channel: every video must be checked, and
+  this script refuses to download anything whose own metadata does not
+  say Creative Commons. There is no override flag on purpose.
+* **2024+ streams live on X**, which grants no reuse license at all.
+  X-hosted video is never fetched here.
+* NASA-produced footage of SpaceX missions is public domain regardless
+  — see ``fetch_nasa_broll.py`` for that (often the better source for
+  Crew Dragon / ISS material).
+
+CC BY's attribution requirement is handled end-to-end: every download
+records an ``attribution`` line in ``_provenance.json``, which
+``build_broll_pool.py`` copies into ``broll.json``, and the render
+pipeline appends a "Footage:" credit block to the YouTube description
+of any episode that actually uses the clip.
+
+Workflow::
+
+    # 1. Discover which recent channel videos are CC-licensed:
+    python scripts/fetch_spacex_broll.py --list-cc --max 40
+
+    # 2. Download a bounded section of a CC video (webcasts run hours —
+    #    grab the 30-60s you actually want, e.g. liftoff or landing):
+    python scripts/fetch_spacex_broll.py --out-dir spacex_broll \
+        --clip "https://www.youtube.com/watch?v=VIDEO_ID" 19:45-20:40
+
+    # 3. Watch + curate, then publish keepers (attribution flows in
+    #    automatically from _provenance.json):
+    python scripts/build_broll_pool.py --show spacex \
+        spacex_broll/keeper1.mp4 ...
+
+Requires ``yt-dlp`` on PATH (``pip install yt-dlp``). This is an
+operator-run curation tool like the NASA fetcher — it is not wired into
+any workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("fetch_spacex_broll")
+
+DEFAULT_CHANNEL = "https://www.youtube.com/@SpaceX/videos"
+# Bare (section-less) downloads only below this duration — anything
+# longer is a webcast and the operator must name the seconds they want.
+MAX_FULL_DOWNLOAD_SECONDS = 15 * 60
+
+_SECTION_RE = re.compile(
+    r"^(?P<start>\d{1,2}(?::\d{2}){0,2})-(?P<end>\d{1,2}(?::\d{2}){0,2})$"
+)
+
+
+def is_cc_license(license_str: str | None) -> bool:
+    """True only for YouTube's Creative Commons license strings.
+
+    yt-dlp reports the watch-page value verbatim — e.g. ``"Creative
+    Commons Attribution license (reuse allowed)"`` — and ``None`` or
+    ``"Standard YouTube License"`` otherwise. Substring match so the
+    post-Aug-2025 CC BY 4.0 wording also passes.
+    """
+    return "creative commons" in (license_str or "").lower()
+
+
+def cc_short_label(license_str: str | None, upload_date: str | None) -> str:
+    """Compact CC label for attribution lines.
+
+    YouTube's CC option was CC BY 3.0 until 2025-08-01 and CC BY 4.0
+    after (non-retroactive), keyed off the upload date.
+    """
+    if not is_cc_license(license_str):
+        return ""
+    if upload_date and upload_date >= "20250801":
+        return "CC BY 4.0"
+    return "CC BY 3.0"
+
+
+def parse_section(section: str | None) -> str | None:
+    """Validate ``MM:SS-MM:SS`` / ``H:MM:SS-…`` / ``full`` → yt-dlp form.
+
+    Returns the ``*start-end`` string yt-dlp's ``--download-sections``
+    expects, or ``None`` for a full download. Raises ValueError on any
+    other shape so a typo can't silently download four hours of webcast.
+    """
+    if section is None or section.strip().lower() == "full":
+        return None
+    m = _SECTION_RE.match(section.strip())
+    if not m:
+        raise ValueError(
+            f"bad section {section!r} — expected START-END like 19:45-20:40")
+    return f"*{m.group('start')}-{m.group('end')}"
+
+
+def build_attribution(title: str, video_id: str, license_str: str | None,
+                      upload_date: str | None, uploader: str = "SpaceX") -> str:
+    """One-line CC BY credit for the YouTube description Footage block."""
+    label = cc_short_label(license_str, upload_date) or "CC BY"
+    short_title = (title or video_id).strip()
+    if len(short_title) > 70:
+        short_title = short_title[:67].rstrip() + "..."
+    return (f"{uploader} — \"{short_title}\" "
+            f"({label}, https://youtu.be/{video_id})")
+
+
+def safe_name(video_id: str, title: str, section: str | None) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", (title or video_id))[:50].strip("_")
+    tag = ""
+    if section:
+        tag = "__" + re.sub(r"[^0-9]+", "-", section).strip("-")
+    return f"{video_id}__{slug}{tag}.mp4"
+
+
+def _require_ytdlp() -> str:
+    exe = shutil.which("yt-dlp")
+    if not exe:
+        logger.error("yt-dlp not found on PATH — install with: "
+                     "pip install yt-dlp")
+        raise SystemExit(1)
+    return exe
+
+
+def _probe(url: str) -> dict:
+    """Fetch a single video's metadata (no download)."""
+    exe = _require_ytdlp()
+    out = subprocess.run(  # noqa: S603
+        [exe, "-J", "--no-download", "--no-playlist", url],
+        capture_output=True, text=True, timeout=120, check=True,
+    ).stdout
+    return json.loads(out)
+
+
+def _list_channel_ids(channel_url: str, max_videos: int) -> list:
+    exe = _require_ytdlp()
+    out = subprocess.run(  # noqa: S603
+        [exe, "-J", "--flat-playlist", "--playlist-end", str(max_videos),
+         channel_url],
+        capture_output=True, text=True, timeout=300, check=True,
+    ).stdout
+    data = json.loads(out)
+    return [e.get("id") for e in (data.get("entries") or []) if e.get("id")]
+
+
+def _merge_provenance(out_dir: Path, rows: list) -> None:
+    """Merge this run's rows into ``_provenance.json`` keyed by file name.
+
+    (The NASA fetcher overwrites with only the current run's rows; here
+    curation typically spans several runs, so earlier rows must survive.)
+    """
+    path = out_dir / "_provenance.json"
+    existing: list = []
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, list):
+                existing = loaded
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("existing _provenance.json unreadable (%s) — "
+                           "starting fresh", exc)
+    by_file = {r.get("file"): r for r in existing if isinstance(r, dict)}
+    for row in rows:
+        by_file[row["file"]] = row
+    path.write_text(json.dumps(list(by_file.values()), indent=2),
+                    encoding="utf-8")
+
+
+def _download_clip(url: str, section_raw: str, out_dir: Path) -> dict | None:
+    try:
+        ytdlp_section = parse_section(section_raw)
+    except ValueError as exc:
+        logger.error("%s: %s — skipped", url, exc)
+        return None
+    try:
+        info = _probe(url)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("%s: metadata probe failed (%s) — skipped", url, exc)
+        return None
+    license_str = info.get("license")
+    video_id = info.get("id") or ""
+    title = info.get("title") or ""
+    uploader = info.get("uploader") or info.get("channel") or "SpaceX"
+    upload_date = info.get("upload_date") or ""
+    if not is_cc_license(license_str):
+        logger.error(
+            "REFUSED %s — license is %r, not Creative Commons. Only "
+            "CC-marked videos can be reused on a monetized channel; find "
+            "CC candidates with --list-cc, or use fetch_nasa_broll.py "
+            "for public-domain NASA coverage.", url, license_str)
+        return None
+    duration = float(info.get("duration") or 0)
+    if ytdlp_section is None and duration > MAX_FULL_DOWNLOAD_SECONDS:
+        logger.error(
+            "REFUSED full download of %s — %.0f min long. Webcasts must "
+            "be fetched as sections (e.g. --clip URL 19:45-20:40).",
+            url, duration / 60)
+        return None
+
+    dest = out_dir / safe_name(video_id, title, section_raw
+                               if ytdlp_section else None)
+    if dest.exists():
+        logger.info("skip (exists): %s", dest.name)
+        return None
+    exe = _require_ytdlp()
+    cmd = [exe,
+           # Video-only ≤1080p: b-roll is silent garnish, and skipping
+           # audio keeps webcast sections small.
+           "-f", "bv*[height<=1080][ext=mp4]/bv*[height<=1080]/bv*",
+           "--remux-video", "mp4",
+           "--no-playlist",
+           "-o", str(dest)]
+    if ytdlp_section:
+        cmd += ["--download-sections", ytdlp_section,
+                "--force-keyframes-at-cuts"]
+    cmd.append(url)
+    logger.info("downloading %s (%s): %s", video_id,
+                section_raw if ytdlp_section else "full", title[:70])
+    try:
+        subprocess.run(cmd, timeout=1800, check=True)  # noqa: S603
+    except Exception as exc:  # noqa: BLE001
+        logger.error("download failed for %s: %s", url, exc)
+        dest.unlink(missing_ok=True)
+        return None
+    if not dest.exists():
+        logger.error("yt-dlp reported success but %s is missing", dest)
+        return None
+    return {
+        "video_id": video_id,
+        "title": title,
+        "uploader": uploader,
+        "upload_date": upload_date,
+        "source_url": f"https://www.youtube.com/watch?v={video_id}",
+        "license": license_str,
+        "section": section_raw if ytdlp_section else "full",
+        "file": dest.name,
+        "attribution": build_attribution(
+            title, video_id, license_str, upload_date, uploader),
+    }
+
+
+def _list_cc(channel_url: str, max_videos: int) -> int:
+    logger.info("scanning %s (newest %d videos; one metadata request "
+                "each, so this takes a minute)...", channel_url, max_videos)
+    try:
+        ids = _list_channel_ids(channel_url, max_videos)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("channel listing failed: %s", exc)
+        return 1
+    found = 0
+    for vid in ids:
+        try:
+            info = _probe(f"https://www.youtube.com/watch?v={vid}")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("%s: probe failed (%s)", vid, exc)
+            continue
+        if is_cc_license(info.get("license")):
+            found += 1
+            dur = float(info.get("duration") or 0)
+            print(f"CC  {vid}  {info.get('upload_date', '????????')}  "
+                  f"{dur / 60:6.1f}min  {info.get('title', '')[:70]}")
+    logger.info("%d of %d scanned videos are CC-licensed. Note: SpaceX's "
+                "2024+ launch streams moved to X (no license grant), so "
+                "expect CC hits to skew toward the back-catalog — scan "
+                "deeper with --max, or pass known video URLs directly "
+                "via --clip.", found, len(ids))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--clip", nargs=2, action="append", default=[],
+                        metavar=("URL", "SECTION"),
+                        help='video URL + section ("19:45-20:40" or "full")')
+    parser.add_argument("--list-cc", action="store_true",
+                        help="scan the channel and list CC-licensed videos")
+    parser.add_argument("--channel", default=DEFAULT_CHANNEL,
+                        help=f"channel URL for --list-cc "
+                             f"(default: {DEFAULT_CHANNEL})")
+    parser.add_argument("--max", type=int, default=40,
+                        help="videos to scan with --list-cc")
+    parser.add_argument("--out-dir", default="spacex_broll")
+    args = parser.parse_args()
+
+    if not args.list_cc and not args.clip:
+        parser.error("nothing to do — pass --list-cc and/or --clip")
+
+    rc = 0
+    if args.list_cc:
+        rc = _list_cc(args.channel, args.max)
+
+    if args.clip:
+        out_dir = Path(args.out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        rows = []
+        for url, section in args.clip:
+            row = _download_clip(url, section, out_dir)
+            if row:
+                rows.append(row)
+        if rows:
+            _merge_provenance(out_dir, rows)
+        logger.info(
+            "downloaded %d clip(s) to %s — now WATCH and curate, then "
+            "publish keepers with scripts/build_broll_pool.py (attribution "
+            "carries over from _provenance.json automatically).",
+            len(rows), out_dir)
+        if not rows and rc == 0:
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_broll_attribution.py
+++ b/tests/test_broll_attribution.py
@@ -1,0 +1,272 @@
+"""Drift guards for the SpaceX CC-footage path + b-roll attribution chain.
+
+The chain (August 2026): ``scripts/fetch_spacex_broll.py`` downloads ONLY
+from YouTube videos whose own metadata says Creative Commons (per-video
+gate — SpaceX's Flickr went CC BY-NC in Dec 2019 and its 2024+ streams
+live on X with no license grant, so the CC-marked YouTube back-catalog is
+the one legally usable slice for a monetized channel). Each download
+records an ``attribution`` line in ``_provenance.json``;
+``build_broll_pool.py`` copies it into ``broll.json``;
+``engine.gallery_library.broll_attributions_for`` maps the clips a render
+used back to credit lines; and ``build_long_form_metadata`` appends them
+as a "Footage:" description block. CC BY makes that block a license
+obligation, not garnish — these tests pin every link.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+_SCRIPTS = PROJECT_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import fetch_spacex_broll as fsb  # noqa: E402
+from engine import gallery_library as gl  # noqa: E402
+from engine import video_metadata as vm  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# fetch_spacex_broll — the CC license gate
+# ---------------------------------------------------------------------------
+
+
+class TestCcLicenseGate:
+    def test_youtube_cc_string_passes(self):
+        # Exact string yt-dlp reports for CC-marked videos.
+        assert fsb.is_cc_license(
+            "Creative Commons Attribution license (reuse allowed)")
+
+    def test_standard_license_and_none_fail(self):
+        assert not fsb.is_cc_license("Standard YouTube License")
+        assert not fsb.is_cc_license(None)
+        assert not fsb.is_cc_license("")
+
+    def test_cc_by_40_wording_passes(self):
+        # YouTube switched its CC option to 4.0 wording on 2025-08-01;
+        # the gate must not be pinned to the 3.0 phrasing.
+        assert fsb.is_cc_license("Creative Commons Attribution 4.0")
+
+    def test_short_label_tracks_youtube_version_switch(self):
+        cc = "Creative Commons Attribution license (reuse allowed)"
+        assert fsb.cc_short_label(cc, "20240301") == "CC BY 3.0"
+        assert fsb.cc_short_label(cc, "20250801") == "CC BY 4.0"
+        assert fsb.cc_short_label("Standard YouTube License", "20240301") == ""
+
+    def test_download_refuses_non_cc_video(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fsb, "_probe", lambda url: {
+            "id": "abc123", "title": "Starship Flight",
+            "license": "Standard YouTube License", "duration": 300,
+        })
+        monkeypatch.setattr(fsb, "_require_ytdlp", lambda: "yt-dlp")
+        assert fsb._download_clip(
+            "https://youtu.be/abc123", "0:10-0:40", tmp_path) is None
+        assert list(tmp_path.iterdir()) == []
+
+    def test_download_refuses_full_webcast_without_section(
+            self, monkeypatch, tmp_path):
+        monkeypatch.setattr(fsb, "_probe", lambda url: {
+            "id": "abc123", "title": "Launch Webcast",
+            "license": "Creative Commons Attribution license (reuse allowed)",
+            "duration": 4 * 3600,
+        })
+        monkeypatch.setattr(fsb, "_require_ytdlp", lambda: "yt-dlp")
+        assert fsb._download_clip(
+            "https://youtu.be/abc123", "full", tmp_path) is None
+
+    def test_no_override_flag_exists(self):
+        # The whole point is that non-CC SpaceX video cannot be fetched.
+        # An --allow-non-cc style escape hatch must not appear.
+        src = (_SCRIPTS / "fetch_spacex_broll.py").read_text(encoding="utf-8")
+        assert "allow-non-cc" not in src
+        assert "allow_non_cc" not in src
+
+
+class TestSectionParsing:
+    def test_valid_sections(self):
+        assert fsb.parse_section("19:45-20:40") == "*19:45-20:40"
+        assert fsb.parse_section("1:02:10-1:03:00") == "*1:02:10-1:03:00"
+
+    def test_full_and_none(self):
+        assert fsb.parse_section("full") is None
+        assert fsb.parse_section("FULL") is None
+        assert fsb.parse_section(None) is None
+
+    def test_garbage_raises(self):
+        with pytest.raises(ValueError):
+            fsb.parse_section("liftoff")
+        with pytest.raises(ValueError):
+            fsb.parse_section("19:45")
+
+
+class TestAttributionLine:
+    def test_shape_carries_source_license_and_link(self):
+        line = fsb.build_attribution(
+            "Starship's Third Flight Test", "vid42",
+            "Creative Commons Attribution license (reuse allowed)",
+            "20240314")
+        assert "SpaceX" in line
+        assert "Starship's Third Flight Test" in line
+        assert "CC BY 3.0" in line
+        assert "https://youtu.be/vid42" in line
+
+    def test_long_titles_are_bounded(self):
+        line = fsb.build_attribution("T" * 200, "vid42",
+                                     "Creative Commons Attribution", "20240101")
+        assert len(line) < 160
+
+    def test_provenance_merge_preserves_earlier_runs(self, tmp_path):
+        (tmp_path / "_provenance.json").write_text(json.dumps(
+            [{"file": "old.mp4", "attribution": "SpaceX — old"}]),
+            encoding="utf-8")
+        fsb._merge_provenance(tmp_path, [
+            {"file": "new.mp4", "attribution": "SpaceX — new"}])
+        rows = json.loads(
+            (tmp_path / "_provenance.json").read_text(encoding="utf-8"))
+        assert {r["file"] for r in rows} == {"old.mp4", "new.mp4"}
+
+
+# ---------------------------------------------------------------------------
+# build_broll_pool — attribution into broll.json
+# ---------------------------------------------------------------------------
+
+
+class TestPoolBuilderAttribution:
+    def _mod(self):
+        import build_broll_pool
+        return build_broll_pool
+
+    def test_explicit_flag_wins(self, tmp_path):
+        clip = tmp_path / "a.mp4"
+        clip.write_bytes(b"x")
+        (tmp_path / "_provenance.json").write_text(json.dumps(
+            [{"file": "a.mp4", "attribution": "from provenance"}]),
+            encoding="utf-8")
+        assert self._mod().attribution_for(clip, "explicit") == "explicit"
+
+    def test_provenance_lookup_by_file_name(self, tmp_path):
+        clip = tmp_path / "a.mp4"
+        clip.write_bytes(b"x")
+        (tmp_path / "_provenance.json").write_text(json.dumps([
+            {"file": "other.mp4", "attribution": "wrong"},
+            {"file": "a.mp4", "attribution": "SpaceX — right"},
+        ]), encoding="utf-8")
+        assert self._mod().attribution_for(clip, None) == "SpaceX — right"
+
+    def test_missing_provenance_is_empty(self, tmp_path):
+        clip = tmp_path / "a.mp4"
+        clip.write_bytes(b"x")
+        assert self._mod().attribution_for(clip, None) == ""
+
+    def test_nasa_fetcher_writes_attribution(self):
+        src = (_SCRIPTS / "fetch_nasa_broll.py").read_text(encoding="utf-8")
+        assert '"attribution"' in src
+
+
+# ---------------------------------------------------------------------------
+# gallery_library — used clips → credit lines
+# ---------------------------------------------------------------------------
+
+
+def _write_pool(digests_dir: Path, entries):
+    (digests_dir / "broll.json").write_text(
+        json.dumps({"clips": entries}), encoding="utf-8")
+
+
+class TestBrollAttributionsFor:
+    def test_matches_used_clips_by_basename(self, tmp_path):
+        _write_pool(tmp_path, [
+            {"url": "https://r2/broll/spacex/aaa.mp4",
+             "attribution": "SpaceX — launch (CC BY 3.0, https://youtu.be/x)"},
+            {"url": "https://r2/broll/spacex/bbb.mp4",
+             "attribution": "NASA (public domain)"},
+            {"url": "https://r2/broll/spacex/ccc.mp4",
+             "attribution": "unused clip"},
+        ])
+        got = gl.broll_attributions_for(
+            [Path("/cache/aaa.mp4"), Path("/cache/bbb.mp4")],
+            digests_dir=tmp_path)
+        assert got == [
+            "SpaceX — launch (CC BY 3.0, https://youtu.be/x)",
+            "NASA (public domain)",
+        ]
+
+    def test_unattributed_entries_contribute_nothing(self, tmp_path):
+        # The recovered Grok Video clips are network-owned — no credit.
+        _write_pool(tmp_path, [{"url": "https://r2/broll/tesla/aaa.mp4"}])
+        assert gl.broll_attributions_for(
+            [Path("/cache/aaa.mp4")], digests_dir=tmp_path) == []
+
+    def test_dedupes_repeated_credits(self, tmp_path):
+        _write_pool(tmp_path, [
+            {"url": "https://r2/x/a.mp4", "attribution": "SpaceX — same"},
+            {"url": "https://r2/x/b.mp4", "attribution": "SpaceX — same"},
+        ])
+        assert gl.broll_attributions_for(
+            [Path("a.mp4"), Path("b.mp4")], digests_dir=tmp_path
+        ) == ["SpaceX — same"]
+
+    def test_none_and_missing_pool_are_clean(self, tmp_path):
+        assert gl.broll_attributions_for(None, digests_dir=tmp_path) == []
+        assert gl.broll_attributions_for([], digests_dir=tmp_path) == []
+        assert gl.broll_attributions_for(
+            [Path("a.mp4")], digests_dir=tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# video_metadata — the Footage description block
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**overrides):
+    publishing = SimpleNamespace(
+        rss_title="SpaceX Daily",
+        base_url="https://nerranetwork.com",
+        rss_link="https://nerranetwork.com/spacex.html",
+    )
+    youtube_cfg = SimpleNamespace(
+        tags=["spacex"], category_id=28, default_language="en",
+        synthetic_disclosure="AI Disclosure: synthesized voice.",
+        description_prompt_file="", pinned_comment_template="",
+        enabled=True, channel="en",
+    )
+    return SimpleNamespace(
+        name="SpaceX Daily", slug="spacex", publishing=publishing,
+        youtube=youtube_cfg, keywords=["spacex"],
+        **overrides,
+    )
+
+
+class TestFootageDescriptionBlock:
+    def _meta(self, **kwargs):
+        return vm.build_long_form_metadata(
+            _make_config(), episode_num=53, today_str="2026-08-01",
+            hook="Starship stacks for Flight 12",
+            digest_text="body", audio_url="https://x/ep.mp3", **kwargs)
+
+    def test_block_renders_credit_lines(self):
+        meta = self._meta(footage_attribution=[
+            "SpaceX — \"Flight Test\" (CC BY 3.0, https://youtu.be/x)",
+            "NASA (public domain)",
+        ])
+        desc = meta["description"]
+        assert "Footage:" in desc
+        assert "CC BY 3.0" in desc
+        assert "NASA (public domain)" in desc
+
+    def test_absent_or_empty_is_byte_identical(self):
+        base = self._meta()["description"]
+        assert self._meta(footage_attribution=[])["description"] == base
+        assert self._meta(footage_attribution=None)["description"] == base
+        assert "Footage:" not in base
+
+    def test_run_show_passes_footage_attribution(self):
+        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "footage_attribution=_broll_credits" in src
+        assert "broll_attributions_for" in src


### PR DESCRIPTION
Operator asked how to use SpaceX's own "open access" videos in SpaceX Daily renders. Verified the licensing first — it's only partly open, and the differences decide what a monetized channel can ship:

- **Flickr photos: CC BY-NC 2.0 since Dec 2019** (were CC0 2015–2019; SpaceX quietly relicensed). NC fails a monetized channel.
- **YouTube back-catalog: the usable slice.** Videos SpaceX marked with YouTube's "Creative Commons Attribution (reuse allowed)" option are CC BY — monetized reuse is fine **with credit**. Per-video flag, never channel-wide.
- **2024+ streams moved to X** — no license grant at all.

## What this adds

**`scripts/fetch_spacex_broll.py`** (operator-run, like the NASA fetcher — needs `yt-dlp` on PATH):
- `--list-cc` scans the channel and lists which videos are actually CC-licensed.
- `--clip URL 19:45-20:40` downloads a bounded section (video-only ≤1080p); full downloads are refused above 15 min so a typo can't pull a 4-hour webcast.
- **Hard CC gate, no override flag by design** — non-CC videos are refused with the exact license string printed.
- `_provenance.json` (merged across runs) records the exact license + a ready-made attribution line, including the CC BY 3.0 → 4.0 wording switch YouTube made on 2025-08-01.

**Attribution chain (CC BY makes this a license obligation, not garnish):**
- `build_broll_pool.py` copies attribution from the sibling `_provenance.json` (or an explicit `--attribution`) into `broll.json`.
- New `engine.gallery_library.broll_attributions_for` maps the clips a render actually used back to credit lines.
- `build_long_form_metadata` appends them as a `Footage:` description block. Empty list → today's description byte-for-byte (guarded).
- `fetch_nasa_broll.py` now writes a courtesy `NASA (public domain)` attribution and its overbroad "SpaceX has no reuse license" note is corrected to the per-video reality.

## Operator workflow

```
python scripts/fetch_spacex_broll.py --list-cc --max 40
python scripts/fetch_spacex_broll.py --out-dir spacex_broll \
    --clip "https://www.youtube.com/watch?v=VIDEO_ID" 19:45-20:40
# watch + curate, then:
python scripts/build_broll_pool.py --show spacex spacex_broll/keeper.mp4
# commit digests/spacex/broll.json
```

## Tests

`tests/test_broll_attribution.py` — 24 new tests: license gate (incl. 4.0 wording), section parsing, webcast refusal, provenance merge, pool-builder precedence, basename→credit mapping, `Footage:` block + byte-identical-when-empty, run_show wiring. Full suite: 5,667 passed; the one failure (`test_video_feed_metadata`) is this sandbox missing the optional `feedgen` package and reproduces on clean main.

No audio, no render change — metadata/tooling only, outside landmine #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_