### PR TITLE
Spread each episode's b-roll across sources, not three cuts from one launch

### DIFF
--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -584,6 +584,59 @@ def broll_attributions_for(
         return []
 
 
+# Auto-cut clips are named "<source stem>__MMmSSs", so the source a clip
+# came from can be recovered from its label even for pools published
+# before ``source`` was recorded explicitly.
+_CUT_STAMP_RE = re.compile(r"_+\d+m\d+s$")
+
+
+def broll_source_key(entry: dict) -> str:
+    """Which source video a pool clip was cut from.
+
+    Prefers the explicit ``source`` field; falls back to stripping the
+    auto-cut timestamp suffix off the label so pools published before
+    that field existed still group correctly; finally the url, which
+    makes every clip its own group (i.e. no grouping).
+    """
+    explicit = str(entry.get("source") or "").strip()
+    if explicit:
+        return explicit
+    label = str(entry.get("label") or "").strip()
+    if label:
+        return _CUT_STAMP_RE.sub("", label) or label
+    return str(entry.get("url") or "")
+
+
+def interleave_by_source(entries: List[dict]) -> List[dict]:
+    """Round-robin the pool across source videos.
+
+    Auto-cutting yields runs of clips from one source, so a contiguous
+    slice of the pool was three moments from the SAME launch — same
+    rocket, same pad, same light. Measured on the first real pool: 5 of
+    7 consecutive episodes drew all three clips from one source.
+    Round-robining means each episode's slice spans different launches
+    while the operator's relative ordering within a source is kept.
+    """
+    groups: Dict[str, List[dict]] = {}
+    for entry in entries:
+        groups.setdefault(broll_source_key(entry), []).append(entry)
+    if len(groups) < 2:
+        return list(entries)
+    # Proportional spread, not naive round-robin: with unequal group
+    # sizes (one launch yielding 10 clips and the others 5) round-robin
+    # exhausts the small groups first and leaves a long single-source
+    # tail — exactly the clustering this is meant to remove. Placing
+    # each clip at its fractional position within its own group spreads
+    # the big group evenly across the whole pool instead.
+    placed = [
+        ((i + 0.5) / len(group), key, entry)
+        for key, group in groups.items()
+        for i, entry in enumerate(group)
+    ]
+    placed.sort(key=lambda t: (t[0], t[1]))
+    return [entry for _pos, _key, entry in placed]
+
+
 def rotate_for_episode(entries: List[dict], episode_seed: Optional[str],
                        limit: int) -> List[dict]:
     """Rotate a pool so consecutive episodes draw different clips.
@@ -603,6 +656,9 @@ def rotate_for_episode(entries: List[dict], episode_seed: Optional[str],
         return []
     if not episode_seed:
         return entries[:limit]
+    # Spread each episode's slice across sources before rotating (the
+    # no-seed path above keeps the exact committed order).
+    entries = interleave_by_source(entries)
     seed = str(episode_seed)
     # Stride by the episode NUMBER when the seed carries one ("…ep053"),
     # so consecutive episodes get DISJOINT slices and the pool is walked

--- a/scripts/build_broll_pool.py
+++ b/scripts/build_broll_pool.py
@@ -162,6 +162,29 @@ def attribution_for(clip: Path, explicit: str | None) -> str:
     return ""
 
 
+def source_for(clip: Path) -> str:
+    """Which source video this clip was cut from, per ``_provenance.json``.
+
+    Recorded in the pool so ``gallery_library.interleave_by_source`` can
+    spread an episode's slice across different launches instead of
+    taking three moments from one. Empty when the clip wasn't auto-cut
+    (the label heuristic covers those).
+    """
+    prov_path = clip.parent / "_provenance.json"
+    if not prov_path.exists():
+        return ""
+    try:
+        rows = json.loads(prov_path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return ""
+    if not isinstance(rows, list):
+        return ""
+    for row in rows:
+        if isinstance(row, dict) and row.get("file") == clip.name:
+            return str(row.get("source_file") or "").strip()
+    return ""
+
+
 def _load_pool(path: Path) -> dict:
     if not path.exists():
         return {}
@@ -281,6 +304,9 @@ def main() -> int:
         credit = attribution_for(source_clip, args.attribution)
         if credit:
             entry["attribution"] = credit
+        origin = source_for(source_clip)
+        if origin:
+            entry["source"] = origin
         if url in by_url:
             by_url[url].update(entry)  # refresh label/duration in place
         else:

--- a/tests/test_broll_auto_cut.py
+++ b/tests/test_broll_auto_cut.py
@@ -235,6 +235,98 @@ class TestRotateForEpisode:
         assert len(seen) == 10
 
 
+class TestSourceInterleave:
+    """Auto-cutting yields runs of clips from one source, so a
+    contiguous slice was three moments from the SAME launch. Measured on
+    the first real 25-clip pool: 5 of 7 consecutive episodes drew all
+    three clips from one source."""
+
+    def _pool(self, spec):
+        out = []
+        for src, n in spec:
+            for i in range(n):
+                out.append({"url": f"https://r2/{src}{i}.mp4",
+                            "label": f"KSC-0001-{src}_Isolated___0{i}m00s"})
+        return out
+
+    def test_source_recovered_from_explicit_field(self):
+        assert gl.broll_source_key(
+            {"source": "DART.mp4", "label": "whatever__01m00s"}) == "DART.mp4"
+
+    def test_source_recovered_from_legacy_label(self):
+        """Pools published before ``source`` existed still group — the
+        operator's committed pool is one of them."""
+        assert gl.broll_source_key(
+            {"label": "KSC-20211123-0001-SpaceX_DART_Isolated___00m25s"}
+        ) == "KSC-20211123-0001-SpaceX_DART_Isolated"
+
+    def test_clips_from_one_source_share_a_key(self):
+        keys = {
+            gl.broll_source_key({"label": f"KSC-1-DART_Iso___0{i}m10s"})
+            for i in range(4)
+        }
+        assert len(keys) == 1
+
+    def test_no_episode_is_all_one_source(self):
+        """The bar that matters: never three moments from one launch.
+
+        Perfect 3-distinct isn't achievable for every episode when one
+        source is 40% of the pool (the real shape — IXPE contributed two
+        files), so this pins the property that actually protects the
+        viewer and the next test pins the typical case.
+        """
+        pool = self._pool([("DART", 5), ("IXPE", 10), ("GOES", 5),
+                           ("IMAP", 5)])
+        for n in range(50, 90):
+            got = gl.rotate_for_episode(pool, f"spacex:ep{n:03d}", 3)
+            sources = {gl.broll_source_key(c) for c in got}
+            assert len(sources) >= 2, f"ep{n} drew only from {sources}"
+
+    def test_most_episodes_span_three_sources(self):
+        pool = self._pool([("DART", 5), ("IXPE", 10), ("GOES", 5),
+                           ("IMAP", 5)])
+        three = sum(
+            len({gl.broll_source_key(c) for c in gl.rotate_for_episode(
+                pool, f"spacex:ep{n:03d}", 3)}) == 3
+            for n in range(50, 90)
+        )
+        # Measured 24/40 on this shape. A clear majority is the bar; a
+        # higher one isn't reachable while one source is 40% of the pool
+        # (three distinct then needs exactly one clip from it), and the
+        # load-bearing guarantee is the no-single-source test above.
+        assert three >= 20, f"only {three}/40 episodes span 3 sources"
+
+    def test_single_source_pool_is_unchanged(self):
+        pool = self._pool([("DART", 5)])
+        assert gl.interleave_by_source(pool) == pool
+
+    def test_interleave_preserves_every_clip(self):
+        pool = self._pool([("DART", 5), ("IXPE", 10), ("GOES", 5)])
+        got = gl.interleave_by_source(pool)
+        assert sorted(c["url"] for c in got) == sorted(
+            c["url"] for c in pool)
+
+    def test_order_within_a_source_is_preserved(self):
+        pool = self._pool([("DART", 3), ("IXPE", 3)])
+        got = [c["url"] for c in gl.interleave_by_source(pool)]
+        dart = [u for u in got if "DART" in u]
+        assert dart == ["https://r2/DART0.mp4", "https://r2/DART1.mp4",
+                        "https://r2/DART2.mp4"]
+
+    def test_coverage_still_complete_over_a_month(self):
+        pool = self._pool([("DART", 5), ("IXPE", 10), ("GOES", 5),
+                           ("IMAP", 5)])
+        seen = set()
+        for n in range(1, 31):
+            for c in gl.rotate_for_episode(pool, f"spacex:ep{n:03d}", 3):
+                seen.add(c["url"])
+        assert len(seen) == len(pool)
+
+    def test_no_seed_still_bypasses_interleaving(self):
+        pool = self._pool([("DART", 5), ("IXPE", 5)])
+        assert gl.rotate_for_episode(pool, None, 3) == pool[:3]
+
+
 class TestWiring:
     def test_visual_reuse_passes_an_episode_seed(self):
         src = (PROJECT_ROOT / "engine" / "visual_reuse.py").read_text(


### PR DESCRIPTION
Closes the follow-up left open in #939. The first real auto-cut pool (25 NASA Falcon segments, `caa6e516`) showed it isn't an edge case.

## Measured on the real pool

**Before** — 5 of 7 consecutive episodes drew all three clips from one source:

```
ep54: IXPE, IXPE, IXPE
ep55: IXPE, IXPE, IXPE
ep57: GOES, GOES, GOES
ep59: IMAP, IMAP, IMAP
ep60: DART, DART, DART
```

Three moments from the same launch means the same rocket, pad, lighting and camera setup — it reads as one shot repeated, which is the opposite of what the pool is for.

**After** — 0 of 10:

```
ep54: GOES, IMAP, IXPE
ep55: IXPE, DART, GOES
ep56: IMAP, IXPE, IXPE
ep57: DART, GOES, IMAP
ep58: IXPE, IXPE, DART
```

30-day coverage unchanged at 25/25.

## Implementation

`interleave_by_source` reorders the pool so a contiguous slice spans different sources. **Proportional placement, not naive round-robin** — I tried round-robin first and it failed its own test: with unequal groups (IXPE contributed two files and 10 of the 25 clips, the others 5 each) it exhausts the small groups and leaves a long single-source tail, i.e. the same clustering moved to the end of the pool. Placing each clip at its fractional position within its own group spreads the big group evenly instead.

Source resolution has a fallback that matters: the explicit `source` field (now recorded by `build_broll_pool` from the cut script's provenance) when present, otherwise the auto-cut timestamp suffix stripped off the label. **So the pool already committed benefits immediately — no re-upload, no re-cut.**

Preserved: order within a source, the no-seed legacy path (exact committed order), and full pool coverage.

## Tests

9 new (34 in the file, 153 across the b-roll suites). The load-bearing guard is *no episode is all one source*. The 3-distinct case is asserted as a **majority** (measured 24/40) rather than a round number — a higher bar isn't reachable while one source is 40% of the pool, since three distinct sources then requires exactly one clip from it. Both the threshold and its reasoning are in the test.

Selection logic only — no audio, no render change, outside landmine #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_