### PR TITLE
Stop regenerating digests over domain vocabulary; show Buttondown's actual tags

### DIFF
--- a/engine/generator.py
+++ b/engine/generator.py
@@ -519,6 +519,18 @@ def _validate_llm_output(
     def _is_entity_phrase(phrase: str) -> bool:
         return any(t in _entity_tokens for t in phrase.split())
 
+    # Framing the SHOW ITSELF supplies. The narrative-memory block
+    # (engine.show_memory) hands the prompt an "open questions" heading
+    # per tracked program, so a memory-enabled show naturally says it
+    # once per program — SpaceX Ep029/Ep035 tripped the retry purely on
+    # "open question" / "open questions" / "whose open questions". Same
+    # class as Omni View's steel-man phrases in _COMMON_BIGRAMS, but
+    # matched as a family because it appears in several shapes.
+    _STRUCTURAL_FRAMING = ("open question",)
+
+    def _is_structural_framing(phrase: str) -> bool:
+        return any(frag in phrase for frag in _STRUCTURAL_FRAMING)
+
     if not text or not text.strip():
         logger.error(
             "LLM returned EMPTY %s for '%s' — treating as retryable failure",
@@ -679,6 +691,14 @@ def _validate_llm_output(
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):
                 continue
+            # A bigram needs TWO content words to mean anything. The
+            # length-only test above passed "the first" / "the same" /
+            # "the work" / "whether the" straight through, and phrases
+            # like those were the bulk of the measured false positives —
+            # a determiner plus one word carries no information, so
+            # repeating it says nothing about hallucination.
+            if sum(1 for t in tokens if t not in _STOPWORDS) < 2:
+                continue
             # Skip speaker-attribution bigrams (e.g. "host: the", "patrick:
             # this", "olya: now"): the first token is a dialogue label ending
             # in a colon, so the repeat is the script format, not a
@@ -693,6 +713,9 @@ def _validate_llm_output(
                 continue
             # Skip the show's own entity names ("model y" on Tesla).
             if _is_entity_phrase(phrase):
+                continue
+            # Skip framing the show's own memory block supplies.
+            if _is_structural_framing(phrase):
                 continue
             if count >= _rep_threshold:
                 _suspicious_count += 1
@@ -755,6 +778,11 @@ def _validate_llm_output(
             tokens = phrase.split()
             if all(len(t) <= 3 for t in tokens):
                 continue
+            # Same content-word floor as the bigram pass: a trigram that
+            # is one content word padded with function words ("the open
+            # question of") describes the show's own framing, not a loop.
+            if sum(1 for t in tokens if t not in _STOPWORDS) < 2:
+                continue
             # Speaker-attribution trigrams (e.g. "host: the first") are a
             # dialogue-format artifact, not hallucination — see the bigram
             # loop above.
@@ -768,6 +796,9 @@ def _validate_llm_output(
                 continue
             # Skip the show's own entity names ("the model y" on Tesla).
             if _is_entity_phrase(phrase):
+                continue
+            # Skip framing the show's own memory block supplies.
+            if _is_structural_framing(phrase):
                 continue
             if count >= _rep_threshold:
                 _suspicious_count += 1

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -260,6 +260,17 @@ _VALID_STATUSES = {"about_to_send", "draft", "scheduled"}
 # lazily from GET /v1/tags the first time a name is needed in a process.
 _TAG_ID_CACHE: Dict[str, str] = {}
 
+# Every tag name the account actually has, in fetch order. Kept so a
+# failed lookup can SHOW the operator what exists instead of asking them
+# to go compare by eye — "verify the name matches" is not actionable when
+# the list it must match isn't in the log.
+_ALL_TAG_NAMES: List[str] = []
+
+
+def _fold_tag(name: str) -> str:
+    """Normalise a tag name for tolerant comparison."""
+    return " ".join(str(name or "").split()).casefold()
+
 
 def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
     """Resolve Buttondown tag display names to their tag identifiers.
@@ -277,6 +288,7 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
     """
     need = [t for t in tag_names if t and t not in _TAG_ID_CACHE]
     if need:
+        _ALL_TAG_NAMES.clear()
         try:
             url: Optional[str] = f"{BUTTONDOWN_API_BASE}/tags"
             params: Optional[Dict[str, str]] = {"page_size": "100"}
@@ -294,6 +306,7 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
                     tid = tag.get("id")
                     if name and tid:
                         _TAG_ID_CACHE[name] = tid
+                        _ALL_TAG_NAMES.append(name)
                 # The ``next`` URL is fully qualified and already carries
                 # the cursor — drop our params so we don't override it.
                 url = payload.get("next") or None
@@ -302,7 +315,25 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
             logger.error(
                 "Failed to fetch Buttondown tags for id resolution: %s", exc,
             )
-    return {t: _TAG_ID_CACHE[t] for t in tag_names if t in _TAG_ID_CACHE}
+    resolved = {t: _TAG_ID_CACHE[t] for t in tag_names if t in _TAG_ID_CACHE}
+    # Tolerant second pass for the names that missed. Buttondown's Tags
+    # page is hand-edited, so a stray trailing space or a case change
+    # ("Spacex Daily") silently drops a show's whole send — an exact-match
+    # -only lookup turns a typo into an outage. A tolerant hit is used but
+    # announced, so the YAML still gets corrected.
+    still_missing = [t for t in tag_names if t not in resolved]
+    if still_missing and _TAG_ID_CACHE:
+        folded = {_fold_tag(name): name for name in _TAG_ID_CACHE}
+        for want in still_missing:
+            actual = folded.get(_fold_tag(want))
+            if actual:
+                resolved[want] = _TAG_ID_CACHE[actual]
+                logger.warning(
+                    "Buttondown tag %r matched %r only after normalising "
+                    "case/whitespace — update the show YAML's "
+                    "newsletter.tag to the exact name.", want, actual,
+                )
+    return resolved
 
 
 def send_newsletter(
@@ -398,10 +429,13 @@ def send_newsletter(
         resolved_ids = [tag_id_map[t] for t in tags if t in tag_id_map]
         missing = [t for t in tags if t not in tag_id_map]
         if missing:
+            known = ", ".join(repr(n) for n in sorted(_ALL_TAG_NAMES)[:40])
             logger.error(
                 "Could not resolve Buttondown tag id(s) for %s — those "
-                "subscribers will not be targeted. Verify the tag name(s) "
-                "match the Buttondown Tags page exactly.", missing,
+                "subscribers will not be targeted. The account has %d tag(s): "
+                "[%s]. Either fix newsletter.tag in the show YAML to match "
+                "one of those exactly, or create the tag in Buttondown.",
+                missing, len(_ALL_TAG_NAMES), known or "none returned",
             )
         if not resolved_ids:
             # Never fall through to an unfiltered ``data`` (that would

--- a/tests/test_repetition_and_tags.py
+++ b/tests/test_repetition_and_tags.py
@@ -1,0 +1,219 @@
+"""Guards for two Ep054 failures: a wasted regen and a blocked send.
+
+**Repetition.** The digest bigram bar was 4, and measured across the
+last 30 committed digests on six shows it fired on 17 of 180 (20% on
+SpaceX) with EVERY flagged phrase a false positive — domain nouns
+("upper stage", "static fire", "flight 13") or bare function phrases
+("the first", "the same", "whether the"). Ep054 burned a full
+lower-temperature regeneration and then logged "did not improve —
+keeping original". The detector must still catch a genuine loop.
+
+**Buttondown tag.** ``Could not resolve Buttondown tag id(s) for
+['SpaceX Daily']`` blocked the send (correctly refusing to blast the
+whole list unfiltered), but told the operator only to "verify the name
+matches" — without showing what names exist.
+"""
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest  # noqa: E402
+
+from engine.generator import _validate_llm_output  # noqa: E402
+
+
+# Varied filler to clear the 50-word floor the scanners require WITHOUT
+# introducing repetition of its own (an earlier version of this helper
+# repeated one sentence and tripped the detector it was meant to test).
+_FILLER = (
+    "Starbase crews rolled a booster to the pad before dawn. Weather "
+    "officers gave a favourable forecast for Tuesday. Range control "
+    "cleared a corridor over the Gulf. Investors watched premarket "
+    "quotes drift sideways. A supplier confirmed new tooling arrived "
+    "in Florida. Regulators published an updated environmental review. "
+)
+
+
+def _digest(body: str) -> str:
+    return _FILLER + body
+
+
+_SUBJECTS = ["Analysts", "Engineers", "Regulators", "Investors", "Crews",
+             "Suppliers", "Controllers", "Auditors", "Planners", "Managers",
+             "Inspectors", "Technicians"]
+_VERBS = ["described", "flagged", "measured", "questioned", "welcomed",
+          "audited", "compared", "documented", "revisited", "praised",
+          "disputed", "modelled"]
+_NOUNS = ["telemetry", "margins", "cadence", "tooling", "propellant",
+          "avionics", "schedule", "throughput", "hardware", "staffing",
+          "insulation", "guidance"]
+_TAILS = ["ahead of the review", "in the quarterly filing",
+          "during a campaign", "at the Cape", "before a window",
+          "under a new contract", "across two pads", "for the manifest",
+          "in a briefing", "on a call", "after a delay",
+          "with fresh capacity"]
+
+
+def _phrase_in_varied_sentences(phrase: str, times: int) -> str:
+    """Repeat *phrase* with EVERY neighbouring word varying.
+
+    This is how a phrase recurs in a real digest: the phrase returns,
+    the sentences around it do not. Holding any neighbour fixed would
+    manufacture a second repeated n-gram and test the harness rather
+    than the detector — and repeating a whole sentence would build an
+    actual hallucination loop, which the detector is supposed to catch.
+    """
+    return _digest(" ".join(
+        f"{_SUBJECTS[i % len(_SUBJECTS)]} {_VERBS[i % len(_VERBS)]} "
+        f"{phrase} {_NOUNS[i % len(_NOUNS)]} {_TAILS[i % len(_TAILS)]}."
+        for i in range(times)
+    ))
+
+
+class TestFunctionPhrasesNoLongerFire:
+    """A determiner plus one word carries no information."""
+
+    @pytest.mark.parametrize("phrase", [
+        "the first", "the same", "the work", "the open", "whether the",
+        "the upper", "the ship",
+    ])
+    def test_bare_function_bigrams_are_ignored(self, phrase):
+        text = _phrase_in_varied_sentences(phrase, 12)
+        assert _validate_llm_output(text, "digest", "spacex", 0, ()) == 0
+
+
+class TestDomainVocabularyIsNotHallucination:
+    # The bar that matters is the RETRY trigger (_rep_count >= 3), not
+    # whether a phrase is noted at all. One domain noun recurring is
+    # allowed to be logged; what must not happen is burning a
+    # regeneration over it, which is what Ep054 did.
+    RETRY_AT = 3
+
+    def test_technical_noun_phrase_does_not_trigger_a_regen(self):
+        """'upper stage' ×5 in a digest about the upper stage is the
+        subject matter — this is the exact Ep054 flag."""
+        text = _phrase_in_varied_sentences("upper stage", 5)
+        assert _validate_llm_output(
+            text, "digest", "spacex", 0, ()) < self.RETRY_AT
+
+    def test_static_fire_and_flight_number(self):
+        for phrase in ("static fire", "flight 13"):
+            assert _validate_llm_output(
+                _phrase_in_varied_sentences(phrase, 5),
+                "digest", "spacex", 0, ()) < self.RETRY_AT
+
+    def test_memory_block_framing_is_exempt(self):
+        """"open questions" is a heading engine.show_memory hands the
+        prompt per tracked program — SpaceX Ep029/Ep035 regenerated on
+        it alone."""
+        for phrase in ("open question", "open questions",
+                       "whose open questions"):
+            assert _validate_llm_output(
+                _phrase_in_varied_sentences(phrase, 6),
+                "digest", "spacex", 0, ()) < self.RETRY_AT
+
+
+class TestRealLoopsStillCaught:
+    def test_repeated_clause_is_flagged(self):
+        loop = (
+            "The rocket achieved orbital velocity today. " * 3
+            + "Engineers confirmed the anomaly was contained within the "
+              "vehicle. " * 9
+            + "More detail followed from the flight director. "
+        ) * 3
+        assert _validate_llm_output(loop, "digest", "spacex", 0, ()) >= 3
+
+    def test_content_bigram_above_the_new_bar_still_fires(self):
+        """Two content words recurring far past the bar, in otherwise
+        varied prose — the shape a real fixation takes."""
+        text = _phrase_in_varied_sentences("quantum entanglement", 9)
+        assert _validate_llm_output(text, "digest", "spacex", 0, ()) >= 1
+
+    def test_sensitivity_was_not_bought_by_raising_the_threshold(self):
+        """The count threshold is deliberately UNCHANGED — a blunt raise
+        also blunts real tics (it broke
+        test_known_entities_do_not_mask_unrelated_repetition, which
+        catches a clause tic at 5 repeats). The fix is the content-word
+        floor, which discriminates instead."""
+        src = (PROJECT_ROOT / "engine" / "generator.py").read_text(
+            encoding="utf-8")
+        assert '_rep_threshold = 5 if stage == "podcast_script" else 4' in src
+        assert "if sum(1 for t in tokens if t not in _STOPWORDS) < 2:" in src
+
+    def test_clause_level_tic_at_five_repeats_still_fires(self):
+        """Pins the behaviour the threshold raise would have lost."""
+        filler = " ".join(f"unique{i} token{i} filler{i}" for i in range(30))
+        text = filler + " " + (
+            "The kicker is nobody expected the kicker is real. " * 5)
+        assert _validate_llm_output(text, "digest", "tesla", 0,
+                                    ("tesla", "model y")) >= 1
+
+
+class TestNoNetworkRegressionOnCommittedDigests:
+    def test_recent_digests_do_not_trigger_regeneration(self):
+        """The measurement that justified the change, pinned."""
+        import glob
+        from engine.config import load_config
+        fired = 0
+        checked = 0
+        for slug, pat in (
+            ("spacex", "digests/spacex/*.md"),
+            ("tesla", "digests/tesla_shorts_time/*.md"),
+            ("fascinating_frontiers", "digests/fascinating_frontiers/*.md"),
+        ):
+            try:
+                cfg = load_config(f"shows/{slug}.yaml")
+            except Exception:
+                continue
+            kw = tuple(getattr(cfg, "keywords", []) or ())
+            for path in sorted(glob.glob(pat))[-20:]:
+                text = Path(path).read_text(encoding="utf-8")
+                try:
+                    n = _validate_llm_output(text, "digest", slug, 0, kw)
+                except Exception:
+                    continue
+                checked += 1
+                if n >= 3:
+                    fired += 1
+        if checked < 10:
+            pytest.skip("not enough committed digests in this checkout")
+        # Was 13/90 on these three shows before the fix.
+        assert fired == 0, f"{fired}/{checked} digests would still regenerate"
+
+
+class TestButtondownTagDiagnostics:
+    def test_fold_normalises_case_and_whitespace(self):
+        from engine.newsletter import _fold_tag
+        assert _fold_tag("  SpaceX   Daily ") == _fold_tag("spacex daily")
+
+    def test_tolerant_match_recovers_a_case_typo(self, monkeypatch):
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {"SpaceX Daily": "tag_1"})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", ["SpaceX Daily"])
+        got = nl._resolve_tag_ids(["Spacex daily "], api_key="k")
+        assert got == {"Spacex daily ": "tag_1"}
+
+    def test_exact_match_is_unchanged(self, monkeypatch):
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {"SpaceX Daily": "tag_1"})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", ["SpaceX Daily"])
+        assert nl._resolve_tag_ids(["SpaceX Daily"], api_key="k") == {
+            "SpaceX Daily": "tag_1"}
+
+    def test_genuinely_absent_tag_still_misses(self, monkeypatch):
+        """Tolerance must not invent a match — refusing to send is right
+        when the tag does not exist."""
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {"Tesla Shorts Time": "t1"})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", ["Tesla Shorts Time"])
+        assert nl._resolve_tag_ids(["SpaceX Daily"], api_key="k") == {}
+
+    def test_error_names_the_available_tags(self):
+        src = (PROJECT_ROOT / "engine" / "newsletter.py").read_text(
+            encoding="utf-8")
+        assert "The account has %d tag(s)" in src
+        assert "_ALL_TAG_NAMES" in src


### PR DESCRIPTION
The two non-video failures in the Ep054 log.

## 1. The repetition retry was firing on nothing

Measured across the last 30 committed digests on six shows: **17 of 180 fired (20% on SpaceX)** — and **every flagged phrase was a false positive**:

| kind | examples |
|---|---|
| domain nouns | `upper stage`, `static fire`, `flight 13` |
| bare function phrases | `the first`, `the same`, `whether the`, `the work` |
| the show's own memory heading | `open question`, `whose open questions` |

Not one was a hallucination loop. Ep054 burned a full lower-temperature regeneration and then logged `did not improve — keeping original`, which is the mechanism's own verdict on its value.

**Two discriminating rules, not a blunt threshold raise:**

- **A bigram needs two content words.** The existing filter only skipped phrases whose tokens were *all* ≤3 chars, so `the first` / `the same` / `whether the` sailed straight through. A determiner plus one word carries no information — repeating it says nothing about hallucination. Trigrams get the same floor.
- **Phrases containing `open question` are exempt.** `engine.show_memory` hands the prompt that heading per tracked program, so a memory-enabled show says it once per program *by construction*. Same class as Omni View's steel-man framing already in `_COMMON_BIGRAMS`.

**The count threshold is deliberately unchanged.** Raising it 4→6 also cleared the false positives and I nearly shipped it — but it silently blunted real tics: it broke `test_known_entities_do_not_mask_unrelated_repetition`, which catches a clause tic at 5 repeats. That existing guard was right and my change was wrong. Both behaviours are now pinned.

**Result: 0 of 235 digests across eight shows would regenerate**, and a synthetic clause loop is still caught.

## 2. The Buttondown tag error wasn't actionable

```
Could not resolve Buttondown tag id(s) for ['SpaceX Daily']
No tag filters resolved to Buttondown tag IDs — refusing to send
```

Refusing was correct — an unresolved filter would blast the entire network's list. But the guidance was "verify the tag name matches the Buttondown Tags page exactly" *without showing what names exist*, which makes it a guessing game against a remote UI.

Now:
- The error **lists the account's actual tags** and their count.
- A name differing only by **case or whitespace** resolves, with a warning naming the exact string to put in the YAML — a stray trailing space shouldn't cost a show its whole send.
- A **genuinely absent tag still misses**, so the refusal-to-blast behaviour is intact (guarded).

If `SpaceX Daily` simply doesn't exist in Buttondown, the next run's log will now say so and list what does — most likely it needs creating, since the show launched after the other tags were set up.

## Tests

`tests/test_repetition_and_tags.py` (20). Note the fixtures: repeating a whole sentence to test "false positives" would build an actual hallucination loop (my first two attempts did exactly that and correctly failed), so the helper varies **every** neighbouring word and lets only the target phrase recur — how a phrase behaves in a real digest.

Full suite: 6383 passed; the 21 failures are the pre-existing missing `feedgen` package in this sandbox, identical on clean main.

No audio or prompt changes — detector and error-reporting only, outside landmine #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_