### PR TITLE
Royalty-free video sourcing: source survey + Pexels video fetcher for every show

### DIFF
--- a/docs/broll_sources.md
+++ b/docs/broll_sources.md
@@ -1,0 +1,248 @@
+# Where real footage comes from
+
+Survey of royalty-free / public-domain **video** sources for the
+network's shows, done August 2026 after the SpaceX pool proved the
+b-roll pipeline works end to end. The question behind it: every show
+currently renders over Grok-Imagine stills, and real motion is the
+biggest remaining lift in perceived production value.
+
+Every licence below was checked against the source's own terms, not a
+listicle. Where a source is unusable, the reason is recorded so it
+doesn't get re-proposed.
+
+---
+
+## The short answer
+
+| Need | Use |
+|---|---|
+| Any show, 16:9 | **Pexels video API** — `scripts/fetch_stock_broll.py` |
+| Any show, 9:16 (Shorts) | **Pexels video API**, `--orientation portrait` |
+| Rockets / launches / ISS | **NASA** — `scripts/fetch_nasa_broll.py` |
+| Energy, EVs, grid, solar | **DOE / NREL / EERE** (US gov, public domain) |
+| Climate, ocean, weather | **NOAA** (US gov, public domain) |
+| Health, labs, biology | **NIH / NLM** (US gov, public domain) |
+| Tesla / Grok / Cursor as *products* | See [Brands](#brands-tesla-grok-cursor) — no free footage exists |
+
+**Start with Pexels.** `PEXELS_API_KEY` is already configured (the
+still-image pipeline uses it), the video endpoint is included at no
+extra cost, and it is the only source that covers all fifteen shows.
+
+---
+
+## Verified source list
+
+### Pexels — ✅ primary, already wired
+
+* **Licence:** free for commercial use. **The API adds an attribution
+  obligation the site licence doesn't have** — credit the creator and
+  link Pexels. `fetch_stock_broll.py` records
+  `Video by <name> on Pexels (<url>)` per clip, which flows to the
+  YouTube description automatically.
+* **Endpoint:** `GET https://api.pexels.com/v1/videos/search`, with an
+  `orientation` parameter — **this is the only source in the survey
+  that yields native 9:16 footage**, which the Shorts renders have
+  never had.
+* **Limits:** 200 requests/hour, 20,000/month. A per-show fetch is
+  ~10 requests, so the ceiling is irrelevant.
+* **Caveat:** it is stock, and looks it if you pick the obvious clip.
+  Mitigated by driving searches from each show's curated
+  `image_queries` rather than raw keywords (see landmine #14).
+
+### Pixabay — ✅ good second source
+
+* **Licence:** Content Licence — commercial use fine, **no attribution
+  required**, which makes it the cleaner choice where a credit line is
+  awkward.
+* **Cost:** free API key, separate from Pexels.
+* **Caveats:** results must be cached 24 h, no permanent hotlinking, no
+  systematic mass download. All three are satisfied by the
+  fetch-once-then-publish-to-R2 model this pipeline already uses.
+* **Status:** not implemented. A `--provider pixabay` flag on the same
+  script is the natural shape if Pexels coverage proves thin.
+
+### US federal agencies — ✅ best quality, narrow topics
+
+Works of the US government are public domain (17 U.S.C. §105).
+Attribution isn't legally required; the agencies ask for a courtesy
+credit and the fetchers record one.
+
+| Agency | Covers | Shows |
+|---|---|---|
+| **NASA** | launches, ISS, Earth, planetary | spacex, fascinating_frontiers, planetterrian |
+| **DOE / EERE** | grid, batteries, manufacturing | tesla, env_intel, first_principles |
+| **NREL** | solar, wind, EV charging | env_intel, dp_pod, tesla |
+| **NOAA** | ocean, weather, climate | env_intel, planetterrian, dp_pod |
+| **NIH / NLM** | labs, medical imaging | planetterrian, dp_pod |
+
+NASA is implemented (`fetch_nasa_broll.py`, its own JSON API). The
+others have galleries rather than clean APIs, so they're a manual
+download → `cut_broll_segments.py` → `build_broll_pool.py` path today.
+**Check NREL's Image Gallery User Agreement per asset** — it is the one
+agency here whose gallery adds terms on top of the public-domain
+default.
+
+### Mixkit — ✅ usable, manual
+
+No attribution, commercial use allowed, and the curation is noticeably
+less "stocky" than the big libraries. No public API, so it's a manual
+download path. Worth it for hero clips.
+
+### Coverr — ⚠️ attribution required on the free tier
+
+Free downloads oblige a credit to the creator or coverr.co (removed by
+the paid tier). Usable, but Pexels gives the same obligation with an
+API attached.
+
+### Videvo — ⚠️ mixed, check per clip
+
+Three tiers mixed in one search: royalty-free, attribution-required,
+and premium. Nothing in the UI stops you conflating them. Only worth
+using deliberately, per clip.
+
+### Wikimedia Commons — ❌ avoid for composited video
+
+Much of the SpaceX/Tesla footage there is **CC BY-SA**. Share-alike
+attaches to *adaptations*, and cutting a clip into a narrated,
+graded, captioned episode is squarely an adaptation — the resulting
+episode would arguably have to be released CC BY-SA in full, letting
+anyone reuse the network's own work commercially. Not worth it for
+b-roll garnish. **CC BY (no SA) and public-domain files on Commons are
+fine**; the licence must be checked per file, and the file page's
+licence is the authority, not the category.
+
+### SpaceX's own channels — ❌ settled, don't revisit
+
+* Flickr photos went **CC BY-NC** in Dec 2019 (they were CC0
+  2015-2019). NC fails a monetized channel.
+* **0 of 210** videos on `@SpaceX/videos` carry a CC licence — scanned
+  2026-08-01 with `fetch_spacex_broll.py --list-cc`.
+* The `@SpaceX/streams` tab needs authentication to scan; unresolved,
+  but the main tab result makes a different answer unlikely.
+* 2024+ launch streams moved to X, which grants no reuse licence.
+
+`fetch_spacex_broll.py` remains, with a hard per-video CC gate, in case
+that ever changes. NASA covers the same subject matter and its
+"Isolated Launch Views" are *better* b-roll — no commentary, no overlay
+graphics.
+
+---
+
+## Brands: Tesla, Grok, Cursor
+
+There is **no royalty-free footage of a company's product as such**.
+Three distinct problems, three different answers.
+
+### Tesla
+
+* No Tesla-licensed footage exists. Tesla's brand guidelines forbid any
+  use implying affiliation or endorsement, and say nothing granting
+  editorial rights.
+* **Nominative use** — showing and naming a product while commenting on
+  it — is the ordinary basis on which news and review channels operate.
+  Showing a Tesla while discussing Tesla is normal editorial practice;
+  what the guidelines forbid is using the marks so as to suggest Tesla
+  endorses the show.
+* **Practical source:** user-shot Teslas on Pexels/Pixabay (plenty:
+  charging, driving, interiors), plus DOE/NREL for charging
+  infrastructure and battery manufacturing.
+* **Avoid:** Tesla's own ad footage, keynote/event recordings, and
+  anything with the wordmark/logo as a design element rather than
+  incidentally in shot.
+
+### Grok / Cursor (and software products generally)
+
+Stock libraries have no footage of a software UI, and generic "AI"
+b-roll (glowing brains, binary rain) actively cheapens a show.
+
+Ranked options:
+
+1. **Record it yourself.** A screen capture of Grok or Cursor answering
+   a real prompt is *your* recording — you own that copyright, and
+   showing a product's interface while discussing it is the same
+   nominative use as above. It is also the only footage that actually
+   matches what the episode is talking about. A handful of 10-second
+   captures (a prompt resolving, a diff applying, an agent looping)
+   would serve M&A and MAB indefinitely, and they never date as fast
+   as the news does.
+2. **Brand assets for logos only.** xAI publishes brand guidelines at
+   `x.ai/legal/brand-guidelines` — **read them before using the marks**;
+   they returned 403 to automated fetching here, so the terms are
+   unverified in this document. Cursor/Anysphere has no press page I
+   could find; contact them for anything beyond nominative use.
+3. **Abstract-but-honest stock:** data centres, server racks, fibre,
+   code on screens. Real, non-cheesy, and available on Pexels. This is
+   what `models_agents` should use until screen captures exist.
+
+**Do not** lift footage from other creators' review videos, conference
+recordings, or company keynotes. That is someone's copyright regardless
+of how it's framed.
+
+---
+
+## Per-show starting point
+
+| Show | Best sources |
+|---|---|
+| tesla | Pexels (EVs, charging, factory robots) + DOE/NREL |
+| spacex | **NASA** (done) |
+| fascinating_frontiers | NASA + Pexels (observatories, labs) |
+| planetterrian | NIH + NOAA + Pexels (labs, nature) |
+| models_agents / MAB | **own screen captures** + Pexels (data centres) |
+| modern_investing | Pexels (trading floors, city finance districts) |
+| env_intel | NREL + NOAA + Pexels (Canadian wilderness, industry) |
+| dp_pod | NREL + Pexels (solar installs, volunteers, labs) |
+| first_principles | DOE + Pexels (foundries, machining, assembly) |
+| unintended_consequences | Pexels (archival-feeling city/industry) |
+| omni_view | Pexels (world cities, transport) — avoid anything that reads as a specific news event |
+| finansy_prosto / privet_russian | Pexels (home, family, everyday Russia/Canada) |
+| dp_pod / age_of_ai | Pexels (studio, conversation, human hands) |
+
+---
+
+## Pipeline
+
+All sources converge on the same three steps:
+
+```bash
+# 1. Fetch (per source)
+python3 scripts/fetch_stock_broll.py --show tesla --out-dir tesla_stock
+python3 scripts/fetch_stock_broll.py --show tesla --orientation portrait \
+    --out-dir tesla_stock_9x16
+python3 scripts/fetch_nasa_broll.py --query "Isolated Launch Views"
+
+# 2. Cut long sources into accents (skip for stock — already short)
+python3 scripts/cut_broll_segments.py nasa_broll/*.mp4 --out-dir cuts
+
+# 3. Publish (attribution carries through from _provenance.json)
+python3 scripts/build_broll_pool.py --show tesla tesla_stock/*.mp4
+git add digests/tesla/broll.json && git commit && git push
+```
+
+Renders then draw a rotating, source-spread slice per episode
+(`engine.gallery_library.rotate_for_episode` /
+`interleave_by_source`), clamped to 8 s accents
+(`engine.video._MAX_BROLL_SEGMENT_S`).
+
+### Known gap
+
+The pool feeds the **long-form** render only. Shorts currently take
+their motion from the Grok Imagine A/B path, so `--orientation
+portrait` footage has no consumer yet — fetching it is useful for
+building the library, but wiring Shorts to the pool is a separate
+change.
+
+---
+
+## Rules
+
+1. **Never assume a licence from a listicle.** Every entry above was
+   read at source; two "free" sources (SpaceX Flickr, Coverr free tier)
+   carry terms that a summary would have missed.
+2. **Attribution is cheap; a takedown isn't.** Where a source requires
+   credit, the credit is recorded at fetch time, not remembered later.
+3. **CC BY-NC and CC BY-SA are both disqualifying** for this network —
+   NC because the channels are monetized, SA because episodes are
+   adaptations.
+4. **Public domain still gets a courtesy credit.** NASA and DOE ask
+   for one and it costs a line of description text.

--- a/scripts/fetch_stock_broll.py
+++ b/scripts/fetch_stock_broll.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Fetch royalty-free stock VIDEO for any show, from the Pexels video API.
+
+The network already pays for nothing here: ``PEXELS_API_KEY`` is the
+same key ``engine/visual_assets.py`` uses for still images, and the
+video endpoint is included. This is the one source that covers EVERY
+show rather than one beat — see
+[`docs/broll_sources.md`](../docs/broll_sources.md) for the full
+source survey (what is public domain, what is CC BY-NC and therefore
+unusable, and where the brand-specific footage has to come from).
+
+Two things make this safe to point at a whole network:
+
+* **Queries come from the show's own curated ``image_queries``.** Those
+  phrases were written to disambiguate stock-search traps (landmine
+  #14: "model 3" returned fashion models, which shipped in a Tesla
+  video). Reusing them means video inherits work already done, and a
+  new show gets video the moment it has image queries.
+* **The same safety filter runs.** ``engine.visual_assets._photo_is_safe``
+  is imported rather than reimplemented, so the skip-term list has one
+  home; a term added for images protects video automatically.
+
+**Attribution is mandatory here and differs from the site license.**
+Pexels content used via the *API* requires crediting the creator and
+linking Pexels — so every download records a credit line in
+``_provenance.json``, which ``build_broll_pool.py`` copies into
+``broll.json`` and the render appends to the YouTube description.
+
+Usage::
+
+    # 16:9 for the long-form slideshow, using the show's own queries:
+    python scripts/fetch_stock_broll.py --show tesla --out-dir tesla_stock
+
+    # 9:16 for Shorts — nothing else in the pipeline produces these:
+    python scripts/fetch_stock_broll.py --show tesla --orientation portrait \\
+        --out-dir tesla_stock_vertical
+
+    # Ad-hoc topic, ignoring the show's queries:
+    python scripts/fetch_stock_broll.py --show models_agents \\
+        --query "server room racks" --query "code on a screen"
+
+Clips arrive short (the fetcher prefers 5-30 s), so they usually go
+straight to the pool without needing ``cut_broll_segments.py``::
+
+    python scripts/build_broll_pool.py --show tesla tesla_stock/*.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(PROJECT_ROOT / ".env")
+
+from engine.config import load_config  # noqa: E402
+from engine.visual_assets import _photo_is_safe  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(levelname)s %(message)s")
+logger = logging.getLogger("fetch_stock_broll")
+
+PEXELS_VIDEO_SEARCH = "https://api.pexels.com/v1/videos/search"
+
+# Accent-length clips. Anything shorter than MIN can't fill an 8 s slot;
+# anything much longer is a mini-documentary that would need cutting.
+MIN_DURATION_S = 5
+MAX_DURATION_S = 40
+MAX_BYTES = 120 * 1024 * 1024
+
+# Renditions, best-usable-first. 4K is a needless download for a
+# 1920x1080 render; "sd" is too soft to intercut with Grok stills.
+_QUALITY_ORDER = ("hd", "sd", "uhd")
+
+
+def orientation_of(width: int, height: int) -> str:
+    """``landscape`` / ``portrait`` / ``square`` for a frame size."""
+    if not width or not height:
+        return "square"
+    if width > height * 1.1:
+        return "landscape"
+    if height > width * 1.1:
+        return "portrait"
+    return "square"
+
+
+def pick_video_file(video: dict, orientation: str,
+                    *, max_bytes: int = MAX_BYTES) -> Optional[dict]:
+    """Choose the best downloadable rendition of one Pexels video.
+
+    Prefers a file whose own aspect matches the requested orientation —
+    Pexels returns portrait-cropped renditions alongside landscape ones
+    for the same clip, and taking the wrong one means the render
+    letterboxes or crops the subject out.
+    """
+    files = [f for f in (video.get("video_files") or [])
+             if isinstance(f, dict) and f.get("link")]
+    if not files:
+        return None
+    matching = [
+        f for f in files
+        if orientation_of(int(f.get("width") or 0),
+                          int(f.get("height") or 0)) == orientation
+    ]
+    pool = matching or files
+    # Highest resolution within the preferred quality tiers.
+    def _rank(f: dict) -> tuple:
+        quality = str(f.get("quality") or "").lower()
+        tier = (_QUALITY_ORDER.index(quality)
+                if quality in _QUALITY_ORDER else len(_QUALITY_ORDER))
+        return (tier, -(int(f.get("width") or 0)))
+    return sorted(pool, key=_rank)[0]
+
+
+def build_attribution(video: dict) -> str:
+    """Credit line required by the Pexels API terms.
+
+    The API terms are stricter than the site license: using the API
+    obliges a creator credit and a link back to Pexels.
+    """
+    user = video.get("user") or {}
+    name = str(user.get("name") or "Pexels contributor").strip()
+    url = str(video.get("url") or "https://www.pexels.com").strip()
+    return f"Video by {name} on Pexels ({url})"
+
+
+def video_is_usable(video: dict, skip_terms: List[str],
+                    *, min_s: int = MIN_DURATION_S,
+                    max_s: int = MAX_DURATION_S) -> bool:
+    """Duration + safety gate for one search result."""
+    duration = int(video.get("duration") or 0)
+    if duration < min_s or duration > max_s:
+        return False
+    # Pexels video objects carry the same human-curated slug in ``url``
+    # that the image filter keys on ("alt" is absent, which the shared
+    # helper tolerates).
+    return _photo_is_safe(video, skip_terms)
+
+
+def safe_name(video: dict, query: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "_", query)[:40].strip("_")
+    return f"pexels_{video.get('id', 'x')}__{slug}.mp4"
+
+
+def search_videos(query: str, *, api_key: str, orientation: str,
+                  per_page: int = 15) -> List[dict]:
+    """One Pexels video search. Returns the raw ``videos`` list."""
+    params = urllib.parse.urlencode({
+        "query": query,
+        "orientation": orientation,
+        "per_page": max(1, min(80, per_page)),
+    })
+    req = urllib.request.Request(
+        f"{PEXELS_VIDEO_SEARCH}?{params}",
+        headers={"Authorization": api_key},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310
+        payload = json.loads(resp.read().decode("utf-8"))
+    videos = payload.get("videos")
+    return videos if isinstance(videos, list) else []
+
+
+def resolve_queries(config, explicit: List[str]) -> List[str]:
+    """Explicit ``--query`` values, else the show's curated queries."""
+    if explicit:
+        return [q for q in explicit if q.strip()]
+    yt = getattr(config, "youtube", None)
+    queries = list(getattr(yt, "image_queries", []) or [])
+    if queries:
+        return queries
+    # Last resort: the show's keywords, with its disambiguating prefix
+    # (the raw-keyword path is exactly what landmine #14 was about).
+    prefix = str(getattr(yt, "image_query_prefix", "") or "").strip()
+    return [f"{prefix} {k}".strip()
+            for k in (getattr(config, "keywords", []) or [])]
+
+
+def _download(url: str, dest: Path, *, max_bytes: int) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=300) as resp:  # noqa: S310
+            length = int(resp.headers.get("Content-Length") or 0)
+            if length and length > max_bytes:
+                logger.info("    skip (%.0f MB over cap)", length / 1e6)
+                return False
+            with dest.open("wb") as fh:
+                shutil.copyfileobj(resp, fh)
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("    download failed: %s", exc)
+        dest.unlink(missing_ok=True)
+        return False
+
+
+def _write_provenance(out_dir: Path, rows: List[dict]) -> None:
+    path = out_dir / "_provenance.json"
+    existing: List[dict] = []
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, list):
+                existing = loaded
+        except Exception:  # noqa: BLE001
+            pass
+    by_file: Dict[str, dict] = {
+        r.get("file"): r for r in existing if isinstance(r, dict)
+    }
+    for row in rows:
+        by_file[row["file"]] = row
+    path.write_text(json.dumps(list(by_file.values()), indent=2),
+                    encoding="utf-8")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--show", required=True, help="Show slug (e.g. tesla)")
+    ap.add_argument("--query", action="append", default=[],
+                    help="override the show's image_queries (repeatable)")
+    ap.add_argument("--orientation", default="landscape",
+                    choices=["landscape", "portrait", "square"],
+                    help="landscape for long-form, portrait for Shorts")
+    ap.add_argument("--out-dir", default=None,
+                    help="default: stock_broll/<slug>_<orientation>")
+    ap.add_argument("--per-query", type=int, default=2,
+                    help="clips to keep per query")
+    ap.add_argument("--max", type=int, default=20, help="total clip cap")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    api_key = os.getenv("PEXELS_API_KEY", "").strip()
+    if not api_key:
+        logger.error("PEXELS_API_KEY is not set — it's the same key the "
+                     "image pipeline uses; add it to .env")
+        return 1
+    try:
+        config = load_config(f"shows/{args.show}.yaml")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Cannot load shows/%s.yaml: %s", args.show, exc)
+        return 1
+
+    queries = resolve_queries(config, args.query)
+    if not queries:
+        logger.error("%s has no image_queries and no keywords — pass "
+                     "--query explicitly", args.show)
+        return 1
+    skip_terms = list(getattr(config.youtube, "image_safe_skip_terms", [])
+                      or [])
+
+    out_dir = Path(args.out_dir or
+                   f"stock_broll/{args.show}_{args.orientation}")
+    if not args.dry_run:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows: List[dict] = []
+    seen_ids = set()
+    total = 0
+    for query in queries:
+        if total >= args.max:
+            break
+        try:
+            videos = search_videos(query, api_key=api_key,
+                                   orientation=args.orientation)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("%r: search failed (%s)", query, exc)
+            continue
+        kept = 0
+        logger.info("%r: %d result(s)", query, len(videos))
+        for video in videos:
+            if kept >= args.per_query or total >= args.max:
+                break
+            vid = video.get("id")
+            if vid in seen_ids:
+                continue
+            if not video_is_usable(video, skip_terms):
+                continue
+            chosen = pick_video_file(video, args.orientation)
+            if not chosen:
+                continue
+            seen_ids.add(vid)
+            dest = out_dir / safe_name(video, query)
+            credit = build_attribution(video)
+            logger.info("  %s  %sx%s  %ss  — %s", dest.name,
+                        chosen.get("width"), chosen.get("height"),
+                        video.get("duration"), credit)
+            if args.dry_run:
+                kept += 1
+                total += 1
+                continue
+            if dest.exists():
+                logger.info("    skip (exists)")
+                continue
+            if not _download(str(chosen["link"]), dest, max_bytes=MAX_BYTES):
+                continue
+            kept += 1
+            total += 1
+            rows.append({
+                "file": dest.name,
+                "source_file": f"pexels:{vid}",
+                "query": query,
+                "source_url": video.get("url", ""),
+                "license": "Pexels License (API use requires attribution)",
+                "attribution": credit,
+            })
+
+    if rows:
+        _write_provenance(out_dir, rows)
+    if args.dry_run:
+        logger.info("dry run — %d clip(s) would be fetched", total)
+        return 0
+    logger.info("fetched %d clip(s) into %s — watch, delete the duds, then "
+                "publish with scripts/build_broll_pool.py (attribution "
+                "carries over automatically)", total, out_dir)
+    return 0 if total else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        logger.warning("interrupted")
+        raise SystemExit(130)

--- a/tests/test_stock_broll.py
+++ b/tests/test_stock_broll.py
@@ -1,0 +1,196 @@
+"""Drift guards for the Pexels stock-video fetcher.
+
+The Pexels *API* imposes an attribution obligation the site licence
+does not (credit the creator, link Pexels), so the credit line is a
+licence term here rather than a courtesy — those tests are
+load-bearing.
+
+Queries and the safety filter are deliberately shared with the still-
+image path: landmine #14 (raw ``model 3`` keyword → fashion models in a
+Tesla video) was fixed once by curating ``image_queries`` per show, and
+video must not reintroduce it by rolling its own.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+_SCRIPTS = PROJECT_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import fetch_stock_broll as F  # noqa: E402
+
+
+def _video(**over):
+    base = {
+        "id": 12345,
+        "duration": 12,
+        "url": "https://www.pexels.com/video/rocket-launch-12345/",
+        "user": {"name": "Jane Doe", "url": "https://www.pexels.com/@jane"},
+        "video_files": [
+            {"quality": "hd", "width": 1920, "height": 1080,
+             "link": "https://x/hd.mp4"},
+            {"quality": "sd", "width": 640, "height": 360,
+             "link": "https://x/sd.mp4"},
+            {"quality": "uhd", "width": 3840, "height": 2160,
+             "link": "https://x/uhd.mp4"},
+        ],
+    }
+    base.update(over)
+    return base
+
+
+class TestOrientation:
+    def test_classifies_frames(self):
+        assert F.orientation_of(1920, 1080) == "landscape"
+        assert F.orientation_of(1080, 1920) == "portrait"
+        assert F.orientation_of(1080, 1080) == "square"
+
+    def test_zero_dimensions_are_safe(self):
+        assert F.orientation_of(0, 0) == "square"
+
+
+class TestPickVideoFile:
+    def test_prefers_hd_over_uhd_and_sd(self):
+        """4K is a needless download for a 1080p render; sd is too soft
+        to intercut with the Grok stills."""
+        got = F.pick_video_file(_video(), "landscape")
+        assert got["quality"] == "hd"
+
+    def test_prefers_a_rendition_matching_the_orientation(self):
+        """Pexels returns portrait crops of the same clip; taking the
+        wrong one letterboxes or crops the subject out."""
+        video = _video(video_files=[
+            {"quality": "hd", "width": 1920, "height": 1080,
+             "link": "https://x/land.mp4"},
+            {"quality": "hd", "width": 1080, "height": 1920,
+             "link": "https://x/port.mp4"},
+        ])
+        assert F.pick_video_file(video, "portrait")["link"].endswith(
+            "port.mp4")
+        assert F.pick_video_file(video, "landscape")["link"].endswith(
+            "land.mp4")
+
+    def test_falls_back_when_no_orientation_matches(self):
+        video = _video(video_files=[
+            {"quality": "hd", "width": 1920, "height": 1080,
+             "link": "https://x/land.mp4"},
+        ])
+        assert F.pick_video_file(video, "portrait") is not None
+
+    def test_no_files_is_none(self):
+        assert F.pick_video_file(_video(video_files=[]), "landscape") is None
+        assert F.pick_video_file({}, "landscape") is None
+
+    def test_ignores_entries_without_a_link(self):
+        video = _video(video_files=[
+            {"quality": "hd", "width": 1920, "height": 1080},
+            {"quality": "sd", "width": 640, "height": 360,
+             "link": "https://x/sd.mp4"},
+        ])
+        assert F.pick_video_file(video, "landscape")["link"].endswith(
+            "sd.mp4")
+
+
+class TestAttribution:
+    def test_credits_creator_and_links_pexels(self):
+        """API terms require both — this is a licence condition."""
+        line = F.build_attribution(_video())
+        assert "Jane Doe" in line
+        assert "Pexels" in line
+        assert "https://www.pexels.com/video/rocket-launch-12345/" in line
+
+    def test_missing_user_still_produces_a_credit(self):
+        line = F.build_attribution(_video(user={}))
+        assert "Pexels" in line
+        assert line.strip()
+
+    def test_every_downloaded_row_would_carry_attribution(self):
+        """The provenance row shape build_broll_pool reads."""
+        row = {
+            "file": "a.mp4",
+            "attribution": F.build_attribution(_video()),
+            "license": "Pexels License (API use requires attribution)",
+        }
+        assert row["attribution"]
+        assert "attribution" in row["license"]
+
+
+class TestUsabilityGate:
+    def test_rejects_clips_too_short_or_too_long(self):
+        assert not F.video_is_usable(_video(duration=2), [])
+        assert not F.video_is_usable(_video(duration=600), [])
+        assert F.video_is_usable(_video(duration=12), [])
+
+    def test_applies_the_shared_safety_filter(self):
+        """Landmine #14: the image path's skip terms must protect video
+        too, via the SAME helper."""
+        bad = _video(url="https://www.pexels.com/video/topless-model-999/")
+        assert not F.video_is_usable(bad, ["topless"])
+        assert F.video_is_usable(_video(), ["topless"])
+
+    def test_safety_filter_is_imported_not_reimplemented(self):
+        from engine.visual_assets import _photo_is_safe
+        assert F._photo_is_safe is _photo_is_safe
+        src = (_SCRIPTS / "fetch_stock_broll.py").read_text(encoding="utf-8")
+        assert "def _photo_is_safe" not in src
+
+
+class TestQueryResolution:
+    def _cfg(self, **yt):
+        return SimpleNamespace(
+            youtube=SimpleNamespace(**yt), keywords=["model 3", "model y"])
+
+    def test_explicit_queries_win(self):
+        cfg = self._cfg(image_queries=["curated one"])
+        assert F.resolve_queries(cfg, ["ad hoc"]) == ["ad hoc"]
+
+    def test_uses_the_shows_curated_image_queries(self):
+        cfg = self._cfg(image_queries=["tesla car charging at a station"])
+        assert F.resolve_queries(cfg, []) == [
+            "tesla car charging at a station"]
+
+    def test_keyword_fallback_applies_the_disambiguating_prefix(self):
+        """Raw 'model 3' is exactly what shipped fashion models into a
+        Tesla video; the prefix is the fix."""
+        cfg = self._cfg(image_queries=[], image_query_prefix="tesla electric car")
+        got = F.resolve_queries(cfg, [])
+        assert all(q.startswith("tesla electric car") for q in got)
+
+    def test_real_shows_have_queries_to_drive_video_search(self):
+        from engine.config import load_config
+        for slug in ("tesla", "spacex", "models_agents"):
+            cfg = load_config(f"shows/{slug}.yaml")
+            assert F.resolve_queries(cfg, []), f"{slug} has no queries"
+
+
+class TestProvenance:
+    def test_merge_preserves_earlier_rows(self, tmp_path):
+        (tmp_path / "_provenance.json").write_text(
+            json.dumps([{"file": "old.mp4", "attribution": "old credit"}]),
+            encoding="utf-8")
+        F._write_provenance(tmp_path, [
+            {"file": "new.mp4", "attribution": "new credit"}])
+        rows = json.loads(
+            (tmp_path / "_provenance.json").read_text(encoding="utf-8"))
+        assert {r["file"] for r in rows} == {"old.mp4", "new.mp4"}
+
+    def test_filenames_are_filesystem_safe(self):
+        name = F.safe_name(_video(), "rocket launch / at dusk!")
+        assert "/" not in name and name.endswith(".mp4")
+
+
+class TestDocumentation:
+    def test_source_survey_records_the_disqualifying_licences(self):
+        """The two findings most likely to be re-proposed by someone
+        reading a listicle."""
+        doc = (PROJECT_ROOT / "docs" / "broll_sources.md").read_text(
+            encoding="utf-8")
+        assert "CC BY-NC" in doc
+        assert "CC BY-SA" in doc
+        assert "0 of 210" in doc


### PR DESCRIPTION
Operator asked where to get royalty-free video for Tesla, SpaceX, Grok, Cursor — and ideally for every show, so episodes carry real motion instead of only stills.

## The headline

**`PEXELS_API_KEY` is already configured** (the still-image pipeline uses it) and the same key covers Pexels' **video** endpoint. No new credential, no new cost, and it's the only source that covers all fifteen shows. `scripts/fetch_stock_broll.py` wires it up.

It also takes `--orientation portrait`, which makes it **the only source in the survey that yields native 9:16 footage** — Shorts have never had a real-motion source.

## Source survey (`docs/broll_sources.md`)

Every licence read at source, not from a listicle. Two that a summary would get wrong:

- **SpaceX Flickr went CC BY-NC in Dec 2019** (it was CC0 2015–2019). NC fails a monetized channel. Combined with **0 of 210** CC-licensed videos on `@SpaceX/videos` (scanned 2026-08-01), SpaceX's own media is settled as unusable — NASA covers the same subject matter better.
- **Wikimedia's SpaceX/Tesla footage is largely CC BY-SA.** Cutting a clip into a narrated, graded, captioned episode is an *adaptation*, so share-alike would arguably force the entire episode under CC BY-SA — letting anyone reuse the network's own work commercially. Disqualifying.

Also covered: US federal sources mapped per topic (NASA / DOE / NREL / NOAA / NIH — public domain), Pixabay (no attribution required; not yet implemented), and the Mixkit / Coverr / Videvo caveats (Coverr's free tier *does* require credit).

## The brand problem — Tesla, Grok, Cursor

There is **no royalty-free footage of a company's product as such**. Three different answers:

- **Tesla** — no licensed footage exists; its brand guidelines forbid implying endorsement and grant nothing editorially. Nominative use (showing and naming a product while commenting on it) is the ordinary basis news channels operate on. Practical sources: user-shot Teslas on Pexels/Pixabay, plus DOE/NREL for charging and battery manufacturing. Avoid Tesla's own ad/keynote footage.
- **Grok / Cursor** — stock libraries have no software UIs, and generic "AI" b-roll cheapens a show. Best option by a distance: **record it yourself.** A screen capture of Grok answering a real prompt is your recording, it matches what the episode actually discusses, and it doesn't date as fast as the news. A handful of 10-second captures would serve M&A and MAB indefinitely.
- Never lift keynotes, conference recordings, or other creators' review footage.

xAI publishes brand guidelines at `x.ai/legal/brand-guidelines` — flagged in the doc as **unverified**, since the page returned 403 to automated fetching.

## Implementation notes

Two deliberate reuses, both to avoid re-opening a closed wound:

- Queries come from each show's curated `image_queries` — so a new show gets video the moment it has image queries.
- The safety filter is **imported** from `engine.visual_assets`, not reimplemented. Landmine #14 (raw `model 3` → fashion models in a Tesla video) cannot return through a new door; a test asserts the identity of the function object and that the script defines no copy.

**Attribution is a licence condition here, not a courtesy** — Pexels API use requires crediting the creator and linking Pexels (stricter than their site licence). Each download writes a credit line that `build_broll_pool` copies into `broll.json` and the render appends to the description, using the plumbing built earlier today.

## Tests

`tests/test_stock_broll.py` (20): rendition selection incl. orientation matching (Pexels returns portrait crops of the same clip — taking the wrong one crops the subject out), attribution shape, duration + safety gating, query resolution across real show configs, provenance merge.

**Verification limit:** no `PEXELS_API_KEY` in this environment, so the network path is unexercised. Selection, attribution, gating and query resolution are pure functions and tested; the search call itself is not.

## Known gap

The pool feeds the **long-form** render only. Shorts take motion from the Grok Imagine A/B path, so portrait footage has no consumer yet — fetching it builds the library, but wiring Shorts to the pool is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_