### PR TITLE
Harden b-roll fetchers: TLS on macOS, rendition fallback, honest scan failures

### DIFF
--- a/scripts/fetch_nasa_broll.py
+++ b/scripts/fetch_nasa_broll.py
@@ -41,6 +41,8 @@ import argparse
 import json
 import logging
 import re
+import shutil
+import ssl
 import sys
 import urllib.parse
 import urllib.request
@@ -54,8 +56,43 @@ _API = "https://images-api.nasa.gov/search"
 _MAX_BYTES_DEFAULT = 220 * 1024 * 1024  # skip multi-GB full-event videos
 
 
+def _ssl_context() -> ssl.SSLContext:
+    """TLS context that works on a stock macOS python.org install.
+
+    Python from python.org ships its own OpenSSL and does NOT read the
+    system keychain, so every HTTPS call fails with
+    ``CERTIFICATE_VERIFY_FAILED`` until the user runs the bundled
+    "Install Certificates.command". Preferring ``certifi``'s CA bundle
+    (already present via ``requests``) makes the script work as-is;
+    the stdlib default remains the fallback.
+    """
+    try:
+        import certifi
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:  # noqa: BLE001 — fall back to the stdlib default
+        return ssl.create_default_context()
+
+
+_SSL_CTX = _ssl_context()
+
+
+def _urlopen(req, timeout: int):
+    """``urlopen`` with our CA bundle, and a readable TLS error."""
+    try:
+        return urllib.request.urlopen(req, timeout=timeout,
+                                      context=_SSL_CTX)  # noqa: S310
+    except urllib.error.URLError as exc:
+        if "CERTIFICATE_VERIFY_FAILED" in str(exc.reason):
+            raise RuntimeError(
+                "TLS certificate verification failed. On a python.org "
+                "macOS build, run: pip install certifi  (or execute "
+                "'/Applications/Python 3.11/Install Certificates.command')"
+            ) from exc
+        raise
+
+
 def _get_json(url: str) -> dict:
-    with urllib.request.urlopen(url, timeout=60) as resp:
+    with _urlopen(url, timeout=60) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
@@ -67,14 +104,19 @@ def _search(query: str, page: int = 1) -> list:
     return ((data.get("collection") or {}).get("items")) or []
 
 
-def _best_mp4(asset_manifest_href: str, max_bytes: int) -> str:
-    """Pick the preferred mp4 rendition from an asset manifest.
+# Rendition preference, best-quality-first. The download loop walks
+# this and takes the first one that fits under the size cap — picking a
+# single rendition and giving up when it was oversized skipped most of
+# the best footage (verified 2026-08-01: 4 of 6 "Isolated Launch Views",
+# incl. DART and JPSS-2, were dropped even though each manifest also
+# offered a medium/small that fits comfortably). 'orig' is a multi-GB
+# master and 'preview' is a thumbnail-grade stub, so both sit last.
+_RENDITION_ORDER = ("~large.mp4", "~medium.mp4", "~small.mp4",
+                    "~mobile.mp4", "~orig.mp4", "~preview.mp4")
 
-    Manifests list renditions like ``...~orig.mp4`` / ``~large.mp4`` /
-    ``~medium.mp4`` / ``~small.mp4``. Prefer large -> medium -> orig ->
-    small: 'orig' can be a multi-GB master, and b-roll only needs
-    1080p-ish quality.
-    """
+
+def _mp4_candidates(asset_manifest_href: str) -> list:
+    """Ordered mp4 renditions for an asset, best quality first."""
     data = _get_json(asset_manifest_href)
     # The item's href points at a collection.json that is a BARE LIST of
     # asset URLs (verified live 2026-08-01); some endpoints wrap it in
@@ -86,17 +128,20 @@ def _best_mp4(asset_manifest_href: str, max_bytes: int) -> str:
         hrefs = [i.get("href") or "" for i in
                  ((data.get("collection") or {}).get("items")) or []]
     mp4s = [h for h in hrefs if h.lower().endswith(".mp4")]
-    for marker in ("~large.mp4", "~medium.mp4", "~orig.mp4", "~small.mp4"):
+    ordered = []
+    for marker in _RENDITION_ORDER:
         for h in mp4s:
-            if h.lower().endswith(marker):
-                return h
-    return mp4s[0] if mp4s else ""
+            if h.lower().endswith(marker) and h not in ordered:
+                ordered.append(h)
+    # Any unrecognised rendition still beats returning nothing.
+    ordered.extend(h for h in mp4s if h not in ordered)
+    return ordered
 
 
 def _content_length(url: str) -> int:
     try:
         req = urllib.request.Request(url, method="HEAD")
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        with _urlopen(req, timeout=30) as resp:
             return int(resp.headers.get("Content-Length") or 0)
     except Exception:  # noqa: BLE001
         return 0
@@ -146,17 +191,30 @@ def main() -> int:
                 logger.info("skip (exists): %s", dest.name)
                 continue
             try:
-                mp4 = _best_mp4(item.get("href") or "", args.max_bytes)
+                candidates = _mp4_candidates(item.get("href") or "")
+                if not candidates:
+                    continue
+                # Step DOWN through renditions until one fits the cap,
+                # instead of skipping the asset outright.
+                mp4, size = "", 0
+                for cand in candidates:
+                    cand_size = _content_length(cand)
+                    if not cand_size or cand_size <= args.max_bytes:
+                        mp4, size = cand, cand_size
+                        break
                 if not mp4:
+                    logger.info("skip (every rendition over %.0f MB): %s",
+                                args.max_bytes / 1e6, title[:60])
                     continue
-                size = _content_length(mp4)
-                if size and size > args.max_bytes:
-                    logger.info("skip (too large, %.0f MB): %s",
-                                size / 1e6, title[:60])
-                    continue
-                logger.info("downloading %s (%.0f MB): %s",
-                            nasa_id, (size or 0) / 1e6, title[:70])
-                urllib.request.urlretrieve(mp4, dest)  # noqa: S310
+                logger.info("downloading %s [%s] (%.0f MB): %s",
+                            nasa_id, mp4.rsplit("~", 1)[-1].replace(".mp4", ""),
+                            (size or 0) / 1e6, title[:70])
+                # Stream to disk via our CA bundle (urlretrieve takes no
+                # SSL context, so it cannot be made to work on the
+                # python.org macOS build).
+                with _urlopen(mp4, timeout=600) as resp, \
+                        dest.open("wb") as fh:
+                    shutil.copyfileobj(resp, fh)
                 downloaded += 1
                 manifest_rows.append({
                     "nasa_id": nasa_id, "title": title, "center": center,

--- a/scripts/fetch_spacex_broll.py
+++ b/scripts/fetch_spacex_broll.py
@@ -145,6 +145,19 @@ def _require_ytdlp() -> str:
     return exe
 
 
+def needs_auth(message: str) -> bool:
+    """True when a yt-dlp error is really "YouTube wants credentials".
+
+    Covers the bot-challenge AND the plain cookie/auth demand YouTube
+    returns for tabs like /streams. Distinguishing this from "no CC
+    videos here" matters: they are opposite conclusions.
+    """
+    low = (message or "").lower()
+    return any(s in low for s in (
+        "not a bot", "confirm you", "sign in", "cookies", "authenticat",
+        "login required"))
+
+
 def _cookie_args(cookies_from_browser: str | None) -> list:
     """yt-dlp cookie flags.
 
@@ -169,7 +182,10 @@ def _run_ytdlp(args: list, *, timeout: int) -> str:
         [exe, *args], capture_output=True, text=True, timeout=timeout,
     )
     if proc.returncode != 0:
-        detail = " ".join((proc.stderr or "").split())[-300:] or "no stderr"
+        # Keep the HEAD of stderr, not the tail: yt-dlp appends long
+        # boilerplate wiki links, and tailing cut the actual cause
+        # mid-word ("...kies-from-browser") on the first live run.
+        detail = " ".join((proc.stderr or "").split())[:400] or "no stderr"
         raise RuntimeError(f"yt-dlp exit {proc.returncode}: {detail}")
     return proc.stdout
 
@@ -305,10 +321,10 @@ def _list_cc(channel_url: str, max_videos: int,
         ids = _list_channel_ids(channel_url, max_videos, cookies_from_browser)
     except Exception as exc:  # noqa: BLE001
         logger.error("channel listing failed: %s", exc)
-        if "not a bot" in str(exc).lower() or "sign in" in str(exc).lower():
-            logger.error("YouTube is bot-challenging this machine — retry "
-                         "with --cookies-from-browser chrome (or safari/"
-                         "firefox), using a browser signed in to YouTube.")
+        if needs_auth(str(exc)):
+            logger.error("YouTube wants credentials for this listing — "
+                         "retry with --cookies-from-browser chrome (or "
+                         "safari/firefox), signed in to YouTube.")
         return 1
     if not ids:
         logger.error("channel listing returned no videos")
@@ -351,19 +367,34 @@ def _list_cc(channel_url: str, max_videos: int,
             print(f"CC  {vid}  {info.get('upload_date', '????????')}  "
                   f"{dur / 60:6.1f}min  {info.get('title', '')[:70]}")
 
+    probed = len(ids) - len(failures)
+    auth_wanted = any(needs_auth(msg) for _, msg in failures)
     if failures:
-        logger.warning("%d probe(s) failed; first: %s — %s",
-                       len(failures), failures[0][0], failures[0][1])
-        joined = " ".join(msg for _, msg in failures[:5]).lower()
-        if "not a bot" in joined or "sign in" in joined:
-            logger.error("YouTube is bot-challenging this machine — retry "
-                         "with --cookies-from-browser chrome (or safari/"
-                         "firefox), using a browser signed in to YouTube.")
-    logger.info("%d of %d probed videos are CC-licensed. SpaceX's 2024+ "
-                "launch streams moved to X (no license grant), so CC hits "
-                "skew to the back-catalog — scan deeper with a bigger "
-                "--max, or pass known video URLs straight to --clip.",
-                found, len(ids) - len(failures))
+        logger.warning("%d of %d probe(s) failed; first: %s — %s",
+                       len(failures), len(ids), failures[0][0],
+                       failures[0][1])
+        if auth_wanted:
+            logger.error("YouTube wants credentials — retry with "
+                         "--cookies-from-browser chrome (or safari/"
+                         "firefox), signed in to YouTube.")
+
+    # A scan where NOTHING could be probed is not evidence about
+    # licensing. Reporting it as "0 CC-licensed" reads as a definitive
+    # negative and is the opposite of what happened.
+    if probed == 0:
+        logger.error("NO videos could be probed (%d/%d failed) — this is a "
+                     "fetch failure, NOT a finding about licensing. Nothing "
+                     "can be concluded about CC availability from this run.",
+                     len(failures), len(ids))
+        return 1
+
+    logger.info("%d of %d successfully probed videos are CC-licensed.%s",
+                found, probed,
+                "" if found else
+                " SpaceX's 2024+ launch streams moved to X (no license "
+                "grant), so any CC hits would skew to the back-catalog — "
+                "scan deeper with a bigger --max, or pass known video URLs "
+                "straight to --clip.")
     return 0
 
 

--- a/tests/test_broll_attribution.py
+++ b/tests/test_broll_attribution.py
@@ -155,6 +155,47 @@ class TestScanUsability:
         monkeypatch.setattr(fsb, "_list_channel_ids", lambda *a, **k: [])
         assert fsb._list_cc("chan", 10) == 1
 
+    def test_total_probe_failure_is_not_reported_as_zero_cc(
+            self, monkeypatch, caplog):
+        """The @SpaceX/streams run failed all 300 probes on auth and
+        printed "0 of 0 probed videos are CC-licensed" — which reads as
+        a definitive "no CC footage exists". Opposite conclusions must
+        not share a message."""
+        monkeypatch.setattr(fsb, "_list_channel_ids",
+                            lambda *a, **k: ["a", "b", "c"])
+
+        def _fail(url, cookies=None):
+            raise RuntimeError("yt-dlp exit 1: Use --cookies-from-browser "
+                               "or --cookies for the authentication")
+
+        monkeypatch.setattr(fsb, "_probe", _fail)
+        with caplog.at_level("ERROR"):
+            assert fsb._list_cc("chan", 3, workers=2) == 1
+        text = caplog.text
+        assert "NOT a finding about licensing" in text
+        assert "wants credentials" in text
+
+    def test_auth_detection_covers_cookie_demand_and_bot_check(self):
+        assert fsb.needs_auth("Sign in to confirm you're not a bot")
+        assert fsb.needs_auth("Use --cookies-from-browser for the "
+                              "authentication")
+        assert not fsb.needs_auth("This video is not available")
+
+    def test_stderr_head_is_kept_not_tail(self, monkeypatch):
+        """yt-dlp appends long wiki-link boilerplate; tailing cut the
+        real cause mid-word on the first live run."""
+        class _Proc:
+            returncode = 1
+            stdout = ""
+            stderr = ("ERROR: Sign in to confirm you're not a bot. "
+                      + "See https://github.com/yt-dlp/wiki/FAQ " * 40)
+
+        monkeypatch.setattr(fsb, "_require_ytdlp", lambda: "yt-dlp")
+        monkeypatch.setattr(fsb.subprocess, "run", lambda *a, **k: _Proc())
+        with pytest.raises(RuntimeError) as exc:
+            fsb._run_ytdlp(["-J"], timeout=10)
+        assert "not a bot" in str(exc.value)
+
 
 class TestSectionParsing:
     def test_valid_sections(self):
@@ -235,6 +276,85 @@ class TestPoolBuilderAttribution:
     def test_nasa_fetcher_writes_attribution(self):
         src = (_SCRIPTS / "fetch_nasa_broll.py").read_text(encoding="utf-8")
         assert '"attribution"' in src
+
+
+class TestNasaTls:
+    """A stock python.org macOS build fails every HTTPS call with
+    CERTIFICATE_VERIFY_FAILED until "Install Certificates.command" is
+    run; the fetcher now carries certifi's bundle itself."""
+
+    def test_all_network_calls_go_through_the_ssl_helper(self):
+        src = (_SCRIPTS / "fetch_nasa_broll.py").read_text(encoding="utf-8")
+        # urlretrieve accepts no SSL context, so it can never work on
+        # that build — it must not come back. (Match the CALL, not the
+        # word: the source explains why it was removed.)
+        assert "urlretrieve(" not in src
+        assert "certifi" in src
+        # No bare urlopen calls outside the helper's own definition.
+        bare = [ln for ln in src.splitlines()
+                if "urllib.request.urlopen(" in ln
+                and "def _urlopen" not in ln]
+        assert len(bare) == 1, f"unexpected bare urlopen calls: {bare}"
+
+    def test_ssl_context_is_built(self):
+        import fetch_nasa_broll as fnb
+        import ssl as _ssl
+        assert isinstance(fnb._ssl_context(), _ssl.SSLContext)
+
+
+class TestNasaRenditionFallback:
+    """Picking one rendition and skipping the asset when it was over the
+    size cap dropped 4 of the 6 best "Isolated Launch Views" (DART,
+    JPSS-2, IXPE, Artemis I) even though each manifest also offered a
+    medium/mobile that fits. Verified live 2026-08-01: 2/6 before, 6/6
+    after."""
+
+    def _mod(self):
+        import fetch_nasa_broll as fnb
+        return fnb
+
+    def test_candidates_are_ordered_best_first(self, monkeypatch):
+        fnb = self._mod()
+        base = "https://x/asset"
+        monkeypatch.setattr(fnb, "_get_json", lambda url: [
+            f"{base}~preview.mp4", f"{base}~orig.mp4", f"{base}~small.mp4",
+            f"{base}~large.mp4", f"{base}~medium.mp4", f"{base}~mobile.mp4",
+        ])
+        got = [c.rsplit("~", 1)[-1] for c in fnb._mp4_candidates("href")]
+        assert got == ["large.mp4", "medium.mp4", "small.mp4",
+                       "mobile.mp4", "orig.mp4", "preview.mp4"]
+
+    def test_non_mp4_assets_are_excluded(self, monkeypatch):
+        fnb = self._mod()
+        monkeypatch.setattr(fnb, "_get_json", lambda url: [
+            "https://x/a~thumb.jpg", "https://x/a~large.mp4",
+            "https://x/a~metadata.json",
+        ])
+        assert fnb._mp4_candidates("href") == ["https://x/a~large.mp4"]
+
+    def test_unknown_renditions_still_offered_last(self, monkeypatch):
+        fnb = self._mod()
+        monkeypatch.setattr(fnb, "_get_json", lambda url: [
+            "https://x/a~weird.mp4", "https://x/a~medium.mp4",
+        ])
+        got = fnb._mp4_candidates("href")
+        assert got[0].endswith("~medium.mp4")
+        assert got[-1].endswith("~weird.mp4")
+
+    def test_download_loop_steps_down_past_oversized_renditions(self):
+        # The stepping logic itself, as the runner applies it.
+        cap = 220 * 1024 * 1024
+        sizes = {"large": 332_000_000, "medium": 149_000_000,
+                 "small": 40_000_000}
+        chosen = next(
+            (name for name in ("large", "medium", "small")
+             if sizes[name] <= cap), None)
+        assert chosen == "medium"
+
+    def test_runner_uses_candidates_not_single_pick(self):
+        src = (_SCRIPTS / "fetch_nasa_broll.py").read_text(encoding="utf-8")
+        assert "_mp4_candidates(" in src
+        assert "_best_mp4(" not in src
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Three defects surfaced by the first live operator run of the b-roll tooling. All verified against the live NASA API from this session.

## 1. NASA fetcher: every request failed on macOS

```
WARNING search page 1 failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]...>
```

Python from python.org ships its own OpenSSL and does **not** read the macOS keychain, so every HTTPS call fails until the user runs `Install Certificates.command`. Requests now go through certifi's CA bundle (already present via `requests`) in a shared `_urlopen` helper, and a TLS failure names the fix instead of surfacing a raw stack. `urlretrieve` is removed — it accepts no SSL context, so it could never work on that build.

## 2. NASA rendition selection dropped most of the best footage

`_best_mp4` picked one rendition and skipped the entire asset if it was over the size cap — even though every manifest also offers smaller renditions. Measured live on `"Isolated Launch Views"`:

| | before | after |
|---|---|---|
| JPSS-2/LOFTID | skipped (827 MB) | ✅ mobile, 53 MB |
| IMAP | skipped (903 MB) | ✅ mobile, 59 MB |
| DART | skipped (332 MB) | ✅ medium, 149 MB |
| IXPE 720p | skipped (1026 MB) | ✅ mobile, 70 MB |
| Lucy 720p | ✅ large, 163 MB | ✅ large, 163 MB |
| Artemis I | skipped (876 MB) | ✅ mobile, 59 MB |

**2 of 6 → 6 of 6.** The loop now steps down `large → medium → small → mobile → orig → preview` and takes the first that fits, logging which rendition it chose.

## 3. A total scan failure was reported as a clean "no CC videos"

The `@SpaceX/streams` run failed **all 300** probes on authentication and printed:

```
INFO 0 of 0 probed videos are CC-licensed.
```

That reads as a definitive "no CC footage exists" — the opposite conclusion from what actually happened. A scan that probed nothing now exits 1 and says plainly that nothing can be concluded about licensing. Two supporting fixes: `needs_auth` also catches YouTube's plain cookie/authentication demand (not just the bot-challenge wording, which is why the hint never fired), and stderr is truncated from the **head** rather than the tail — tailing cut the real cause mid-word (`...kies-from-browser`).

## Context on the licensing question

The `@SpaceX/videos` scan completed cleanly and found **0 of 210 videos CC-licensed** — that result stands and is conclusive for that tab. The streams-tab result is void pending a re-run with `--cookies-from-browser`.

## Tests

39 in `tests/test_broll_attribution.py` (+10): rendition ordering and fallback, non-mp4 exclusion, TLS helper coverage (no bare `urlopen`, no `urlretrieve`), total-failure exit path, broadened auth detection, head-truncation of stderr.

Operator tooling only — no pipeline, no audio, no render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_