### PR TITLE
Fix b-roll fetch: the pool's R2 URLs need authenticated gets

### DIFF
--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -234,13 +234,31 @@ def _cache_filename(entry: dict) -> str:
     return f"{stem}{ext}"
 
 
+def is_public_media_url(url: str) -> bool:
+    """False for an S3-API endpoint URL, which no plain GET can read.
+
+    ``upload_to_r2`` returns the raw
+    ``https://<account>.r2.cloudflarestorage.com/<bucket>/<key>`` endpoint
+    when ``R2_GALLERY_PUBLIC_BASE_URL`` is unset — that address requires
+    SigV4 signing, so an unauthenticated GET is answered 400, not 403.
+    Recognising it lets the caller go straight to the authenticated path
+    instead of spending a doomed request per object.
+    """
+    return ".r2.cloudflarestorage.com" not in (url or "").lower()
+
+
 def _r2_object_key(entry: dict) -> Optional[str]:
-    """R2 object key for an authenticated get — prefer the manifest's
-    ``original_key``, else derive from the public URL path."""
-    key = (entry.get("original_key") or "").strip().lstrip("/")
-    if key:
-        return key
-    url = (entry.get("original_url") or "").strip()
+    """R2 object key for an authenticated get.
+
+    Prefers an explicit key — ``original_key`` on gallery manifest
+    entries, ``key`` on b-roll pool entries — and only then derives one
+    from the URL path.
+    """
+    for field in ("original_key", "key"):
+        key = (entry.get(field) or "").strip().lstrip("/")
+        if key:
+            return key
+    url = (entry.get("original_url") or entry.get("url") or "").strip()
     if not url:
         return None
     # https://gallery.nerranetwork.com/tesla/2026-07-08/ep535/abc.jpeg
@@ -248,6 +266,20 @@ def _r2_object_key(entry: dict) -> Optional[str]:
     try:
         from urllib.parse import urlparse
         path = urlparse(url).path.lstrip("/")
+        if not path:
+            return None
+        # An S3-endpoint URL puts the BUCKET in the path
+        # (/nerra-gallery/broll/…), but the bucket is passed separately
+        # to the client — leaving it in would look up a key that does
+        # not exist.
+        if not is_public_media_url(url):
+            try:
+                from engine.gallery_uploader import gallery_config_from_env
+                bucket = (gallery_config_from_env().bucket or "").strip("/")
+            except Exception:  # noqa: BLE001
+                bucket = ""
+            if bucket and path.startswith(f"{bucket}/"):
+                path = path[len(bucket) + 1:]
         return path or None
     except Exception:  # noqa: BLE001
         return None
@@ -717,6 +749,16 @@ def select_broll_clips(
             if dest.exists() and dest.stat().st_size > 0:
                 paths.append(dest)
                 continue
+            # Same public-then-authenticated ladder the image path uses.
+            # Ep054 shipped with broll=0 because this did a bare GET
+            # against an S3-endpoint URL and took all 25 400s as "no
+            # clips available" — while the images beside it recovered
+            # through R2 on the very same run.
+            if not is_public_media_url(url) or _prefer_r2_download:
+                if _download_via_r2(entry, dest):
+                    paths.append(dest)
+                    continue
+            public_err: Optional[Exception] = None
             try:
                 resp = requests.get(url, timeout=DOWNLOAD_TIMEOUT_SECONDS)
                 resp.raise_for_status()
@@ -724,9 +766,29 @@ def select_broll_clips(
                     raise ValueError("empty response body")
                 dest.write_bytes(resp.content)
                 paths.append(dest)
-            except Exception as exc:  # noqa: BLE001 — skip, keep going
-                logger.warning("gallery_library: failed to fetch b-roll %s: %s",
-                               url, exc)
+                continue
+            except Exception as exc:  # noqa: BLE001 — try R2 before giving up
+                public_err = exc
+                dest.unlink(missing_ok=True)
+            if _download_via_r2(entry, dest):
+                logger.info("gallery_library: b-roll public fetch failed "
+                            "(%s); R2 fallback OK for %s",
+                            public_err, dest.name)
+                paths.append(dest)
+                continue
+            logger.warning(
+                "gallery_library: failed to fetch b-roll %s: %s (%s)",
+                url, public_err,
+                "R2 fallback also failed" if _r2_configured()
+                else "R2 fallback unavailable (credentials unset)")
+        if entries and not paths:
+            # Every clip failed. Silent-empty here reads downstream as
+            # "the operator published no pool", which is a different
+            # thing and hid a whole-pool outage for a full episode.
+            print("::warning::b-roll pool for "
+                  f"{show_slug} has {len(entries)} clip(s) but NONE could be "
+                  "fetched — the episode renders on stills only. Check R2 "
+                  "credentials and the pool's URLs.", flush=True)
         return paths
     except Exception as exc:  # noqa: BLE001 — b-roll is optional garnish
         logger.warning("gallery_library: b-roll selection failed for %s: %s",

--- a/scripts/build_broll_pool.py
+++ b/scripts/build_broll_pool.py
@@ -245,6 +245,7 @@ def main() -> int:
     by_url = {c["url"]: c for c in clips}
 
     uploaded = 0
+    non_public_warned = False
     work_dir = Path(tempfile.mkdtemp(prefix="broll_trim_"))
     for source_clip in args.clips:
         clip = source_clip
@@ -314,6 +315,18 @@ def main() -> int:
             by_url[url] = entry
         uploaded += 1
         logger.info("%s → %s (%.1fs)", source_clip.name, url, duration)
+        if not non_public_warned and ".r2.cloudflarestorage.com" in url:
+            # R2_GALLERY_PUBLIC_BASE_URL unset → upload_to_r2 hands back
+            # the S3 API endpoint, which answers an unauthenticated GET
+            # with 400. Renders recover via the authenticated fallback
+            # (the `key` above is what makes that possible), but the
+            # operator should know the pool is not publicly readable.
+            logger.warning(
+                "R2_GALLERY_PUBLIC_BASE_URL is unset, so the pool stores "
+                "S3-endpoint URLs that no plain GET can read. Renders fall "
+                "back to authenticated R2, but set it to publish public "
+                "URLs.")
+            non_public_warned = True
 
     if not uploaded:
         logger.error("No clips uploaded — broll.json unchanged.")

--- a/tests/test_broll_fetch_fallback.py
+++ b/tests/test_broll_fetch_fallback.py
@@ -1,0 +1,191 @@
+"""Drift guards: a b-roll pool must survive a non-public object URL.
+
+SpaceX Ep054 (2026-08-02) rendered with ``broll=0`` despite a healthy
+25-clip pool. Every clip failed::
+
+    failed to fetch b-roll ***/nerra-gallery/broll/spacex/….mp4:
+        400 Client Error: Bad Request
+
+The URLs were S3 API endpoints
+(``https://<acct>.r2.cloudflarestorage.com/<bucket>/<key>``), which
+``upload_to_r2`` returns when ``R2_GALLERY_PUBLIC_BASE_URL`` is unset —
+they need SigV4 signing, so an unauthenticated GET is answered 400.
+
+The gallery IMAGE path already handled exactly this and recovered on the
+same run ("public CDN failed …; R2 fallback OK"). ``select_broll_clips``
+had no such ladder: it did one bare GET and treated the failure as "no
+clips", which downstream is indistinguishable from "no pool published".
+"""
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest  # noqa: E402
+
+from engine import gallery_library as gl  # noqa: E402
+
+_ENDPOINT = "https://abc123.r2.cloudflarestorage.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cdn_state(monkeypatch):
+    monkeypatch.setattr(gl, "_prefer_r2_download", False, raising=False)
+
+
+def _pool(tmp_path, entries):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "broll.json").write_text(json.dumps({"clips": entries}),
+                                         encoding="utf-8")
+    return tmp_path
+
+
+class TestPublicUrlDetection:
+    def test_s3_endpoint_is_not_public(self):
+        assert not gl.is_public_media_url(
+            f"{_ENDPOINT}/nerra-gallery/broll/spacex/a.mp4")
+
+    def test_custom_domain_is_public(self):
+        assert gl.is_public_media_url(
+            "https://gallery.nerranetwork.com/spacex/a.mp4")
+
+    def test_empty_url_is_treated_as_public(self):
+        # Nothing to special-case; the normal path reports the failure.
+        assert gl.is_public_media_url("")
+
+
+class TestObjectKeyResolution:
+    def test_prefers_the_pool_entrys_key(self):
+        entry = {"url": f"{_ENDPOINT}/nerra-gallery/broll/spacex/a.mp4",
+                 "key": "broll/spacex/a.mp4"}
+        assert gl._r2_object_key(entry) == "broll/spacex/a.mp4"
+
+    def test_still_prefers_manifest_original_key(self):
+        entry = {"original_key": "tesla/2026-07-08/ep535/abc.jpeg",
+                 "original_url": "https://gallery.nerranetwork.com/x.jpeg"}
+        assert gl._r2_object_key(entry) == "tesla/2026-07-08/ep535/abc.jpeg"
+
+    def test_derives_from_a_public_url_path(self):
+        entry = {"original_url":
+                 "https://gallery.nerranetwork.com/tesla/ep535/abc.jpeg"}
+        assert gl._r2_object_key(entry) == "tesla/ep535/abc.jpeg"
+
+    def test_strips_the_bucket_segment_from_an_endpoint_url(self, monkeypatch):
+        """The bucket is passed to the client separately; leaving it in
+        the key looks up an object that does not exist."""
+        monkeypatch.setattr(
+            "engine.gallery_uploader.gallery_config_from_env",
+            lambda: type("C", (), {"bucket": "nerra-gallery"})())
+        entry = {"url": f"{_ENDPOINT}/nerra-gallery/broll/spacex/a.mp4"}
+        assert gl._r2_object_key(entry) == "broll/spacex/a.mp4"
+
+    def test_no_url_and_no_key_is_none(self):
+        assert gl._r2_object_key({}) is None
+
+
+class TestBrollFallback:
+    def test_endpoint_urls_skip_the_doomed_public_get(self, tmp_path,
+                                                      monkeypatch):
+        """25 clips × one guaranteed-400 request is pure waste."""
+        d = _pool(tmp_path / "digests", [
+            {"url": f"{_ENDPOINT}/nerra-gallery/broll/spacex/a.mp4",
+             "key": "broll/spacex/a.mp4"},
+        ])
+        called = {"get": 0}
+        monkeypatch.setattr(gl.requests, "get",
+                            lambda *a, **k: called.__setitem__("get", 1))
+
+        def _r2(entry, dest):
+            dest.write_bytes(b"video")
+            return True
+
+        monkeypatch.setattr(gl, "_download_via_r2", _r2)
+        got = gl.select_broll_clips("spacex", digests_dir=d, limit=1,
+                                    cache_dir=tmp_path / "cache")
+        assert len(got) == 1
+        assert called["get"] == 0
+
+    def test_public_failure_falls_back_to_r2(self, tmp_path, monkeypatch):
+        d = _pool(tmp_path / "digests", [
+            {"url": "https://gallery.nerranetwork.com/broll/a.mp4",
+             "key": "broll/spacex/a.mp4"},
+        ])
+
+        def _boom(*a, **k):
+            raise RuntimeError("403 Forbidden")
+
+        monkeypatch.setattr(gl.requests, "get", _boom)
+
+        def _r2(entry, dest):
+            dest.write_bytes(b"video")
+            return True
+
+        monkeypatch.setattr(gl, "_download_via_r2", _r2)
+        got = gl.select_broll_clips("spacex", digests_dir=d, limit=1,
+                                    cache_dir=tmp_path / "cache")
+        assert len(got) == 1
+
+    def test_the_ep054_shape_now_yields_clips(self, tmp_path, monkeypatch):
+        """The exact regression: a full pool of endpoint URLs."""
+        d = _pool(tmp_path / "digests", [
+            {"url": f"{_ENDPOINT}/nerra-gallery/broll/spacex/c{i}.mp4",
+             "key": f"broll/spacex/c{i}.mp4",
+             "label": f"src{i % 4}_Isolated___0{i}m00s"}
+            for i in range(25)
+        ])
+        monkeypatch.setattr(gl.requests, "get", lambda *a, **k: (_ for _ in ()
+                                                                ).throw(
+            RuntimeError("400 Bad Request")))
+
+        def _r2(entry, dest):
+            dest.write_bytes(b"video")
+            return True
+
+        monkeypatch.setattr(gl, "_download_via_r2", _r2)
+        got = gl.select_broll_clips("spacex", digests_dir=d, limit=3,
+                                    cache_dir=tmp_path / "cache",
+                                    episode_seed="spacex:ep054")
+        assert len(got) == 3
+
+    def test_total_failure_is_announced_not_silent(self, tmp_path,
+                                                   monkeypatch, capsys):
+        """Empty-because-broken must not look like empty-because-unpublished."""
+        d = _pool(tmp_path / "digests", [
+            {"url": f"{_ENDPOINT}/x/a.mp4", "key": "broll/spacex/a.mp4"},
+        ])
+        monkeypatch.setattr(gl.requests, "get", lambda *a, **k: (_ for _ in ()
+                                                                ).throw(
+            RuntimeError("400")))
+        monkeypatch.setattr(gl, "_download_via_r2", lambda e, d_: False)
+        got = gl.select_broll_clips("spacex", digests_dir=d, limit=3,
+                                    cache_dir=tmp_path / "cache")
+        assert got == []
+        out = capsys.readouterr().out
+        assert "::warning::" in out and "NONE could be fetched" in out
+
+    def test_no_pool_stays_quiet(self, tmp_path, capsys):
+        """An unpublished pool is not a failure — no warning."""
+        d = _pool(tmp_path / "digests", [])
+        assert gl.select_broll_clips("spacex", digests_dir=d, limit=3,
+                                     cache_dir=tmp_path / "cache") == []
+        assert "::warning::" not in capsys.readouterr().out
+
+
+class TestCommittedPoolIsRecoverable:
+    def test_every_clip_carries_the_key_the_fallback_needs(self):
+        pool_path = PROJECT_ROOT / "digests" / "spacex" / "broll.json"
+        if not pool_path.exists():
+            pytest.skip("spacex pool not published in this checkout")
+        clips = json.loads(pool_path.read_text(encoding="utf-8"))["clips"]
+        assert clips
+        missing = [c.get("url") for c in clips if not c.get("key")]
+        assert not missing, f"unrecoverable clips (no key): {missing}"
+
+    def test_pool_builder_warns_on_non_public_urls(self):
+        src = (PROJECT_ROOT / "scripts" / "build_broll_pool.py").read_text(
+            encoding="utf-8")
+        assert "R2_GALLERY_PUBLIC_BASE_URL is unset" in src


### PR DESCRIPTION
SpaceX Ep054 rendered with **`broll=0`** despite a healthy 25-clip pool. All 25 clips failed identically:

```
failed to fetch b-roll ***/nerra-gallery/broll/spacex/….mp4: 400 Client Error: Bad Request
  ... × 25
visual_reuse: long-form plan for spacex ep054 — mode=chapter_schedule fresh=4 library=16 broll=0
```

## Cause

The pool stores **S3 API endpoint URLs** (`https://<acct>.r2.cloudflarestorage.com/<bucket>/<key>`) — what `upload_to_r2` returns when `R2_GALLERY_PUBLIC_BASE_URL` is unset, which it was on the laptop that published the pool. Those require SigV4 signing, so an unauthenticated GET is answered **400**.

The tell is three lines earlier in the same log: the gallery **images** hit the same wall and *recovered*.

```
gallery CDN rejected a public read (HTTP 403) — falling back to authenticated R2
gallery_library: public CDN failed (403 …); R2 fallback OK for ad33bec6b732
```

`_download_entry` (images) has a public→authenticated ladder. `select_broll_clips` had one bare `requests.get`, and returned the failure as an empty list — which downstream is **indistinguishable from "the operator published no pool"**. A total outage looked like an unconfigured feature for a whole episode.

## Fixes

- **`select_broll_clips` uses the same ladder**, reusing `_download_via_r2`. `broll.json` already stores `key`, so **the committed pool is recoverable with no re-upload or re-cut.**
- **Endpoint-style URLs skip the doomed public GET** (25 clips × one guaranteed-400 request is pure waste) and honour the `_prefer_r2_download` flag the image path already sets.
- **`_r2_object_key` accepts the pool's `key`**, and when deriving from an endpoint URL strips the bucket segment — the bucket goes to the client separately, so leaving it in looks up a key that doesn't exist.
- **A pool where nothing could be fetched now emits `::warning::`** instead of returning silently empty. Empty-because-broken and empty-because-unpublished are different states and must not share an output.
- **`build_broll_pool` warns once** when it stores non-public URLs, naming `R2_GALLERY_PUBLIC_BASE_URL`.

## What was actually working

Worth stating, since the report was that none of it worked — Ep054's log shows the rest landed: per-word ASS captions on long-form and all 3 Shorts, tier-A 3-Shorts, hook-first Short #1 at `0.0s`, chapter-aligned scenes (24 slots), single-pass render, 16 library scenes blended. Only the b-roll was missing.

## Tests

`tests/test_broll_fetch_fallback.py` (15), including the exact Ep054 shape (25 endpoint URLs → 3 clips), the doomed-GET skip, the announce-on-total-failure path, and a guard that every clip in the committed pool carries the `key` the fallback needs.

## Operator note (separate issue)

`gallery.nerranetwork.com` is **403ing public reads** — images work but pay the slower authenticated path on every fetch, up to 16 times per render. That's a Cloudflare public-access / custom-domain config regression, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_