### PR TITLE
Split the Buttondown send id from the subscribe-form display name

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -428,7 +428,16 @@ class NewsletterConfig:
     platform: str = "buttondown"
     api_key_env: str = "BUTTONDOWN_API_KEY"
     status: str = "about_to_send"  # "about_to_send", "draft", or "scheduled"
-    tag: str = ""  # Buttondown tag for per-show subscriber filtering
+    # Buttondown tag DISPLAY NAME. Used for per-show subscriber
+    # filtering AND as the subscribe-form checkbox value on every show
+    # page / blog post / the network page — subscribers carry tag names,
+    # so this must stay human-readable.
+    tag: str = ""
+    # Optional Buttondown tag IDENTIFIER (e.g. ``sub_tag_…``). When set,
+    # the SEND FILTER uses it instead of resolving ``tag`` through
+    # Buttondown's hand-edited Tags page, so renaming a tag there cannot
+    # silently break the show's send. Never reaches the subscribe form.
+    tag_id: str = ""
     # June 10 2026: these fields were set in show YAMLs and read via
     # getattr() on this dataclass — but never DECLARED here, so
     # _build_nested silently dropped them and the getattr defaults always

--- a/engine/newsletter.py
+++ b/engine/newsletter.py
@@ -362,6 +362,29 @@ def _resolve_tag_ids(tag_names: List[str], api_key: str) -> Dict[str, str]:
     return resolved
 
 
+def tag_exists(tag: str, api_key: str) -> Optional[bool]:
+    """Whether *tag* exists on the Buttondown account.
+
+    ``True`` / ``False`` when the account was read successfully;
+    ``None`` when it could not be read at all — the caller must not
+    treat an unreachable API as "the tag is missing".
+
+    Capture tags (``ru-spacex``, ``gallery-subscriber``) are created by
+    Buttondown when the FIRST subscriber arrives carrying them, so
+    "absent" legitimately means "no signups yet" for those surfaces.
+    """
+    tag = (tag or "").strip()
+    if not tag:
+        return False
+    if looks_like_tag_id(tag):
+        return True  # ids need no lookup; the API validates on send
+    resolved = _resolve_tag_ids([tag], api_key)
+    if resolved:
+        return True
+    # Distinguish "fetched the list, tag absent" from "fetch failed".
+    return False if _ALL_TAG_NAMES else None
+
+
 def send_newsletter(
     subject: str,
     body: str,
@@ -642,7 +665,15 @@ def send_show_newsletter(
         slug, hook, send_date=_today, hook_max_chars=50, is_daily=True,
     )
 
-    tag = getattr(newsletter, "tag", "") or ""
+    # ``tag_id`` (send filter) is separate from ``tag`` (display name)
+    # ON PURPOSE. ``tag`` is ALSO the value of the subscribe-form
+    # checkbox on every show page, blog post and the network page —
+    # subscribers carry tag NAMES, so putting an identifier there tags
+    # new signups with a literal "sub_tag_…" string that matches
+    # nothing, and they silently never receive the newsletter. Pinning
+    # ids directly into ``tag`` did exactly that for one commit.
+    tag = (getattr(newsletter, "tag_id", "") or "").strip() \
+        or (getattr(newsletter, "tag", "") or "")
     tags_list = [tag] if tag else None
 
     # Body transforms — clean up scaffold + render Tesla price /

--- a/scripts/send_ru_spacex_weekly.py
+++ b/scripts/send_ru_spacex_weekly.py
@@ -327,7 +327,24 @@ def main(argv: Optional[List[str]] = None) -> int:
                     today.isoformat())
         return 0
 
-    from engine.newsletter import send_newsletter
+    from engine.newsletter import send_newsletter, tag_exists
+
+    # A capture tag only comes into being when the first subscriber
+    # arrives with it (the Worker assigns "ru-spacex" on the RU lander;
+    # "gallery-subscriber" appeared the same way). So an absent tag here
+    # means the pilot has no subscribers YET — a legitimate state, not a
+    # broken configuration, and it must not fail the workflow every week
+    # with the same red run. ``tag_exists`` returns None when the account
+    # could not be read at all, which IS an error worth surfacing.
+    present = tag_exists(CAPTURE_TAG, api_key)
+    if present is False:
+        log.info(
+            "No subscribers have been captured with %r yet — nothing to "
+            "send. Buttondown creates the tag with the first signup from "
+            "%s; this becomes a real send once the lander converts "
+            "someone.", CAPTURE_TAG, LANDING_URL,
+        )
+        return 0
 
     email_id = send_newsletter(
         subject,

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -134,11 +134,11 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  # Pinned to the immutable Buttondown tag id (display name:
-  # "First Principles Daily") — see the note in shows/spacex.yaml. This
-  # show had been failing its send silently every day until the tag was
-  # created on 2026-08-02.
-  tag: "sub_tag_7dyy5s9nqk8sbars6b45e45ev1"
+  # Display name (also the subscribe-form value) + pinned send id —
+  # see the note in shows/spacex.yaml. This show had been failing its
+  # send silently every day until the tag was created on 2026-08-02.
+  tag: First Principles Daily
+  tag_id: "sub_tag_7dyy5s9nqk8sbars6b45e45ev1"
   short_label: First Principles
   emoji: 💡
   newsletter_start_date: '2026-06-15'

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -320,12 +320,15 @@ newsletter:
   platform: buttondown
   api_key_env: BUTTONDOWN_API_KEY
   status: about_to_send
-  # Pinned to the immutable Buttondown tag id (display name:
-  # "SpaceX Daily"). The name-based lookup reads Buttondown's Tags page,
-  # which is hand-edited — this show's sends failed outright until the
-  # tag was created on 2026-08-02, and a later rename would fail the
-  # same silent way. The id cannot drift.
-  tag: "sub_tag_75a48w4wsm9fhr6n2eckfysexs"
+  # ``tag`` is the DISPLAY NAME and must stay readable — it is also the
+  # subscribe-form checkbox value on the show page, blog posts and the
+  # network page, and subscribers carry tag names.
+  tag: "SpaceX Daily"
+  # ``tag_id`` pins the send filter to the immutable identifier, so a
+  # rename on Buttondown's hand-edited Tags page cannot silently break
+  # the send (this show's newsletter failed every day until the tag was
+  # created on 2026-08-02).
+  tag_id: "sub_tag_75a48w4wsm9fhr6n2eckfysexs"
   short_label: "SpaceX Daily"
   emoji: "🚀"
   newsletter_start_date: "2026-06-12"

--- a/tests/test_repetition_and_tags.py
+++ b/tests/test_repetition_and_tags.py
@@ -261,7 +261,10 @@ class TestTagIdPassthrough:
             ["Tesla Shorts Time", "sub_tag_abc"], api_key="k")
         assert got == {"Tesla Shorts Time": "t1", "sub_tag_abc": "sub_tag_abc"}
 
-    def test_the_two_repaired_shows_are_pinned_to_ids(self):
+    def test_the_two_repaired_shows_pin_an_id_in_tag_id(self):
+        """The id lives in ``tag_id``, NOT ``tag`` — see
+        TestTagIdIsSeparateFromDisplayName for why that distinction is
+        load-bearing."""
         import logging
         logging.disable(logging.CRITICAL)
         try:
@@ -269,8 +272,9 @@ class TestTagIdPassthrough:
             from engine.newsletter import looks_like_tag_id
             for slug in ("spacex", "first_principles"):
                 cfg = load_config(f"shows/{slug}.yaml")
-                tag = (getattr(cfg.newsletter, "tag", "") or "").strip()
-                assert looks_like_tag_id(tag), f"{slug} tag is not an id: {tag!r}"
+                tag_id = (getattr(cfg.newsletter, "tag_id", "") or "").strip()
+                assert looks_like_tag_id(tag_id), (
+                    f"{slug} tag_id is not an id: {tag_id!r}")
         finally:
             logging.disable(logging.NOTSET)
 
@@ -286,3 +290,108 @@ class TestTagIdPassthrough:
             assert not looks_like_tag_id(cfg.newsletter.tag)
         finally:
             logging.disable(logging.NOTSET)
+
+
+class TestTagIdIsSeparateFromDisplayName:
+    """``tag`` is ALSO the subscribe-form checkbox value.
+
+    Pinning identifiers into ``newsletter.tag`` (one commit on
+    2026-08-02) meant the next site regeneration would have written
+    ``value="sub_tag_75a4…"`` into every show page, blog post and the
+    network page's signup form. Subscribers carry tag NAMES, so those
+    signups would have been tagged with a literal identifier string
+    matching nothing — and would silently never receive the newsletter.
+    Caught by a dirty working tree before the nightly regen shipped it.
+    """
+
+    def _cfg(self, slug):
+        import logging
+        logging.disable(logging.CRITICAL)
+        try:
+            from engine.config import load_config
+            return load_config(f"shows/{slug}.yaml")
+        finally:
+            logging.disable(logging.NOTSET)
+
+    def test_pinned_shows_keep_a_readable_display_name(self):
+        from engine.newsletter import looks_like_tag_id
+        for slug, name in (("spacex", "SpaceX Daily"),
+                           ("first_principles", "First Principles Daily")):
+            tag = self._cfg(slug).newsletter.tag
+            assert tag == name
+            assert not looks_like_tag_id(tag), (
+                f"{slug}: an id in `tag` reaches the subscribe form")
+
+    def test_pinned_shows_carry_the_id_in_tag_id(self):
+        from engine.newsletter import looks_like_tag_id
+        for slug in ("spacex", "first_principles"):
+            assert looks_like_tag_id(self._cfg(slug).newsletter.tag_id)
+
+    def test_tag_id_is_declared_on_the_dataclass(self):
+        """Landmine: _build_nested drops YAML keys the dataclass does
+        not declare, so an undeclared tag_id would silently be lost."""
+        from engine.config import NewsletterConfig
+        assert hasattr(NewsletterConfig(), "tag_id")
+        assert self._cfg("spacex").newsletter.tag_id
+
+    def test_send_prefers_the_id_over_the_name(self):
+        src = (PROJECT_ROOT / "engine" / "newsletter.py").read_text(
+            encoding="utf-8")
+        assert 'getattr(newsletter, "tag_id", "")' in src
+
+    def test_page_generation_reads_the_display_name(self):
+        """The site helper reads newsletter.tag — with the id split out,
+        the form value is a name again."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "_gh", PROJECT_ROOT / "generate_html.py")
+        src = (PROJECT_ROOT / "generate_html.py").read_text(encoding="utf-8")
+        assert '(data.get("newsletter") or {}).get("tag")' in src
+        assert "tag_id" not in src.split("_newsletter_tag_for_slug")[1][:900]
+
+
+class TestCaptureTagAbsenceIsNotAnError:
+    """``ru-spacex`` does not exist because the RU lander has not
+    converted anyone yet — Buttondown creates a capture tag with the
+    first signup (that is how ``gallery-subscriber`` appeared). Failing
+    the weekly workflow red every week for that is noise."""
+
+    @staticmethod
+    def _account(monkeypatch, names, fail=False):
+        """Stub the Tags endpoint with a real account shape."""
+        import engine.newsletter as nl
+        monkeypatch.setattr(nl, "_TAG_ID_CACHE", {})
+        monkeypatch.setattr(nl, "_ALL_TAG_NAMES", [])
+
+        class _Resp:
+            def raise_for_status(self):
+                if fail:
+                    raise RuntimeError("401 Unauthorized")
+
+            def json(self):
+                return {"results": [{"name": n, "id": f"sub_tag_{i}"}
+                                    for i, n in enumerate(names)],
+                        "next": None}
+
+        monkeypatch.setattr(nl.requests, "get", lambda *a, **k: _Resp())
+        return nl
+
+    def test_absent_tag_reports_false_when_the_account_was_read(
+            self, monkeypatch):
+        nl = self._account(monkeypatch, ["SpaceX Daily", "gallery-subscriber"])
+        assert nl.tag_exists("ru-spacex", "k") is False
+
+    def test_unreachable_account_reports_none_not_false(self, monkeypatch):
+        """An API outage must not be read as 'no subscribers yet'."""
+        nl = self._account(monkeypatch, [], fail=True)
+        assert nl.tag_exists("ru-spacex", "k") is None
+
+    def test_present_tag_reports_true(self, monkeypatch):
+        nl = self._account(monkeypatch, ["ru-spacex", "SpaceX Daily"])
+        assert nl.tag_exists("ru-spacex", "k") is True
+
+    def test_weekly_script_exits_zero_on_absence(self):
+        src = (PROJECT_ROOT / "scripts" / "send_ru_spacex_weekly.py").read_text(
+            encoding="utf-8")
+        assert "present = tag_exists(CAPTURE_TAG, api_key)" in src
+        assert "if present is False:" in src


### PR DESCRIPTION
**#945 introduced a latent break on the public site.** Caught before it shipped.

## What I missed

`newsletter.tag` does **double duty** — it's the send filter *and* the subscribe-form checkbox value on every show page, blog post, and the network page. Subscribers carry tag **names**, so pinning identifiers meant the next site regeneration would have written:

```html
<input type="checkbox" name="tag" value="sub_tag_75a48w4wsm9fhr6n2eckfysexs">
```

into every signup form — tagging new subscribers with a literal id string that matches nothing, so they'd silently never receive the newsletter. Exactly the failure we've been fixing all day, newly created by the fix for it.

It surfaced as a dirty working tree (the test run regenerates HTML). The committed pages still carry display names, so **nothing reached the live site** — but the nightly regen would have baked it in.

## The split

| field | purpose |
|---|---|
| `newsletter.tag` | display name — filtering **and** the subscribe form |
| `newsletter.tag_id` | optional identifier — **send filter only** |

`tag_id` is **declared on `NewsletterConfig`**, not just read via `getattr`. `_build_nested` drops YAML keys the dataclass doesn't declare — this exact dataclass has been bitten before (`requires_financial_disclaimer` was silently always `False`).

Verified the form values resolve back to names:

```
spacex            subscribe-form value = 'SpaceX Daily'            OK
first_principles  subscribe-form value = 'First Principles Daily'  OK
tesla             subscribe-form value = 'Tesla Shorts Time'       OK
```

## A third dead surface, found by the new diagnostics

The improved tag error immediately paid for itself — the RU SpaceX weekly fails on `ru-spacex`, which doesn't exist in the account (all 17 tags now listed in the log).

But `ru-spacex` is a **capture** tag: Buttondown creates it when the first subscriber arrives carrying it, which is how `gallery-subscriber` came to exist. Its absence means **the RU lander hasn't converted anyone yet** — a legitimate state, not a misconfiguration, and not worth failing the workflow red every week.

New `tag_exists` returns `True`/`False` when the account was read and **`None` when it couldn't be**, so an API outage is never mistaken for "no subscribers yet". The weekly script exits 0 with an explanation on `False` only.

That's the same distinction as the b-roll fix earlier today: *empty* and *broken* must not share an output.

## Tests

`tests/test_repetition_and_tags.py` (+11): the id never appears in `tag`, `tag_id` is declared on the dataclass, the send prefers the id, page generation reads the name, and `tag_exists` returns None (not False) when the Tags endpoint fails.

Full suite: 6409 passed; only the pre-existing `feedgen` sandbox gap fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_