### PR TITLE
Real footage in Shorts; fix the dead b-roll rotation; one-click pools for every show

### DIFF
--- a/.github/workflows/build-broll-pool.yml
+++ b/.github/workflows/build-broll-pool.yml
@@ -72,23 +72,28 @@ jobs:
         if: ${{ inputs.source == 'pexels' }}
         env:
           PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
+          SHOW: ${{ inputs.show }}
+          MAX_CLIPS: ${{ inputs.max_clips }}
         run: |
           set -euo pipefail
           python scripts/fetch_stock_broll.py \
-            --show "${{ inputs.show }}" \
+            --show "$SHOW" \
             --out-dir /tmp/broll_ready \
-            --max "${{ inputs.max_clips }}"
+            --max "$MAX_CLIPS"
 
       - name: Fetch + auto-cut footage (nasa)
         if: ${{ inputs.source == 'nasa' }}
+        env:
+          QUERY: ${{ inputs.query }}
+          MAX_CLIPS: ${{ inputs.max_clips }}
         run: |
           set -euo pipefail
-          if [ -z "${{ inputs.query }}" ]; then
+          if [ -z "$QUERY" ]; then
             echo "::error::the nasa source needs a query (e.g. 'Isolated Launch Views')"
             exit 1
           fi
           python scripts/fetch_nasa_broll.py \
-            --query "${{ inputs.query }}" \
+            --query "$QUERY" \
             --max 8 \
             --out-dir /tmp/broll_src
           python scripts/cut_broll_segments.py /tmp/broll_src/*.mp4 \
@@ -101,7 +106,7 @@ jobs:
           mkdir -p /tmp/broll_ready
           count=0
           for f in /tmp/broll_cuts/*.mp4; do
-            [ "$count" -ge "${{ inputs.max_clips }}" ] && break
+            [ "$count" -ge "$MAX_CLIPS" ] && break
             cp "$f" /tmp/broll_ready/
             count=$((count + 1))
           done
@@ -114,6 +119,7 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_GALLERY_BUCKET: ${{ secrets.R2_GALLERY_BUCKET }}
           R2_GALLERY_PUBLIC_BASE_URL: ${{ secrets.R2_GALLERY_PUBLIC_BASE_URL }}
+          SHOW: ${{ inputs.show }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -122,8 +128,8 @@ jobs:
             echo "::error::no clips survived fetching/cutting — nothing to publish"
             exit 1
           fi
-          echo "Publishing ${#clips[@]} clip(s) to the ${{ inputs.show }} pool"
-          python scripts/build_broll_pool.py --show "${{ inputs.show }}" "${clips[@]}"
+          echo "Publishing ${#clips[@]} clip(s) to the $SHOW pool"
+          python scripts/build_broll_pool.py --show "$SHOW" "${clips[@]}"
 
       - uses: ./.github/actions/safe-commit-push
         with:

--- a/.github/workflows/build-broll-pool.yml
+++ b/.github/workflows/build-broll-pool.yml
@@ -1,0 +1,131 @@
+name: Build B-roll Pool
+
+# One-click real-footage pool for any show — the operator-laptop steps
+# (fetch → auto-cut → upload to R2 → commit broll.json) as a single
+# workflow_dispatch. This is what makes "real footage on every show"
+# operationally cheap: the SpaceX pool took a multi-step local session;
+# every further show should be one dispatch from the Actions tab.
+#
+# Sources:
+#   * pexels — royalty-free stock video via the show's own curated
+#     image_queries (scripts/fetch_stock_broll.py). Clips arrive short,
+#     so no cutting stage. Attribution recorded per clip (a Pexels API
+#     licence condition) and carried into the YouTube description.
+#   * nasa — public-domain NASA footage for a given query
+#     (scripts/fetch_nasa_broll.py), auto-cut into ~7 s accents at the
+#     moments with real motion (scripts/cut_broll_segments.py).
+#
+# The clips are machine-curated (motion scoring / curated queries +
+# safety filter), not human-watched: SPOT-CHECK the next episode's video
+# after a pool lands. A dud clip is removed by editing the show's
+# digests/<dir>/broll.json (delete its entry) — no re-upload needed.
+#
+# Consumers: long-form interleaves up to broll_clips_per_episode clips;
+# Shorts draw 2 per Short (youtube.shorts_broll). Both rotate per
+# episode so a deeper pool means more day-to-day variety.
+
+on:
+  workflow_dispatch:
+    inputs:
+      show:
+        description: "Show slug (e.g. tesla, fascinating_frontiers)"
+        required: true
+      source:
+        description: "Footage source"
+        type: choice
+        options:
+          - pexels
+          - nasa
+        default: pexels
+      query:
+        description: "NASA search query (nasa source only), e.g. Isolated Launch Views"
+        required: false
+        default: ""
+      max_clips:
+        description: "Max clips to add to the pool this run"
+        required: false
+        default: "12"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-broll-pool-${{ inputs.show }}
+  cancel-in-progress: false
+
+jobs:
+  build-pool:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.12'
+          requirements-file: 'requirements.txt'
+          skip-checkout: 'true'
+          system-packages: 'ffmpeg'
+
+      - name: Fetch footage (pexels)
+        if: ${{ inputs.source == 'pexels' }}
+        env:
+          PEXELS_API_KEY: ${{ secrets.PEXELS_API_KEY }}
+        run: |
+          set -euo pipefail
+          python scripts/fetch_stock_broll.py \
+            --show "${{ inputs.show }}" \
+            --out-dir /tmp/broll_ready \
+            --max "${{ inputs.max_clips }}"
+
+      - name: Fetch + auto-cut footage (nasa)
+        if: ${{ inputs.source == 'nasa' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${{ inputs.query }}" ]; then
+            echo "::error::the nasa source needs a query (e.g. 'Isolated Launch Views')"
+            exit 1
+          fi
+          python scripts/fetch_nasa_broll.py \
+            --query "${{ inputs.query }}" \
+            --max 8 \
+            --out-dir /tmp/broll_src
+          python scripts/cut_broll_segments.py /tmp/broll_src/*.mp4 \
+            --out-dir /tmp/broll_cuts \
+            --per-source 5
+          # Bound the run to max_clips. The cut script orders best-first
+          # WITHIN each source; this head is alphabetical across sources,
+          # which is fine — every surviving cut already cleared the
+          # motion floor.
+          mkdir -p /tmp/broll_ready
+          count=0
+          for f in /tmp/broll_cuts/*.mp4; do
+            [ "$count" -ge "${{ inputs.max_clips }}" ] && break
+            cp "$f" /tmp/broll_ready/
+            count=$((count + 1))
+          done
+          cp /tmp/broll_cuts/_provenance.json /tmp/broll_ready/ 2>/dev/null || true
+
+      - name: Upload to R2 + write pool index
+        env:
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_GALLERY_BUCKET: ${{ secrets.R2_GALLERY_BUCKET }}
+          R2_GALLERY_PUBLIC_BASE_URL: ${{ secrets.R2_GALLERY_PUBLIC_BASE_URL }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          clips=(/tmp/broll_ready/*.mp4)
+          if [ "${#clips[@]}" -eq 0 ]; then
+            echo "::error::no clips survived fetching/cutting — nothing to publish"
+            exit 1
+          fi
+          echo "Publishing ${#clips[@]} clip(s) to the ${{ inputs.show }} pool"
+          python scripts/build_broll_pool.py --show "${{ inputs.show }}" "${clips[@]}"
+
+      - uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: "digests/*/broll.json"
+          commit-message: "B-roll pool: ${{ inputs.show }} += ${{ inputs.source }} footage"

--- a/engine/config.py
+++ b/engine/config.py
@@ -833,6 +833,11 @@ class YouTubeConfig:
     # rotated per episode, so this is the WIDTH of each episode's slice,
     # not which clips it gets. Capped by engine.video._MAX_BROLL_CLIPS.
     broll_clips_per_episode: int = 3
+    # Fill Shorts backgrounds from the same pool (real footage between
+    # the stills, via the motion-A/B's hybrid path). Clean no-op until a
+    # pool is published; suppressed automatically while a Shorts motion
+    # A/B is enrolled so neither arm changes mid-experiment.
+    shorts_broll: bool = True
 
     # Optional path (relative to repo root) to a text template for the
     # long-form description body. Placeholders: {hook}, {episode_num},

--- a/engine/gallery_library.py
+++ b/engine/gallery_library.py
@@ -670,7 +670,7 @@ def interleave_by_source(entries: List[dict]) -> List[dict]:
 
 
 def rotate_for_episode(entries: List[dict], episode_seed: Optional[str],
-                       limit: int) -> List[dict]:
+                       limit: int, *, stride: Optional[int] = None) -> List[dict]:
     """Rotate a pool so consecutive episodes draw different clips.
 
     The pool was consumed in fixed committed order, so EVERY episode of
@@ -702,9 +702,19 @@ def rotate_for_episode(entries: List[dict], episode_seed: Optional[str],
     digits = re.findall(r"\d+", seed)
     show_part = re.sub(r"\d+", "", seed)
     show_offset = zlib.crc32(show_part.encode("utf-8"))
+    # The per-episode step. ``stride`` exists because a caller that wants
+    # the FULL rotated pool back (select_broll_clips, so a failed
+    # download can backfill from the remainder) passes limit=len(entries)
+    # — and with the step derived from that limit, index * len % len == 0
+    # cancelled the episode number entirely. Production shipped the SAME
+    # clips on every episode from Ep055 until this fix while the direct
+    # unit tests (which pass the slice width as limit) stayed green. The
+    # stride must be the SLICE WIDTH the consumer will take, never the
+    # pool size.
+    step = int(stride) if stride else max(1, limit)
     if digits:
         index = int(digits[-1])
-        offset = (index * max(1, limit) + show_offset) % len(entries)
+        offset = (index * max(1, step) + show_offset) % len(entries)
     else:
         offset = show_offset % len(entries)
     rotated = entries[offset:] + entries[:offset]
@@ -735,8 +745,12 @@ def select_broll_clips(
         if not entries or limit <= 0:
             return []
         # Rotate first, then walk — so a download failure inside the
-        # rotated slice backfills from the rest of the pool.
-        entries = rotate_for_episode(entries, episode_seed, len(entries))
+        # rotated slice backfills from the rest of the pool. The stride
+        # is the CALLER's slice width (see rotate_for_episode: deriving
+        # it from this full-pool limit cancelled the rotation and shipped
+        # identical clips every episode).
+        entries = rotate_for_episode(entries, episode_seed, len(entries),
+                                     stride=limit)
         cdir = (Path(cache_dir) if cache_dir
                 else _default_cache_dir() / "broll" / show_slug)
         cdir.mkdir(parents=True, exist_ok=True)

--- a/engine/pipeline.py
+++ b/engine/pipeline.py
@@ -262,6 +262,12 @@ def record_youtube_outcomes(
             metrics.record("scene_library_count", int(youtube_urls.get("scene_library_count", 0) or 0))
         if "broll_clips_used" in youtube_urls:
             metrics.record("broll_clips_used", int(youtube_urls.get("broll_clips_used", 0) or 0))
+        # Real-footage Shorts (Aug 2026): pool clips per Short, in upload
+        # order — [2, 2] means both Shorts carried footage, [0, 0] means
+        # the pool was missing/unfetchable and stills shipped.
+        if "shorts_broll_counts" in youtube_urls:
+            metrics.record("shorts_broll_counts",
+                           list(youtube_urls.get("shorts_broll_counts") or []))
         # Shorts-only scene saving (July 2026): 16:9 scenes are only worth
         # generating when a long-form video is actually produced.
         if "scene_long_form_produced" in youtube_urls:

--- a/run_show.py
+++ b/run_show.py
@@ -5973,9 +5973,49 @@ def _publish_youtube(
                     if short_idx < len(_short_variants):
                         _short_variants[short_idx] = _variant.variant
 
+                    # ---- Real-footage Shorts (Aug 2026) ----
+                    # The evergreen b-roll pool fed only the long-form
+                    # render; every Short still shipped stills even
+                    # after the operator published real launch footage.
+                    # Reuse the motion-A/B's proven hybrid path: when no
+                    # experiment is enrolled, fill clip_paths from the
+                    # pool. Per-short seed (episode*4 + index — the
+                    # multiplier exceeds MAX_SHORTS so slices stay
+                    # disjoint across Shorts AND stride across episodes).
+                    # Clean no-op without a pool. While an A/B is
+                    # enrolled BOTH arms keep their designed visuals —
+                    # pool clips in the control arm would upgrade it
+                    # mid-experiment.
+                    _short_broll: list = []
+                    if (not _ab_on
+                            and not _variant.clip_paths
+                            and getattr(config.youtube,
+                                        "shorts_broll", True)):
+                        try:
+                            from engine.gallery_library import (
+                                select_broll_clips,
+                            )
+                            _short_broll = select_broll_clips(
+                                args.show,
+                                digests_dir=digests_dir,
+                                limit=2,
+                                episode_seed=(
+                                    f"{args.show}-short:"
+                                    f"e{episode_num * 4 + short_idx:05d}"
+                                ),
+                            )
+                        except Exception as exc:  # noqa: BLE001
+                            logger.warning(
+                                "Shorts b-roll selection failed: %s — "
+                                "stills only", exc)
+                            _short_broll = []
+                    result.setdefault("shorts_broll_counts", []).append(
+                        len(_short_broll))
+
                     build_short_video(
                         final_mp3, cover_path, this_short_video_path,
-                        clip_paths=_variant.clip_paths or None,
+                        clip_paths=(_variant.clip_paths
+                                    or _short_broll or None),
                         clip_seconds=float(getattr(
                             config.youtube, "shorts_ab_clip_seconds", 5) or 5),
                         # A1 guard: a show running the Shorts motion A/B

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -461,3 +461,6 @@ youtube:
   # raise this only to add more motion per episode (cap: 3 in
   # engine.video._MAX_BROLL_CLIPS).
   broll_clips_per_episode: 3
+  # Shorts draw 2 clips per Short from the same pool (real footage
+  # between the stills). No-op until the show has a broll.json.
+  shorts_broll: true

--- a/tests/test_shorts_broll.py
+++ b/tests/test_shorts_broll.py
@@ -1,0 +1,212 @@
+"""Guards for real-footage Shorts + the rotation-stride regression.
+
+Two findings from the August 2026 video review:
+
+**The rotation was dead in production.** ``select_broll_clips`` passes
+``limit=len(entries)`` into ``rotate_for_episode`` (so a failed download
+can backfill from the rest of the pool), and the per-episode step was
+derived from that limit — ``index * len % len == 0``, cancelling the
+episode number. Every episode shipped the SAME clips from the day the
+pool landed, while the direct unit tests (which pass the slice width as
+the limit) stayed green. The fix is an explicit ``stride`` carrying the
+consumer's slice width; the tests here go through the PRODUCTION call
+path, not the function in isolation.
+
+**Shorts never used the pool.** The b-roll pool fed only the long-form
+hybrid; every Short shipped stills even after real launch footage was
+published. Shorts now draw 2 pool clips each through the motion-A/B's
+proven ``clip_paths`` path, with a per-short seed so Shorts of one
+episode differ from each other and from yesterday's.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest  # noqa: E402
+
+from engine import gallery_library as gl  # noqa: E402
+
+_ENDPOINT = "https://abc123.r2.cloudflarestorage.com"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cdn_state(monkeypatch):
+    monkeypatch.setattr(gl, "_prefer_r2_download", False, raising=False)
+
+
+def _make_pool(tmp_path, n=25):
+    d = tmp_path / "digests"
+    d.mkdir(parents=True, exist_ok=True)
+    clips = [
+        {"url": f"{_ENDPOINT}/nerra-gallery/broll/spacex/c{i:02d}.mp4",
+         "key": f"broll/spacex/c{i:02d}.mp4",
+         "label": f"src{i % 4}_Isolated___{i:02d}m00s"}
+        for i in range(n)
+    ]
+    (d / "broll.json").write_text(json.dumps({"clips": clips}),
+                                  encoding="utf-8")
+    return d
+
+
+def _select(digests_dir, cache_root, seed, limit=3):
+    """select_broll_clips with downloads faked — the PRODUCTION path."""
+    got = gl.select_broll_clips(
+        "spacex", digests_dir=digests_dir, limit=limit,
+        cache_dir=cache_root / seed.replace(":", "_"),
+        episode_seed=seed,
+    )
+    return tuple(p.name for p in got)
+
+
+@pytest.fixture()
+def _fake_r2(monkeypatch):
+    def _r2(entry, dest):
+        dest.write_bytes(b"video")
+        return True
+    monkeypatch.setattr(gl, "_download_via_r2", _r2)
+
+
+class TestRotationAliveInProduction:
+    """These tests exist because the direct-call tests lied."""
+
+    def test_consecutive_episodes_get_different_clips(self, tmp_path,
+                                                      _fake_r2):
+        d = _make_pool(tmp_path)
+        slices = [
+            _select(d, tmp_path, f"spacex:ep{n:03d}") for n in (55, 56, 57, 58)
+        ]
+        assert len(set(slices)) == len(slices), slices
+        # And back-to-back episodes share nothing.
+        for a, b in zip(slices, slices[1:]):
+            assert not (set(a) & set(b)), (a, b)
+
+    def test_the_dead_rotation_shape_is_pinned(self):
+        """Reproduce the bug arithmetic so a revert fails loudly: with
+        the step equal to the pool size, every episode collapses to the
+        same offset."""
+        pool = [{"url": f"u{i}"} for i in range(25)]
+        same = {
+            tuple(c["url"] for c in gl.rotate_for_episode(
+                pool, f"spacex:ep{n:03d}", len(pool)))[:3]
+            for n in (55, 56, 57)
+        }
+        # Without an explicit stride the full-pool call is STILL the
+        # degenerate one — the fix is that select_broll_clips passes
+        # stride, not that the arithmetic changed underneath everyone.
+        assert len(same) == 1
+        strided = {
+            tuple(c["url"] for c in gl.rotate_for_episode(
+                pool, f"spacex:ep{n:03d}", len(pool), stride=3))[:3]
+            for n in (55, 56, 57)
+        }
+        assert len(strided) == 3
+
+    def test_direct_slice_width_callers_are_unchanged(self):
+        pool = [{"url": f"u{i}"} for i in range(12)]
+        a = gl.rotate_for_episode(pool, "spacex:ep010", 3)
+        b = gl.rotate_for_episode(pool, "spacex:ep010", 3, stride=3)
+        assert a == b
+
+    def test_download_failure_still_backfills_from_the_pool(self, tmp_path,
+                                                            monkeypatch):
+        """The reason limit=len(entries) exists at all — keep it working."""
+        d = _make_pool(tmp_path, n=6)
+        calls = {"n": 0}
+
+        def _flaky(entry, dest):
+            calls["n"] += 1
+            if calls["n"] == 1:  # first clip of the slice fails
+                return False
+            dest.write_bytes(b"video")
+            return True
+
+        monkeypatch.setattr(gl, "_download_via_r2", _flaky)
+        got = gl.select_broll_clips(
+            "spacex", digests_dir=d, limit=3,
+            cache_dir=tmp_path / "cache", episode_seed="spacex:ep055")
+        assert len(got) == 3
+
+
+class TestShortsDrawFromThePool:
+    def test_each_short_gets_a_distinct_clip_pair(self, tmp_path, _fake_r2):
+        """The run_show seed shape: episode*4 + short index."""
+        d = _make_pool(tmp_path)
+        ep = 55
+        pairs = [
+            _select(d, tmp_path, f"spacex-short:e{ep * 4 + i:05d}", limit=2)
+            for i in range(3)
+        ]
+        assert len(set(pairs)) == 3, pairs
+
+    def test_same_short_differs_across_episodes(self, tmp_path, _fake_r2):
+        d = _make_pool(tmp_path)
+        short0 = [
+            _select(d, tmp_path, f"spacex-short:e{ep * 4:05d}", limit=2)
+            for ep in (55, 56, 57)
+        ]
+        assert len(set(short0)) == 3, short0
+
+    def test_run_show_wiring(self):
+        src = (PROJECT_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "episode_num * 4 + short_idx" in src
+        assert "clip_paths=(_variant.clip_paths\n" \
+               "                                    or _short_broll or None)" \
+               in src
+        # The A/B guard: no pool clips while an experiment is enrolled.
+        assert "not _ab_on" in src
+        assert '"shorts_broll", True' in src.replace("'", '"')
+
+    def test_config_default_is_on(self):
+        import logging
+        logging.disable(logging.CRITICAL)
+        try:
+            from engine.config import load_config
+            cfg = load_config("shows/spacex.yaml")
+            assert getattr(cfg.youtube, "shorts_broll", None) is True
+        finally:
+            logging.disable(logging.NOTSET)
+
+    def test_metrics_record_the_per_short_counts(self):
+        src = (PROJECT_ROOT / "engine" / "pipeline.py").read_text(
+            encoding="utf-8")
+        assert "shorts_broll_counts" in src
+
+
+class TestPoolBuilderWorkflow:
+    def _wf(self):
+        import yaml
+        path = (PROJECT_ROOT / ".github" / "workflows"
+                / "build-broll-pool.yml")
+        return path.read_text(encoding="utf-8"), yaml.safe_load(
+            path.read_text(encoding="utf-8"))
+
+    def test_dispatch_inputs_cover_both_sources(self):
+        text, data = self._wf()
+        inputs = data[True]["workflow_dispatch"]["inputs"] \
+            if True in data else data["on"]["workflow_dispatch"]["inputs"]
+        assert set(inputs) >= {"show", "source", "query", "max_clips"}
+        assert "pexels" in text and "nasa" in text
+
+    def test_has_ffmpeg_and_r2_credentials(self):
+        text, _ = self._wf()
+        assert "system-packages: 'ffmpeg'" in text
+        for secret in ("R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID",
+                       "R2_SECRET_ACCESS_KEY", "R2_GALLERY_BUCKET",
+                       "R2_GALLERY_PUBLIC_BASE_URL", "PEXELS_API_KEY"):
+            assert secret in text, f"missing {secret}"
+
+    def test_commits_only_the_pool_index(self):
+        """Media in git is landmine #1 — the workflow must add only the
+        JSON index, never clip files."""
+        text, _ = self._wf()
+        assert 'add-paths: "digests/*/broll.json"' in text
+        assert ".mp4" not in text.split("safe-commit-push")[1]
+
+    def test_empty_fetch_fails_loudly(self):
+        text, _ = self._wf()
+        assert "no clips survived" in text


### PR DESCRIPTION
Operator-directed review + improvement pass over the last week's video pipeline, with SpaceX real footage as the focus.

## The review baseline: Ep055 verified everything from yesterday

This morning's SpaceX run confirmed the fixes live: `broll_clips_used: 3` (was 0), Listener Value **8.0** with no warning (was 5.2 from the broken scorer), no wasted repetition regen, tier-A with hook-first Short at 0.0s. The pipeline works. These are the next three items it surfaced.

## 1. Review finding: the per-episode rotation was dead in production

`select_broll_clips` passes `limit=len(entries)` into `rotate_for_episode` (so a failed download can backfill from the rest of the pool) — and the per-episode step was derived from that limit:

```
offset = (episode_index × len(pool) + show_offset) % len(pool)  ≡  show_offset
```

The episode number cancels out. **Every episode has shipped the same three clips since the pool landed** — Ep055's `broll=3` this morning was real footage, but it was the *same* footage every day would have gotten. The unit tests stayed green because they call `rotate_for_episode` directly with the slice width; nothing tested the production call path. (The same blind spot as yesterday's newsletter-tag test — a lesson I evidently needed twice.)

Fix: an explicit `stride` carrying the consumer's slice width. Verified against the real committed pool:

```
ep55: IXPE, DART, GOES     ep57: DART, GOES, IMAP     ep59: GOES, IMAP, IXPE
ep56: IMAP, IXPE, IXPE     ep58: IXPE, IXPE, DART
```

The new regression tests go through `select_broll_clips` itself, downloads faked — and one test pins the dead arithmetic so a revert fails loudly.

## 2. Shorts now carry real launch footage

The pool fed only the long-form render; every Short shipped stills — the known gap from the source survey, and the thing the operator explicitly asked for. Shorts now draw **2 pool clips each** through the motion-A/B's already-proven `clip_paths` → hybrid path: opens the Short on a clip, trims to fit exactly, center-crops 16:9 → 1080×1920 (launch footage is vertical motion, so the crop favours it).

- Per-short seed = `episode×4 + short index` — slices disjoint across the episode's Shorts *and* striding across days. Verified on the real pool: ep55's three Shorts get `GOES+IMAP`, `IXPE+IXPE`, `DART+GOES`.
- **Suppressed while a Shorts motion A/B is enrolled** — pool clips in the control arm would upgrade it mid-experiment. (SpaceX's A/B is off, so it applies there immediately.)
- New knob `youtube.shorts_broll` (default true, clean no-op without a pool). Metrics: `shorts_broll_counts` per episode — `[2, 2]` vs `[0, 0]` is visible in `metrics_epNNN.json`, so a regression to stills can't hide.

## 3. One-click pools for every show

The SpaceX pool took a multi-step operator-laptop session (and hit macOS TLS + missing-tool issues on the way). `.github/workflows/build-broll-pool.yml` collapses it to a single dispatch from the Actions tab:

| input | effect |
|---|---|
| `show` + `source: pexels` | fetch via the show's curated `image_queries` (safety filter, per-clip attribution) |
| `show` + `source: nasa` + `query` | fetch + auto-cut ~7s accents at the real-motion moments |

Both upload to R2 and commit **only** `digests/<dir>/broll.json` (media in git is landmine #1 — guarded by a test). Clips are machine-curated; the workflow header says to spot-check the next episode and how to remove a dud (delete its JSON entry, no re-upload).

Suggested first dispatches: `fascinating_frontiers` + nasa (`Artemis I Isolated Launch Views` fits its beat), `tesla` + pexels, `modern_investing` + pexels, `dp_pod` + pexels.

## Tests

`tests/test_shorts_broll.py` (13): production-path rotation (consecutive episodes disjoint), the pinned dead arithmetic, backfill-on-download-failure still working (the reason the full-pool limit exists), per-short distinctness, run_show wiring, config default, workflow sanity incl. the no-media-committed guard.

Full suite: **6422 passed**; the 21 failures are the pre-existing `feedgen` sandbox gap, identical on clean main. Render/metadata-only — outside landmine #17.

## Not done, deliberately

- **RU/FR dub Shorts** don't draw from the pool yet — same one-call wiring in `ru_dub`/`lang_dub`, but the dub sweep runs in a different workflow and I'd rather land the EN path and see one day of output first. Highest-value follow-up given RU Shorts are the network's best surface.
- Long-form clip count stays at 3 — more would fight the chapter-aligned still rhythm the June pass established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dbge5febMwwU4UbvXLqcnr)_