### PR TITLE
Auto-cut b-roll segments + give every episode a different visual set

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -820,6 +820,10 @@ class YouTubeConfig:
     # published by scripts/build_broll_pool.py) into the long-form
     # slideshow. A clean no-op until the operator publishes a pool.
     evergreen_broll: bool = True
+    # How many pool clips one long-form episode uses. The pool is
+    # rotated per episode, so this is the WIDTH of each episode's slice,
+    # not which clips it gets. Capped by engine.video._MAX_BROLL_CLIPS.
+    broll_clips_per_episode: int = 3
 
     # Optional path (relative to repo root) to a text template for the
     # long-form description body. Placeholders: {hook}, {episode_num},

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -33,6 +33,7 @@ import json
 import logging
 import re
 import tempfile
+import zlib
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence
 
@@ -583,18 +584,61 @@ def broll_attributions_for(
         return []
 
 
+def rotate_for_episode(entries: List[dict], episode_seed: Optional[str],
+                       limit: int) -> List[dict]:
+    """Rotate a pool so consecutive episodes draw different clips.
+
+    The pool was consumed in fixed committed order, so EVERY episode of
+    a show got the same first ``limit`` clips no matter how large the
+    pool grew — the daily long-forms shared one identical set of
+    accents. Rotating by a stable hash of the episode id walks the whole
+    pool across successive episodes while staying deterministic (a
+    re-run of the same episode renders the same video, which the
+    idempotent-publish path depends on).
+
+    Order within the returned slice is preserved from the pool, so the
+    operator's curation still decides sequencing.
+    """
+    if not entries:
+        return []
+    if not episode_seed:
+        return entries[:limit]
+    seed = str(episode_seed)
+    # Stride by the episode NUMBER when the seed carries one ("…ep053"),
+    # so consecutive episodes get DISJOINT slices and the pool is walked
+    # in order. A plain hash of the whole seed collides often enough to
+    # repeat a set every few days (measured: 7 distinct sets across 10
+    # episodes of a 12-clip pool), which is the very thing this exists
+    # to prevent. The non-numeric part still feeds the offset so two
+    # shows don't march in lockstep.
+    digits = re.findall(r"\d+", seed)
+    show_part = re.sub(r"\d+", "", seed)
+    show_offset = zlib.crc32(show_part.encode("utf-8"))
+    if digits:
+        index = int(digits[-1])
+        offset = (index * max(1, limit) + show_offset) % len(entries)
+    else:
+        offset = show_offset % len(entries)
+    rotated = entries[offset:] + entries[:offset]
+    return rotated[:limit]
+
+
 def select_broll_clips(
     show_slug: str,
     *,
     digests_dir: Path,
     limit: int = 3,
     cache_dir: Optional[Path] = None,
+    episode_seed: Optional[str] = None,
 ) -> List[Path]:
     """Download up to ``limit`` curated evergreen clips for a show.
 
     Reads the committed ``broll.json`` pool (see
-    ``scripts/build_broll_pool.py``) and returns local Paths in the pool's
-    stable committed order — no scoring, the operator curated the order.
+    ``scripts/build_broll_pool.py``). With an ``episode_seed`` the pool
+    is rotated per episode (see :func:`rotate_for_episode`) so a growing
+    pool actually produces varied videos; without one the legacy
+    committed order is preserved exactly.
+
     Best-effort: a failed download is skipped (the next entry backfills);
     a missing pool file is a clean ``[]``. Never raises.
     """
@@ -602,6 +646,9 @@ def select_broll_clips(
         entries = load_broll_entries(Path(digests_dir))
         if not entries or limit <= 0:
             return []
+        # Rotate first, then walk — so a download failure inside the
+        # rotated slice backfills from the rest of the pool.
+        entries = rotate_for_episode(entries, episode_seed, len(entries))
         cdir = (Path(cache_dir) if cache_dir
                 else _default_cache_dir() / "broll" / show_slug)
         cdir.mkdir(parents=True, exist_ok=True)

--- a/engine/visual_reuse.py
+++ b/engine/visual_reuse.py
@@ -205,9 +205,15 @@ def long_form_visual_plan(
 
         if _flag(config, "evergreen_broll"):
             from engine.gallery_library import select_broll_clips
+            # episode_seed rotates the pool per episode — without it
+            # every episode shipped the same first clips regardless of
+            # how large the pool grew.
             broll = select_broll_clips(
                 show_slug, digests_dir=Path(digests_dir),
-                limit=_BROLL_LIMIT, cache_dir=cache_dir,
+                limit=int(getattr(_yt(config), "broll_clips_per_episode",
+                                  _BROLL_LIMIT) or _BROLL_LIMIT),
+                cache_dir=cache_dir,
+                episode_seed=f"{show_slug}:{episode_id}",
             )
             out["broll_clips"] = broll or None
 

--- a/scripts/cut_broll_segments.py
+++ b/scripts/cut_broll_segments.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""Auto-cut the interesting moments out of long source footage.
+
+Source archives are long: NASA's "Isolated Launch Views" masters run
+4-40 minutes each, and a render only wants a handful of ~7 s accents.
+Reviewing that by hand every time is the thing this script exists to
+avoid — it finds the moments mechanically, so the operator's job drops
+to a quick sanity-watch of short candidates instead of scrubbing hours
+of tape.
+
+**How a moment is judged interesting.** One cheap ffmpeg pass samples
+the video at 2 fps and reports each sampled frame's *scene score* — how
+different it is from the previous sample. That single signal separates
+the three things we care about:
+
+* near-zero across a stretch → a locked-off hold or a slate (boring),
+* a lone spike → a hard cut between shots (never cut ACROSS one: a
+  b-roll accent containing an edit reads as a mistake),
+* sustained mid-range → something is actually moving in frame, which
+  for launch footage is the rocket. That is the signal we rank on.
+
+No LLM, no per-episode cost, no API. The whole selection
+(:func:`pick_segments`) is a pure function over the sampled scores, so
+it is unit-tested against real measured shapes rather than by
+eyeballing renders.
+
+Segments are spread across the source (``--min-gap``) so five clips
+from one launch aren't five near-identical seconds of the same ascent,
+and the head of the file is skipped by default because that is
+reliably a countdown slate or a title card.
+
+Usage::
+
+    # Cut ~5 candidates from every clip already downloaded:
+    python scripts/cut_broll_segments.py nasa_broll/*.mp4 \\
+        --out-dir broll_cuts --per-source 5
+
+    # Watch the (short!) candidates, delete the duds, then publish:
+    python scripts/build_broll_pool.py --show spacex broll_cuts/*.mp4
+
+Attribution rides along: each cut inherits its source's credit line
+from the fetch script's ``_provenance.json`` and writes a new one beside
+the cuts, so ``build_broll_pool.py`` still finds it and the CC BY /
+NASA credit reaches the YouTube description.
+
+Requires ffmpeg + ffprobe on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("cut_broll_segments")
+
+# Sampling rate for the motion probe. 2 fps is enough to characterise
+# camera/subject motion and keeps the probe cheap on a 40-minute master.
+SAMPLE_FPS = 2.0
+
+# A sampled frame this different from the previous one is a hard cut,
+# not motion. Segments never span one.
+CUT_SCORE = 0.35
+
+# Below this mean score a window is a static hold — a locked-off pad
+# shot or a slate.
+MIN_MOTION_SCORE = 0.008
+
+DEFAULT_SEGMENT_SECONDS = 7.0
+DEFAULT_PER_SOURCE = 5
+DEFAULT_MIN_GAP_SECONDS = 20.0
+DEFAULT_SKIP_HEAD_SECONDS = 8.0
+
+_PTS_RE = re.compile(r"pts_time:(?P<t>[0-9]+(?:\.[0-9]+)?)")
+_SCORE_RE = re.compile(r"lavfi\.scene_score=(?P<s>[0-9]+(?:\.[0-9]+)?)")
+
+
+def parse_motion_output(text: str) -> List[Tuple[float, float]]:
+    """Parse ``metadata=print`` output into ``[(time_s, score), …]``.
+
+    ffmpeg emits a frame header line then the metadata line::
+
+        frame:1    pts:1024   pts_time:0.5
+        lavfi.scene_score=0.123456
+
+    Pairs are matched in order; an unpaired trailing header is dropped.
+    """
+    times: List[float] = []
+    scores: List[float] = []
+    for line in (text or "").splitlines():
+        m = _PTS_RE.search(line)
+        if m:
+            times.append(float(m.group("t")))
+            continue
+        m = _SCORE_RE.search(line)
+        if m:
+            scores.append(float(m.group("s")))
+    return list(zip(times, scores))
+
+
+def pick_segments(
+    samples: Sequence[Tuple[float, float]],
+    *,
+    segment_s: float = DEFAULT_SEGMENT_SECONDS,
+    max_segments: int = DEFAULT_PER_SOURCE,
+    min_gap_s: float = DEFAULT_MIN_GAP_SECONDS,
+    skip_head_s: float = DEFAULT_SKIP_HEAD_SECONDS,
+    cut_score: float = CUT_SCORE,
+    min_motion: float = MIN_MOTION_SCORE,
+) -> List[Tuple[float, float, float]]:
+    """Choose the most interesting non-overlapping windows.
+
+    Pure function over ``(time, scene_score)`` samples. Returns
+    ``[(start_s, end_s, mean_score), …]`` ordered best-first, with:
+
+    * no window spanning a hard cut (score ≥ *cut_score*),
+    * nothing inside the first *skip_head_s* (slates / countdown cards),
+    * at least *min_gap_s* between chosen starts, so the picks come from
+      different parts of the source instead of clustering on the single
+      most energetic moment,
+    * static windows (mean < *min_motion*) rejected outright — better to
+      return three good clips than five padded with locked-off holds.
+    """
+    if not samples or segment_s <= 0 or max_segments <= 0:
+        return []
+    ordered = sorted(samples, key=lambda p: p[0])
+    cuts = [t for t, s in ordered if s >= cut_score]
+    last_t = ordered[-1][0]
+
+    candidates: List[Tuple[float, float, float]] = []
+    for start, _score in ordered:
+        if start < skip_head_s:
+            continue
+        end = start + segment_s
+        if end > last_t:
+            break
+        # Never cut across an edit.
+        if any(start < c < end for c in cuts):
+            continue
+        inside = [s for t, s in ordered if start <= t < end and s < cut_score]
+        if not inside:
+            continue
+        mean = sum(inside) / len(inside)
+        if mean < min_motion:
+            continue
+        candidates.append((start, end, mean))
+
+    # Greedy best-first with a spacing constraint.
+    chosen: List[Tuple[float, float, float]] = []
+    for cand in sorted(candidates, key=lambda c: -c[2]):
+        if len(chosen) >= max_segments:
+            break
+        if any(abs(cand[0] - c[0]) < min_gap_s for c in chosen):
+            continue
+        chosen.append(cand)
+    return chosen
+
+
+def sample_motion(path: Path, *, fps: float = SAMPLE_FPS) -> List[Tuple[float, float]]:
+    """Run the ffmpeg motion probe over *path*."""
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError("ffmpeg not found on PATH")
+    cmd = [
+        "ffmpeg", "-nostats", "-i", str(path),
+        "-vf", f"fps={fps},select='gte(scene,0)',metadata=print:file=-",
+        "-an", "-f", "null", "-",
+    ]
+    proc = subprocess.run(  # noqa: S603
+        cmd, capture_output=True, text=True, timeout=1800,
+    )
+    # metadata=print writes to stdout; ffmpeg's own log goes to stderr.
+    samples = parse_motion_output(proc.stdout)
+    if not samples:
+        samples = parse_motion_output(proc.stderr)
+    return samples
+
+
+def cut_segment(src: Path, start: float, end: float, dest: Path) -> None:
+    """Extract ``[start, end)`` from *src* into *dest*."""
+    cmd = [
+        "ffmpeg", "-y", "-ss", f"{start:.3f}", "-to", f"{end:.3f}",
+        "-i", str(src),
+        # Re-encode: a keyframe-aligned stream copy can drift several
+        # seconds, which at accent length is the whole clip.
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "20",
+        "-an", str(dest),
+    ]
+    subprocess.run(cmd, check=True, capture_output=True, timeout=900)  # noqa: S603
+
+
+def _source_attribution(src: Path) -> str:
+    """Credit line for *src* from a sibling ``_provenance.json``."""
+    prov = src.parent / "_provenance.json"
+    if not prov.exists():
+        return ""
+    try:
+        rows = json.loads(prov.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return ""
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, dict) and row.get("file") == src.name:
+            return str(row.get("attribution") or "").strip()
+    return ""
+
+
+def _write_provenance(out_dir: Path, rows: List[dict]) -> None:
+    path = out_dir / "_provenance.json"
+    existing: List[dict] = []
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, list):
+                existing = loaded
+        except Exception:  # noqa: BLE001
+            pass
+    by_file = {r.get("file"): r for r in existing if isinstance(r, dict)}
+    for row in rows:
+        by_file[row["file"]] = row
+    path.write_text(json.dumps(list(by_file.values()), indent=2),
+                    encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("sources", nargs="+", type=Path,
+                    help="Long source videos to mine")
+    ap.add_argument("--out-dir", default="broll_cuts", type=Path)
+    ap.add_argument("--per-source", type=int, default=DEFAULT_PER_SOURCE,
+                    help="max segments per source video")
+    ap.add_argument("--segment-seconds", type=float,
+                    default=DEFAULT_SEGMENT_SECONDS)
+    ap.add_argument("--min-gap-seconds", type=float,
+                    default=DEFAULT_MIN_GAP_SECONDS,
+                    help="minimum spacing between picks within one source")
+    ap.add_argument("--skip-head-seconds", type=float,
+                    default=DEFAULT_SKIP_HEAD_SECONDS,
+                    help="ignore the first N seconds (slates/countdowns)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="report the chosen timecodes without cutting")
+    args = ap.parse_args()
+
+    out_dir = Path(args.out_dir)
+    if not args.dry_run:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: List[dict] = []
+    total = 0
+    for src in args.sources:
+        if not src.exists():
+            logger.error("%s: not found — skipped", src)
+            continue
+        if src.name == "_provenance.json":
+            continue
+        try:
+            samples = sample_motion(src)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("%s: motion probe failed (%s) — skipped", src, exc)
+            continue
+        if not samples:
+            logger.warning("%s: no motion data (unreadable?) — skipped",
+                           src.name)
+            continue
+        picks = pick_segments(
+            samples,
+            segment_s=args.segment_seconds,
+            max_segments=args.per_source,
+            min_gap_s=args.min_gap_seconds,
+            skip_head_s=args.skip_head_seconds,
+        )
+        if not picks:
+            logger.warning("%s: nothing above the motion floor — skipped "
+                           "(a locked-off or slate-heavy source)", src.name)
+            continue
+        credit = _source_attribution(src)
+        logger.info("%s: %d segment(s) from %.0f min of source",
+                    src.name, len(picks), samples[-1][0] / 60)
+        for idx, (start, end, score) in enumerate(picks, 1):
+            stamp = f"{int(start // 60):02d}m{int(start % 60):02d}s"
+            dest = out_dir / f"{src.stem[:48]}__{stamp}.mp4"
+            logger.info("  %5.1fs → %5.1fs  motion=%.4f  %s",
+                        start, end, score, dest.name)
+            if args.dry_run:
+                continue
+            if dest.exists():
+                logger.info("    skip (exists)")
+                continue
+            try:
+                cut_segment(src, start, end, dest)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("    cut failed: %s", exc)
+                dest.unlink(missing_ok=True)
+                continue
+            total += 1
+            row = {"file": dest.name, "source_file": src.name,
+                   "start_s": round(start, 2), "end_s": round(end, 2),
+                   "motion_score": round(score, 5)}
+            if credit:
+                row["attribution"] = credit
+            rows.append(row)
+
+    if rows:
+        _write_provenance(out_dir, rows)
+    if args.dry_run:
+        logger.info("dry run — nothing written")
+        return 0
+    logger.info("cut %d segment(s) into %s — watch them (they're short), "
+                "delete the duds, then publish the keepers with "
+                "scripts/build_broll_pool.py", total, out_dir)
+    return 0 if total else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        logger.warning("interrupted")
+        raise SystemExit(130)

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -456,3 +456,8 @@ youtube:
   # Interleave curated evergreen b-roll (digests/<dir>/broll.json via
   # scripts/build_broll_pool.py). Clean no-op until a pool is published.
   evergreen_broll: true
+  # Clips per long-form episode. The pool is rotated per episode, so a
+  # bigger pool means different clips each day rather than more of them;
+  # raise this only to add more motion per episode (cap: 3 in
+  # engine.video._MAX_BROLL_CLIPS).
+  broll_clips_per_episode: 3

--- a/tests/test_broll_auto_cut.py
+++ b/tests/test_broll_auto_cut.py
@@ -1,0 +1,248 @@
+"""Drift guards for automatic b-roll segmentation + per-episode variety.
+
+Two halves of one goal — daily long-forms that don't look like each
+other:
+
+* ``scripts/cut_broll_segments.py`` mines many short accents out of long
+  source masters, so the pool is deep enough for variety to be possible
+  without the operator scrubbing hours of tape.
+* ``gallery_library.rotate_for_episode`` makes the render actually USE
+  that depth. Before it, the pool was consumed in fixed committed order,
+  so every episode of a show shipped the same first three clips no
+  matter how large the pool grew.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+_SCRIPTS = PROJECT_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import cut_broll_segments as C  # noqa: E402
+from engine import gallery_library as gl  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Motion probe parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseMotionOutput:
+    def test_parses_ffmpeg_metadata_pairs(self):
+        text = (
+            "frame:0    pts:0      pts_time:0\n"
+            "lavfi.scene_score=0.000000\n"
+            "frame:1    pts:1024   pts_time:0.5\n"
+            "lavfi.scene_score=0.123456\n"
+            "frame:2    pts:2048   pts_time:1\n"
+            "lavfi.scene_score=0.400000\n"
+        )
+        assert C.parse_motion_output(text) == [
+            (0.0, 0.0), (0.5, 0.123456), (1.0, 0.4),
+        ]
+
+    def test_ignores_ffmpeg_log_noise(self):
+        text = (
+            "ffmpeg version 7.1 Copyright (c) 2000-2024\n"
+            "  Stream #0:0: Video: h264, yuv420p, 1920x1080\n"
+            "frame:1    pts:1024   pts_time:2.5\n"
+            "lavfi.scene_score=0.050000\n"
+        )
+        assert C.parse_motion_output(text) == [(2.5, 0.05)]
+
+    def test_empty_input_is_empty(self):
+        assert C.parse_motion_output("") == []
+        assert C.parse_motion_output(None) == []
+
+
+# ---------------------------------------------------------------------------
+# Segment selection (pure)
+# ---------------------------------------------------------------------------
+
+
+def _samples(spec):
+    """[(start, end, score)] → 2 fps samples covering the range."""
+    out = []
+    for start, end, score in spec:
+        t = start
+        while t < end:
+            out.append((round(t, 2), score))
+            t += 0.5
+    return out
+
+
+class TestPickSegments:
+    def test_prefers_sustained_motion_over_static_holds(self):
+        samples = _samples([
+            (0, 60, 0.001),     # long locked-off hold
+            (60, 120, 0.05),    # something moving
+        ])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=1,
+                                min_gap_s=10.0, skip_head_s=8.0)
+        assert len(picks) == 1
+        assert picks[0][0] >= 60.0
+
+    def test_never_spans_a_hard_cut(self):
+        # A cut sits at t=40; no chosen window may contain it.
+        samples = _samples([(0, 40, 0.05)]) + [(40.0, 0.9)] + _samples(
+            [(40.5, 120, 0.05)])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=5,
+                                min_gap_s=5.0, skip_head_s=0.0)
+        assert picks
+        for start, end, _score in picks:
+            assert not (start < 40.0 < end), f"window {start}-{end} spans cut"
+
+    def test_skips_the_head_where_slates_live(self):
+        samples = _samples([(0, 120, 0.05)])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=3,
+                                min_gap_s=10.0, skip_head_s=30.0)
+        assert picks
+        assert all(start >= 30.0 for start, _e, _s in picks)
+
+    def test_spreads_picks_across_the_source(self):
+        samples = _samples([(0, 600, 0.05)])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=5,
+                                min_gap_s=60.0, skip_head_s=8.0)
+        starts = sorted(p[0] for p in picks)
+        assert len(starts) >= 2
+        for a, b in zip(starts, starts[1:]):
+            assert b - a >= 60.0
+
+    def test_rejects_a_wholly_static_source(self):
+        """Better three good clips than five padded with dead holds."""
+        samples = _samples([(0, 300, 0.0001)])
+        assert C.pick_segments(samples, segment_s=7.0, max_segments=5,
+                               min_gap_s=10.0, skip_head_s=8.0) == []
+
+    def test_never_runs_past_the_end_of_the_source(self):
+        samples = _samples([(0, 60, 0.05)])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=9,
+                                min_gap_s=1.0, skip_head_s=0.0)
+        assert picks
+        assert all(end <= 60.0 for _s, end, _sc in picks)
+
+    def test_respects_max_segments(self):
+        samples = _samples([(0, 600, 0.05)])
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=3,
+                                min_gap_s=10.0, skip_head_s=0.0)
+        assert len(picks) == 3
+
+    def test_degenerate_inputs_are_empty(self):
+        assert C.pick_segments([], segment_s=7.0) == []
+        assert C.pick_segments(_samples([(0, 60, 0.05)]), segment_s=0) == []
+        assert C.pick_segments(_samples([(0, 60, 0.05)]),
+                               max_segments=0) == []
+
+    def test_returns_best_first(self):
+        samples = (_samples([(0, 100, 0.02)])
+                   + _samples([(100, 200, 0.09)])
+                   + _samples([(200, 300, 0.05)]))
+        picks = C.pick_segments(samples, segment_s=7.0, max_segments=3,
+                                min_gap_s=30.0, skip_head_s=8.0)
+        scores = [p[2] for p in picks]
+        assert scores == sorted(scores, reverse=True)
+
+
+class TestCutSegmentCommand:
+    def test_reencodes_rather_than_stream_copies(self, monkeypatch, tmp_path):
+        captured = {}
+        monkeypatch.setattr(C.subprocess, "run",
+                            lambda cmd, **k: captured.setdefault("cmd", cmd))
+        C.cut_segment(tmp_path / "src.mp4", 84.0, 92.0, tmp_path / "o.mp4")
+        cmd = captured["cmd"]
+        assert "-ss" in cmd and "84.000" in cmd
+        assert "-to" in cmd and "92.000" in cmd
+        assert "libx264" in cmd and "copy" not in cmd
+
+    def test_attribution_rides_from_source_provenance(self, tmp_path):
+        (tmp_path / "_provenance.json").write_text(
+            '[{"file": "src.mp4", "attribution": "NASA (public domain)"}]',
+            encoding="utf-8")
+        assert C._source_attribution(tmp_path / "src.mp4") == \
+            "NASA (public domain)"
+
+    def test_missing_provenance_is_blank_not_an_error(self, tmp_path):
+        assert C._source_attribution(tmp_path / "src.mp4") == ""
+
+
+# ---------------------------------------------------------------------------
+# Per-episode rotation
+# ---------------------------------------------------------------------------
+
+
+class TestRotateForEpisode:
+    def _pool(self, n):
+        return [{"url": f"https://r2/c{i}.mp4"} for i in range(n)]
+
+    def test_consecutive_episodes_share_no_clips(self):
+        """The strong property: back-to-back episodes are disjoint, so a
+        daily viewer never sees the same accent two days running."""
+        pool = self._pool(12)
+        slices = [
+            set(c["url"] for c in gl.rotate_for_episode(
+                pool, f"spacex:ep{n:03d}", 3))
+            for n in range(1, 11)
+        ]
+        for day, (a, b) in enumerate(zip(slices, slices[1:]), start=1):
+            assert not (a & b), f"ep{day} and ep{day + 1} overlap: {a & b}"
+
+    def test_every_episode_gets_a_distinct_set(self):
+        pool = self._pool(12)
+        slices = [
+            tuple(c["url"] for c in gl.rotate_for_episode(
+                pool, f"spacex:ep{n:03d}", 3))
+            for n in range(1, 5)
+        ]
+        assert len(set(slices)) == 4, slices
+
+    def test_is_deterministic_for_the_same_episode(self):
+        pool = self._pool(12)
+        a = gl.rotate_for_episode(pool, "spacex:ep053", 3)
+        b = gl.rotate_for_episode(pool, "spacex:ep053", 3)
+        assert a == b
+
+    def test_no_seed_preserves_legacy_committed_order(self):
+        pool = self._pool(5)
+        assert gl.rotate_for_episode(pool, None, 3) == pool[:3]
+        assert gl.rotate_for_episode(pool, "", 3) == pool[:3]
+
+    def test_shows_diverge_on_the_same_episode_number(self):
+        pool = self._pool(12)
+        a = gl.rotate_for_episode(pool, "spacex:ep010", 3)
+        b = gl.rotate_for_episode(pool, "tesla:ep010", 3)
+        assert a != b
+
+    def test_pool_smaller_than_limit_is_safe(self):
+        pool = self._pool(2)
+        got = gl.rotate_for_episode(pool, "spacex:ep001", 5)
+        assert len(got) == 2
+
+    def test_empty_pool_is_empty(self):
+        assert gl.rotate_for_episode([], "spacex:ep001", 3) == []
+
+    def test_rotation_walks_the_whole_pool_over_time(self):
+        """Every clip should get screen time across a month of episodes,
+        not just the first three forever."""
+        pool = self._pool(10)
+        seen = set()
+        for n in range(1, 31):
+            for c in gl.rotate_for_episode(pool, f"spacex:ep{n:03d}", 3):
+                seen.add(c["url"])
+        assert len(seen) == 10
+
+
+class TestWiring:
+    def test_visual_reuse_passes_an_episode_seed(self):
+        src = (PROJECT_ROOT / "engine" / "visual_reuse.py").read_text(
+            encoding="utf-8")
+        assert "episode_seed=" in src
+        assert "broll_clips_per_episode" in src
+
+    def test_config_exposes_the_width_knob(self):
+        from engine.config import load_config
+        cfg = load_config("shows/spacex.yaml")
+        assert getattr(cfg.youtube, "broll_clips_per_episode", None) == 3


### PR DESCRIPTION
**Stacked on #938** (base is `claude/broll-accent-cap`, not `main`) — merge that first and this retargets to main cleanly.

Operator goal: unique, engaging videos every day, without hand-reviewing footage constantly.

## The blocker nobody would have seen

`select_broll_clips` returned the pool **in fixed committed order**. Every episode of a show got the same first three clips — so growing the pool would have changed *nothing*. Auto-cutting 50 clips would have produced 50 clips and three of them on screen, forever.

Both halves are needed; either alone does nothing.

## 1. Auto-cut (`scripts/cut_broll_segments.py`)

Source masters run 4–40 minutes; a render wants ~7 s accents. One cheap ffmpeg pass samples at 2 fps and reports each frame's **scene score**, which cleanly separates the three cases that matter:

| signal | meaning |
|---|---|
| near-zero across a stretch | locked-off hold or slate → boring |
| a lone spike | hard cut between shots → never cut across one |
| sustained mid-range | something is moving (the rocket) → **rank on this** |

No LLM, no per-episode cost, no API. Picks skip the head (slates/countdowns), never span an edit, and are spaced apart so five clips from one launch aren't five near-identical seconds of the same ascent. `pick_segments` is a **pure function** over the samples, so it's unit-tested against measured shapes rather than by eyeballing renders.

```bash
python3 scripts/cut_broll_segments.py nasa_broll/*.mp4 --out-dir broll_cuts --per-source 5
python3 scripts/cut_broll_segments.py nasa_broll/*.mp4 --dry-run   # timecodes only
```

Attribution rides through — each cut inherits its source's credit line and writes a new `_provenance.json`, so `build_broll_pool.py` still finds it and the NASA/CC BY credit reaches the description.

## 2. Variety (`gallery_library.rotate_for_episode`)

Selection now **strides by episode number**, so consecutive episodes get *disjoint* slices and the pool is walked in order.

I tried a plain hash of the seed first and rejected it on measurement — it collided into **7 distinct sets across 10 episodes** of a 12-clip pool, which is the very thing this exists to prevent. The stride is deterministic per episode (a re-run renders the same video, which idempotent publish depends on), and the non-numeric part of the seed feeds the offset so two shows don't march in lockstep.

Simulated on a realistic pool (4 sources × 5 cuts = 20 clips):

```
ep53: DART_seg4, IMAP_seg0, IMAP_seg1
ep54: IMAP_seg2, IMAP_seg3, IMAP_seg4
ep55: IXPE_seg0, IXPE_seg1, IXPE_seg2
ep56: IXPE_seg3, IXPE_seg4, GOES_seg0
...
clips used across 30 days: 20/20
```

No seed → exact legacy committed order, so nothing changes for a caller that doesn't pass one.

## New knob

`youtube.broll_clips_per_episode` (default **3**, unchanged) sets how many clips an episode uses; the rotation decides which. Capped by `_MAX_BROLL_CLIPS`.

## Known refinement, not done

Within a single episode, clips can cluster on one source (ep54 above is all IMAP). They're different moments 20 s+ apart so it isn't repetitive, but interleaving by source would be better — it needs `source` recorded in `broll.json`, which is a follow-up.

## Tests

`tests/test_broll_auto_cut.py` (25): motion parsing incl. ffmpeg log noise, cut-spanning refusal, head-skip, spacing, static-source rejection, best-first ordering, degenerate inputs, re-encode-not-copy, and the rotation properties (disjoint consecutive episodes, determinism, show divergence, whole-pool coverage, legacy fallback).

Full suite: 6318 passed. The 21 failures are the pre-existing missing `feedgen` package in this sandbox — identical on clean main.

Render/tooling only — no audio path, outside landmine #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_