### PR TITLE
Pin the two repaired newsletter tags to their Buttondown ids

### DIFF
--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -272,6 +272,25 @@ def _fold_tag(name: str) -> str:
     return " ".join(str(name or "").split()).casefold()
 
 
+# Buttondown tag identifiers are TypeIDs. Observed live (Aug 2026) as
+# ``sub_tag_…``; the send-filter docs elsewhere in this file describe a
+# ``tag_…`` shape. Accept both — the prefix is Buttondown's to change,
+# and the value is only ever passed straight back to their API.
+_TAG_ID_PREFIXES = ("sub_tag_", "tag_")
+
+
+def looks_like_tag_id(value: str) -> bool:
+    """True when a configured tag is already an identifier.
+
+    Lets a show pin ``newsletter.tag`` to the immutable id instead of
+    the display name. Names are resolved through Buttondown's Tags page,
+    which is hand-edited — renaming a tag there would otherwise break
+    that show's send silently, the same class of failure as the tag
+    simply not existing.
+    """
+    return str(value or "").strip().startswith(_TAG_ID_PREFIXES)
+
+
 def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
     """Resolve Buttondown tag display names to their tag identifiers.
 
@@ -286,6 +305,12 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
     how to handle misses. Resolved pairs are cached per-process so a run that
     sends several shows only pays for one tag fetch.
     """
+    # A tag configured as an identifier needs no lookup — and must not
+    # trigger one, or a show pinned to an id would still fail whenever
+    # the Tags endpoint is unreachable.
+    passthrough = {t: t.strip() for t in tag_names if looks_like_tag_id(t)}
+    tag_names = [t for t in tag_names if t not in passthrough]
+
     need = [t for t in tag_names if t and t not in _TAG_ID_CACHE]
     if need:
         _ALL_TAG_NAMES.clear()
@@ -316,6 +341,7 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
                 "Failed to fetch Buttondown tags for id resolution: %s", exc,
             )
     resolved = {t: _TAG_ID_CACHE[t] for t in tag_names if t in _TAG_ID_CACHE}
+    resolved.update(passthrough)
     # Tolerant second pass for the names that missed. Buttondown's Tags
     # page is hand-edited, so a stray trailing space or a case change
     # ("Spacex Daily") silently drops a show's whole send — an exact-match

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -134,7 +134,11 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  tag: First Principles Daily
+  # Pinned to the immutable Buttondown tag id (display name:
+  # "First Principles Daily") — see the note in shows/spacex.yaml. This
+  # show had been failing its send silently every day until the tag was
+  # created on 2026-08-02.
+  tag: "sub_tag_7dyy5s9nqk8sbars6b45e45ev1"
   short_label: First Principles
   emoji: 💡
   newsletter_start_date: '2026-06-15'

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -320,7 +320,12 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  tag: "SpaceX Daily"
+  # Pinned to the immutable Buttondown tag id (display name:
+  # "SpaceX Daily"). The name-based lookup reads Buttondown's Tags page,
+  # which is hand-edited — this show's sends failed outright until the
+  # tag was created on 2026-08-02, and a later rename would fail the
+  # same silent way. The id cannot drift.
+  tag: "sub_tag_75a48w4wsm9fhr6n2eckfysexs"
   short_label: "SpaceX Daily"
   emoji: "🚀"
   newsletter_start_date: "2026-06-12"

--- a/tests/test_repetition_and_tags.py
+++ b/tests/test_repetition_and_tags.py
@@ -217,3 +217,72 @@ class TestButtondownTagDiagnostics:
             encoding="utf-8")
         assert "The account has %d tag(s)" in src
         assert "_ALL_TAG_NAMES" in src
+
+
+class TestTagIdPassthrough:
+    """A show may pin the immutable id instead of the display name.
+
+    Buttondown's Tags page is hand-edited: SpaceX Daily and First
+    Principles Daily both failed every send until their tags were
+    created (2026-08-02), and a later rename would fail the same silent
+    way. Both are pinned to ids now.
+    """
+
+    def test_recognises_both_observed_id_shapes(self):
+        from engine.newsletter import looks_like_tag_id
+        assert looks_like_tag_id("sub_tag_75a48w4wsm9fhr6n2eckfysexs")
+        assert looks_like_tag_id("tag_abc123")
+
+    def test_display_names_are_not_mistaken_for_ids(self):
+        from engine.newsletter import looks_like_tag_id
+        for name in ("SpaceX Daily", "Tesla Shorts Time", "DP Pod", ""):
+            assert not looks_like_tag_id(name)
+
+    def test_pinned_id_resolves_without_any_api_lookup(self, monkeypatch):
+        """An id must not depend on the Tags endpoint being reachable."""
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", [])
+
+        def _no_calls(*a, **k):
+            raise AssertionError("Tags endpoint must not be called")
+
+        monkeypatch.setattr(nl.requests, "get", _no_calls)
+        got = nl._resolve_tag_ids(["sub_tag_75a48w4wsm9fhr6n2eckfysexs"],
+                                  api_key="k")
+        assert got == {"sub_tag_75a48w4wsm9fhr6n2eckfysexs":
+                       "sub_tag_75a48w4wsm9fhr6n2eckfysexs"}
+
+    def test_ids_and_names_resolve_together(self, monkeypatch):
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {"Tesla Shorts Time": "t1"})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", ["Tesla Shorts Time"])
+        got = nl._resolve_tag_ids(
+            ["Tesla Shorts Time", "sub_tag_abc"], api_key="k")
+        assert got == {"Tesla Shorts Time": "t1", "sub_tag_abc": "sub_tag_abc"}
+
+    def test_the_two_repaired_shows_are_pinned_to_ids(self):
+        import logging
+        logging.disable(logging.CRITICAL)
+        try:
+            from engine.config import load_config
+            from engine.newsletter import looks_like_tag_id
+            for slug in ("spacex", "first_principles"):
+                cfg = load_config(f"shows/{slug}.yaml")
+                tag = (getattr(cfg.newsletter, "tag", "") or "").strip()
+                assert looks_like_tag_id(tag), f"{slug} tag is not an id: {tag!r}"
+        finally:
+            logging.disable(logging.NOTSET)
+
+    def test_other_shows_still_use_readable_names(self):
+        """Names stay where they work — ids are for the surfaces that
+        actually broke, not a blanket rewrite."""
+        import logging
+        logging.disable(logging.CRITICAL)
+        try:
+            from engine.config import load_config
+            from engine.newsletter import looks_like_tag_id
+            cfg = load_config("shows/tesla.yaml")
+            assert not looks_like_tag_id(cfg.newsletter.tag)
+        finally:
+            logging.disable(logging.NOTSET)


### PR DESCRIPTION
Operator created the two missing tags and supplied their ids.

| show | id | display name |
|---|---|---|
| `spacex` | `sub_tag_75a48w4wsm9fhr6n2eckfysexs` | SpaceX Daily |
| `first_principles` | `sub_tag_7dyy5s9nqk8sbars6b45e45ev1` | First Principles Daily |

## Why pin ids rather than just use the names

Creating the tags fixes today's failure — name resolution would now work. But the names are the fragile part: resolution reads Buttondown's **Tags page, which is hand-edited**. These two shows failed *every* send until the tags were created, and a later rename would fail the same silent way. The id can't drift.

`_resolve_tag_ids` now passes a configured identifier straight through **without a lookup**, so a pinned show doesn't depend on the Tags endpoint being reachable at all.

Both observed id shapes are accepted: `sub_tag_…` (what the API returned live today) and `tag_…` (what this module's own send-filter comments describe). The prefix is Buttondown's to change and the value is only ever handed back to their API, so accepting both costs nothing.

## What I deliberately didn't do

**The other 13 shows keep their readable display names.** They resolve correctly today, and a blanket rewrite would trade legibility for typo risk on surfaces that never broke — a 27-character opaque string in YAML is worse documentation than "Tesla Shorts Time". Both behaviours are guarded, so the split is intentional rather than drift.

## Verification

Every newsletter-enabled show now resolves to either a known tag name or a pinned id — checked against the live tag list from the operator's Buttondown account:

```
enabled shows with an unresolvable tag: NONE — all resolve
```

`tests/test_repetition_and_tags.py` (26, +6): both id shapes recognised, display names not mistaken for ids, a pinned id resolving with the Tags endpoint rigged to fail on call, ids and names resolving together in one request, and the split between the two pinned shows and the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_