### PR TITLE
Bound b-roll clips to accent length before the first real-footage render

### DIFF
--- a/engine/video.py
+++ b/engine/video.py
@@ -973,7 +973,10 @@ def _hybrid_slideshow_cmd(visuals: Sequence[tuple], output: Path, *,
     inputs: List[str] = []
     for path, is_video, duration in visuals:
         if is_video:
-            inputs.extend(["-i", str(path)])
+            # Input-level -t as well as the graph's trim: without it
+            # ffmpeg decodes the WHOLE source, which is free for a 5 s
+            # generated clip and ruinous for a 40-minute NASA master.
+            inputs.extend(["-t", f"{float(duration):.2f}", "-i", str(path)])
         else:
             inputs.extend([
                 "-loop", "1",
@@ -1064,6 +1067,16 @@ def _build_hybrid_sequence(scene_paths: Sequence[Path],
 # Evergreen-B-roll cap: more than ~3 clips per episode stops feeling like
 # accent motion and starts fighting the chapter-aligned still rhythm.
 _MAX_BROLL_CLIPS = 3
+
+# ...and the same logic bounds each clip's LENGTH. The pool was built
+# around the recovered Grok Video clips (~5 s each), so nothing bounded
+# the per-clip segment — the interleaver simply used each file's full
+# duration. The first real-footage pool (Aug 2026: NASA launch views,
+# 229 s - 2442 s per file) would therefore have asked for ~72 minutes of
+# b-roll inside a ~10 minute episode, collapsing every still to its 1 s
+# floor and making ffmpeg decode 40-minute inputs. A pool clip is an
+# ACCENT: it is trimmed to at most this many seconds.
+_MAX_BROLL_SEGMENT_S = 8.0
 
 
 def _interleave_broll_into_schedule(
@@ -2424,9 +2437,18 @@ def build_long_form_video(
                 clip_durs: List[float] = []
                 for c in usable_clips:
                     try:
-                        clip_durs.append(float(_get_duration(str(c)) or 5.0))
+                        raw_dur = float(_get_duration(str(c)) or 5.0)
                     except Exception:
-                        clip_durs.append(5.0)
+                        raw_dur = 5.0
+                    # Clamp: a long source file contributes an accent,
+                    # not a takeover (see _MAX_BROLL_SEGMENT_S).
+                    if raw_dur > _MAX_BROLL_SEGMENT_S:
+                        logger.info(
+                            "B-roll %s is %.0fs — using its first %.0fs as "
+                            "an accent", Path(c).name, raw_dur,
+                            _MAX_BROLL_SEGMENT_S)
+                        raw_dur = _MAX_BROLL_SEGMENT_S
+                    clip_durs.append(raw_dur)
                 if schedule:
                     visuals = _interleave_broll_into_schedule(
                         schedule, usable_clips, clip_durs,

--- a/scripts/build_broll_pool.py
+++ b/scripts/build_broll_pool.py
@@ -47,7 +47,10 @@ import argparse
 import datetime
 import json
 import logging
+import re
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import List
 
@@ -77,6 +80,58 @@ _VIDEO_CONTENT_TYPES = {
     ".webm": "video/webm",
     ".mkv": "video/x-matroska",
 }
+
+
+# Renders use a pool clip as a short ACCENT (engine.video's
+# _MAX_BROLL_SEGMENT_S). Anything much longer than that is a source
+# file the operator probably meant to trim, so warn — and offer --trim
+# to cut the moment they actually want.
+ACCENT_SECONDS = 8.0
+LONG_CLIP_WARN_SECONDS = 30.0
+
+_TRIM_RE = re.compile(
+    r"^(?P<start>\d{1,2}(?::\d{2}){0,2}(?:\.\d+)?)"
+    r"-(?P<end>\d{1,2}(?::\d{2}){0,2}(?:\.\d+)?)$")
+
+
+def parse_trim(spec: str) -> tuple:
+    """``MM:SS-MM:SS`` (or ``H:MM:SS``/bare seconds) → (start, end).
+
+    Raises ValueError on anything else so a typo cannot silently upload
+    the untrimmed original.
+    """
+    m = _TRIM_RE.match((spec or "").strip())
+    if not m:
+        raise ValueError(
+            f"bad --trim {spec!r} — expected START-END like 1:24-1:32")
+
+    def _secs(value: str) -> float:
+        parts = [float(p) for p in value.split(":")]
+        total = 0.0
+        for part in parts:
+            total = total * 60 + part
+        return total
+
+    start, end = _secs(m.group("start")), _secs(m.group("end"))
+    if end <= start:
+        raise ValueError(f"--trim {spec!r}: end must be after start")
+    return start, end
+
+
+def trim_clip(clip: Path, spec: str, work_dir: Path) -> Path:
+    """Cut ``spec`` out of *clip* with ffmpeg, returning the new file."""
+    start, end = parse_trim(spec)
+    out = work_dir / f"{clip.stem}__{int(start)}-{int(end)}{clip.suffix}"
+    cmd = [
+        "ffmpeg", "-y", "-ss", f"{start:.3f}", "-to", f"{end:.3f}",
+        "-i", str(clip),
+        # Re-encode rather than stream-copy: a keyframe-aligned copy
+        # drifts by seconds, which is the whole clip at accent length.
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+        "-an", str(out),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True)  # noqa: S603
+    return out
 
 
 def attribution_for(clip: Path, explicit: str | None) -> str:
@@ -133,7 +188,18 @@ def main() -> int:
                     help="Footage credit line for the uploaded clips "
                          "(default: looked up per clip in a sibling "
                          "_provenance.json from the fetch scripts)")
+    ap.add_argument("--trim", default=None, metavar="START-END",
+                    help="Cut this section out of each clip before upload, "
+                         "e.g. 1:24-1:32. Renders use only the first "
+                         f"~{ACCENT_SECONDS:.0f}s of a pool clip, so trim to "
+                         "the moment you actually want.")
     args = ap.parse_args()
+
+    if args.trim:
+        try:
+            parse_trim(args.trim)
+        except ValueError as exc:
+            ap.error(str(exc))
 
     try:
         config = load_config(f"shows/{args.show}.yaml")
@@ -156,7 +222,9 @@ def main() -> int:
     by_url = {c["url"]: c for c in clips}
 
     uploaded = 0
-    for clip in args.clips:
+    work_dir = Path(tempfile.mkdtemp(prefix="broll_trim_"))
+    for source_clip in args.clips:
+        clip = source_clip
         if not clip.exists():
             logger.error("%s: not found — skipped", clip)
             continue
@@ -165,11 +233,25 @@ def main() -> int:
         if content_type is None:
             logger.error("%s: unsupported extension %s — skipped", clip, ext)
             continue
+        if args.trim:
+            try:
+                clip = trim_clip(clip, args.trim, work_dir)
+                logger.info("%s: trimmed to %s", source_clip.name, args.trim)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("%s: trim failed (%s) — skipped. Is ffmpeg "
+                             "installed?", source_clip, exc)
+                continue
         duration = get_audio_duration(clip)  # ffprobe format probe; video OK
         if not duration:
             logger.error("%s: ffprobe could not read a duration — skipped "
                          "(is it a valid video file?)", clip)
             continue
+        if duration > LONG_CLIP_WARN_SECONDS:
+            logger.warning(
+                "%s is %.0fs, but a render uses only its first ~%.0fs. "
+                "Re-run with --trim START-END to pick the moment you want "
+                "(the pool entry is replaced, not duplicated).",
+                source_clip.name, duration, ACCENT_SECONDS)
         # Content-hash key (same idempotency convention as gallery images):
         # re-running on the same bytes re-uploads to the same object.
         stem = compute_image_id(clip.read_bytes())
@@ -191,10 +273,12 @@ def main() -> int:
         entry = {
             "url": url,
             "duration_s": round(float(duration), 2),
-            "label": args.label or clip.stem,
+            "label": args.label or source_clip.stem,
             "key": key,
         }
-        credit = attribution_for(clip, args.attribution)
+        # Provenance lives beside the ORIGINAL download, not the temp
+        # trimmed copy.
+        credit = attribution_for(source_clip, args.attribution)
         if credit:
             entry["attribution"] = credit
         if url in by_url:
@@ -203,7 +287,7 @@ def main() -> int:
             clips.append(entry)
             by_url[url] = entry
         uploaded += 1
-        logger.info("%s → %s (%.1fs)", clip.name, url, duration)
+        logger.info("%s → %s (%.1fs)", source_clip.name, url, duration)
 
     if not uploaded:
         logger.error("No clips uploaded — broll.json unchanged.")

--- a/tests/test_broll_accent_cap.py
+++ b/tests/test_broll_accent_cap.py
@@ -1,0 +1,136 @@
+"""Drift guards: a pool b-roll clip is an ACCENT, never a takeover.
+
+The evergreen b-roll pool was designed around the recovered Grok Video
+clips (~5 s each), so nothing ever bounded a clip's LENGTH — the
+interleaver used each file's full duration verbatim. The first
+real-footage pool (2026-08-01: NASA "Isolated Launch Views", 229 s to
+2442 s per file) would have asked for ~72 minutes of b-roll inside a
+~10 minute episode: ``_interleave_broll_into_schedule``'s
+``factor = (total - clip_total)/total`` goes to 0, every still collapses
+to its 1 s floor, and ffmpeg decodes 40-minute inputs in a pipeline that
+already runs near a 40-minute timeout.
+
+Caught before the first render that would have used it.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+_SCRIPTS = PROJECT_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import pytest  # noqa: E402
+
+from engine import video as V  # noqa: E402
+
+
+class TestAccentCap:
+    def test_cap_is_short_enough_to_be_an_accent(self):
+        assert 0 < V._MAX_BROLL_SEGMENT_S <= 15.0
+
+    def test_runner_clamps_long_clips(self):
+        """The clamp lives in the long-form runner where clip_durs is
+        built; pin it so a refactor cannot drop it silently."""
+        src = (PROJECT_ROOT / "engine" / "video.py").read_text(
+            encoding="utf-8")
+        assert "_MAX_BROLL_SEGMENT_S" in src
+        assert "raw_dur = _MAX_BROLL_SEGMENT_S" in src
+
+    def test_real_nasa_durations_would_have_swamped_an_episode(self):
+        """The concrete regression, with the real numbers."""
+        episode_s = 600.0
+        nasa = [506.4, 1396.7, 2442.0]  # DART, IMAP, GOES-U as uploaded
+        assert sum(nasa) > 7 * episode_s           # the bug (~72 min)
+        clamped = [min(d, V._MAX_BROLL_SEGMENT_S) for d in nasa]
+        assert sum(clamped) < 0.1 * episode_s      # the fix
+
+    def test_stills_keep_real_holds_after_clamping(self):
+        """With the clamp, the interleaver leaves stills their time."""
+        schedule = [(Path(f"s{i}.jpg"), 60.0) for i in range(10)]  # 600 s
+        clips = [Path("a.mp4"), Path("b.mp4"), Path("c.mp4")]
+        durs = [V._MAX_BROLL_SEGMENT_S] * 3
+        visuals = V._interleave_broll_into_schedule(schedule, clips, durs)
+        still_holds = [d for _p, is_v, d in visuals if not is_v]
+        # Every still keeps a real hold, not the 1.0 s collapse floor.
+        assert min(still_holds) > 30.0
+        total = sum(d for _p, _v, d in visuals)
+        assert 590.0 <= total <= 610.0
+
+    def test_unclamped_long_clips_would_collapse_stills(self):
+        """Guard the guard: prove the failure mode is real, so this
+        test fails loudly if the clamp is ever removed upstream."""
+        schedule = [(Path(f"s{i}.jpg"), 60.0) for i in range(10)]
+        visuals = V._interleave_broll_into_schedule(
+            schedule, [Path("a.mp4")], [2442.0])
+        still_holds = [d for _p, is_v, d in visuals if not is_v]
+        assert max(still_holds) == 1.0  # the collapse
+
+
+class TestHybridInputTrim:
+    def test_video_inputs_carry_input_level_t(self):
+        """Without ``-t`` before ``-i`` ffmpeg decodes the whole source;
+        free on a 5 s generated clip, ruinous on a 40-minute master."""
+        visuals = [
+            (Path("clip.mp4"), True, 8.0),
+            (Path("still.jpg"), False, 30.0),
+        ]
+        cmd = V._hybrid_slideshow_cmd(visuals, Path("/tmp/out.mp4"))
+        i_clip = cmd.index("clip.mp4")
+        assert cmd[i_clip - 1] == "-i"
+        assert cmd[i_clip - 2] == "8.00"
+        assert cmd[i_clip - 3] == "-t"
+
+    def test_graph_still_trims_video_segments(self):
+        graph = V._hybrid_filter_graph([(Path("c.mp4"), True, 8.0)])
+        assert "trim=duration=8.00" in graph
+
+
+class TestPoolTrimOption:
+    def _mod(self):
+        import build_broll_pool
+        return build_broll_pool
+
+    def test_parses_common_forms(self):
+        m = self._mod()
+        assert m.parse_trim("1:24-1:32") == (84.0, 92.0)
+        assert m.parse_trim("0:10-0:18") == (10.0, 18.0)
+        assert m.parse_trim("1:02:10-1:02:18") == (3730.0, 3738.0)
+
+    def test_rejects_garbage_and_inverted_ranges(self):
+        m = self._mod()
+        for bad in ("liftoff", "1:24", "", "1:32-1:24", "1:24-1:24"):
+            with pytest.raises(ValueError):
+                m.parse_trim(bad)
+
+    def test_trim_command_reencodes_for_frame_accuracy(self, monkeypatch,
+                                                       tmp_path):
+        """A keyframe-aligned stream copy can drift by seconds, which at
+        accent length is the entire clip."""
+        m = self._mod()
+        captured = {}
+
+        def _run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _P:
+                returncode = 0
+            return _P()
+
+        monkeypatch.setattr(m.subprocess, "run", _run)
+        src = tmp_path / "src.mp4"
+        src.write_bytes(b"x")
+        m.trim_clip(src, "1:24-1:32", tmp_path)
+        cmd = captured["cmd"]
+        assert "-ss" in cmd and "84.000" in cmd
+        assert "-to" in cmd and "92.000" in cmd
+        assert "libx264" in cmd
+        assert "copy" not in cmd
+
+    def test_long_clip_warning_threshold_exceeds_accent_length(self):
+        m = self._mod()
+        assert m.ACCENT_SECONDS < m.LONG_CLIP_WARN_SECONDS
+        assert m.ACCENT_SECONDS == V._MAX_BROLL_SEGMENT_S


### PR DESCRIPTION
**Blocks tomorrow's SpaceX render.** Found while verifying the b-roll pool committed in `d866de59`.

## The bug

The evergreen b-roll pool was designed around the recovered Grok Video clips — **~5 seconds each** — so nothing ever bounded a clip's *length*. The interleaver uses each file's full duration verbatim.

The first real-footage pool went in today: NASA "Isolated Launch Views" at **229 s / 506 s / 1397 s / 2442 s** per file. The renderer would take the first 3 and ask for **~72 minutes of b-roll inside a ~10 minute episode.**

Two distinct failures:

1. **Stills collapse.** `_interleave_broll_into_schedule` computes `factor = (total - clip_total)/total`. With `clip_total` (4345 s) ≫ `total` (~600 s), factor → 0 and *every* still drops to its `max(1.0, …)` floor. One 40-minute launch clip covers the whole episode.
2. **ffmpeg decodes the entire master.** `_hybrid_slideshow_cmd` passed video inputs with no input-level `-t`; the filter graph's `trim=duration=` bounds the *output*, not the decode. This pipeline already runs near a 40-minute timeout.

## Fixes

**`engine/video.py`** — `_MAX_BROLL_SEGMENT_S = 8.0` clamps each pool clip's contribution (logged when it fires), and video inputs now carry `-t` before `-i`:

```
ffmpeg -y -threads 0 -t 8.00 -i /b/dart.mp4 -loop 1 -framerate 30 -t 45.50 -i /s/a.jpg -t 8.00 -i /b/goes.mp4 ...
```

**`scripts/build_broll_pool.py`** — `--trim START-END` cuts the moment you actually want, since otherwise a render always uses the opening seconds (which on a NASA master is often a slate). Re-encoded rather than stream-copied: keyframe alignment drifts by seconds, and at accent length that's the entire clip. A clip over 30 s now warns that only its first ~8 s will ship. Label and attribution still resolve from the **original** file, so a trimmed upload keeps its provenance.

## Effect on the committed pool

| | before | after |
|---|---|---|
| b-roll requested | 4345 s (~72 min) | 24 s |
| min still hold | 1.0 s (collapsed) | > 30 s |
| ffmpeg decode | full 40-min masters | 8 s each |

The existing `digests/spacex/broll.json` needs no change — the clamp makes it safe as committed. Trimming is an optional quality improvement.

## Tests

`tests/test_broll_accent_cap.py` (11), including one that pins the collapse itself so removing the clamp fails loudly, and the real NASA durations as a regression case. Suites re-run: `test_video_commands`, `test_visual_reuse`, `test_scene_scheduler`, `test_shorts_ab`, `test_broll_attribution` — 245 + 50 passing.

**Verification limit:** the generated ffmpeg command was inspected directly, but no actual render was executed — this environment has no ffmpeg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_