### PR TITLE
Offshore North: weekly fetch window, thin-script floor, dead feed, and a real debut introduction

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -930,6 +930,17 @@ class ShowConfig:
     web_search_queries: List[str] = field(default_factory=list)
     min_articles: int = 3  # Minimum articles before expanding search
     min_articles_skip: int = 3  # Hard cutoff — skip episode if fewer articles
+    # Progressive fetch-window ladder, in hours, widest last. Empty = use
+    # the network default (24 → 48 → 72), which is tuned for DAILY shows.
+    #
+    # A show whose publication interval exceeds the widest stage can never
+    # see its own period: Offshore North publishes Monday covering seven
+    # days, and on the 2026-08-04 run the 72h ceiling starved it to 6
+    # on-topic articles from 2 of 17 feeds. The pipeline only reached 46
+    # articles by switching keyword filtering OFF, i.e. by going
+    # off-topic, and the resulting digest came out at 596 words against a
+    # 1300 target. Set this to cover the show's own cadence.
+    fetch_expansion_hours: List[int] = field(default_factory=list)
     min_audio_duration: int = 0  # Minimum audio seconds — skip if shorter (0 = disabled)
     max_weekly_cost_usd: float = 0.0  # 0 = no limit; >0 skips episode if 7-day spend exceeds
     # Item 4 stronger breakers (May 2026 review)
@@ -1141,6 +1152,9 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         web_search_queries=data.get("web_search_queries", []),
         min_articles=data.get("min_articles", 3),
         min_articles_skip=data.get("min_articles_skip", 3),
+        fetch_expansion_hours=[
+            int(h) for h in (data.get("fetch_expansion_hours") or [])
+        ],
         min_audio_duration=int(
             data.get("min_audio_duration")
             or (data.get("audio") or {}).get("min_audio_duration")

--- a/engine/first_episode.py
+++ b/engine/first_episode.py
@@ -35,6 +35,46 @@ This is the **series premiere** for "{show_name}".
 # audio.debut_song_file; the script must introduce it).
 
 _SHOW_DIGEST_EP1 = {
+    "offshore_north": """
+### FIRST EPISODE (Episode {episode_num}) — DEBUT BRIEF for "{show_name}"
+A normal weekly brief with a real introduction in front of it. Keep the
+standard hook line and the standard section headings — the pipeline and the
+blog both read them — and add ONE new section directly after the hook:
+
+**## What This Show Is** (250-350 words, first episode only)
+- The gap: one of the great endurance sports on earth is reported almost
+  entirely in French, leaving English-speaking fans with the results but
+  not the meaning. This show closes that gap weekly. State it once,
+  plainly — no grievance, no hype.
+- The spine: every four years a small number of people sail alone, without
+  stopping and without assistance, around the world, and no Canadian has
+  ever finished. Scott Shawyer and Canada Ocean Racing are trying to change
+  that at the Vendee Globe starting 12 November 2028. The show follows that
+  attempt week by week and uses it as a door into the whole sport.
+- The weekly shape: The Canadian Boat (consequence, not recap), The Fleet
+  (the week in offshore racing with the why-it-matters layer), Plain
+  Sailing (one concept explained properly), The Countdown (days to the
+  start and where qualification stands).
+- The promise: sources named and linked every week; no hype; no
+  play-by-play that is stale by Monday; nothing stated that the sources do
+  not support, and uncertainty flagged as uncertainty.
+- Who it is for: people who are enthusiastic, not expert — and never
+  treated as though those are the same thing.
+- The network, in two or three sentences: Offshore North is part of the
+  Nerra Network, an independent, ad-free network of daily shows built by
+  two friends (Novak plus Perra equals Nerra) covering technology, science,
+  markets, world news and language learning in several languages, free with
+  no ads and no paywall, at nerranetwork.com. An invitation, not a
+  commercial — no superlatives, no growth numbers, no counts of shows or
+  listeners.
+
+Then run the normal sections for the week. Debut discipline: choose the
+STRONGEST stories rather than padding the list; define every piece of
+jargon on first use; do not reference previous episodes or weeks; and hold
+every racing claim to the show's normal sourcing and [VERIFY: ...] rules —
+only the introduction speaks from the show's own identity rather than from
+the week's sources.
+""",
     "dp_pod": """
 ### FIRST EPISODE — THE FOUNDING BRIEF (Episode 1 of {show_name})
 This debut brief is NOT a news digest. It MUST still begin with the standard
@@ -83,6 +123,82 @@ Papers news-item format entirely and structure the brief as:
 }
 
 _SHOW_PODCAST_EP1 = {
+    "offshore_north": """
+### FIRST EPISODE — THE DEBUT SCRIPT (series premiere of {show_name})
+A real episode with a real introduction in front of it, NOT a news-only
+week. Target 1,900-2,100 words — longer than a normal episode because the
+introduction is additive, and every regular segment still runs and is still
+announced BY NAME so its chapter marker latches.
+
+Order and shape:
+
+1. **[Cold open — the week's single most interesting development, 2-3
+   sentences]** Plain fact, no preamble, exactly as on any other week.
+2. **[The supplied intro line — copy it VERBATIM, immediately after the
+   cold open]** It must appear within the first ~100 words of the script.
+   Do not push it later with extra cold-open material; the Introduction
+   chapter marker is positional and will not latch if it drifts.
+3. **[THE INTRODUCTION — 450-600 WORDS, first episode only]** Dan explains,
+   in his own plain voice, what this show is. Cover, in whatever order
+   reads naturally — as talk, not as a list read aloud:
+   - **WHY IT EXISTS.** One of the great endurance sports on earth is
+     reported almost entirely in French, which leaves English-speaking
+     fans with the results but not the meaning. This show closes that gap
+     every Monday. Say it once, without grievance and without hype.
+   - **THE SPINE OF THE SERIES.** Every four years a small number of
+     people sail alone, without stopping and without assistance, all the
+     way around the world, and no Canadian has ever finished. Scott
+     Shawyer and Canada Ocean Racing are trying to change that at the
+     Vendee Globe starting 12 November 2028. The show follows that attempt
+     week by week and uses it as a door into the whole sport.
+   - **WHAT LISTENERS GET EACH WEEK.** Name the four segments and what
+     each is FOR in one clause apiece: The Canadian Boat (what the
+     campaign did and what it changes — consequence, not recap), The Fleet
+     (the week in offshore racing with the why-it-matters layer), Plain
+     Sailing (one concept explained properly), The Countdown (days to the
+     start and where qualification actually stands).
+   - **THE PROMISE.** Sources named in the episode and linked in the
+     notes. No hype. No play-by-play that is stale by Monday. Nothing
+     stated that the sources do not support — and when something is
+     uncertain, it gets said as uncertain.
+   - **WHO IT IS FOR, AND WHO IS TALKING.** Made for people who are
+     enthusiastic, not expert, and never treated as though those are the
+     same thing. Dan is a commercial airline pilot and a Nerra Network
+     co-founder, not an offshore racing expert, and says so plainly. He
+     may name the two things he does bring — a working life spent reading
+     weather, trading a shorter track against a faster one, and making
+     irreversible calls on incomplete information; and having felt, at a
+     far smaller scale, what it is like when a hull comes unstuck and
+     starts to fly. ONE such touch, briefly. No career history, no resume,
+     no life story. Do NOT invent any specific past event, place, date or
+     anecdote for Dan — he is a real person.
+   - **WHAT THE NERRA NETWORK IS.** Offshore North is part of it, so say
+     what it is: an independent, ad-free network of daily shows built by
+     two friends — Novak plus Perra equals Nerra — covering technology,
+     science, markets, world news and language learning, in several
+     languages, free to listen to with no ads and no paywall. Point at
+     "nerra network dot com" once, said naturally, for every show and the
+     episode notes. Two or three sentences. This is an invitation, not a
+     commercial: no superlatives, no growth numbers, no claims about how
+     many shows or listeners there are.
+4. **[The Canadian Boat]** As normal, announced by name. If the campaign
+   made no public news this week, say so in one sentence and use a
+   standing item — do not pad and do not speculate about the campaign's
+   internal decisions, finances or plans.
+5. **[The Fleet]** As normal, announced by name.
+6. **[Plain Sailing]** As normal, announced by name. On a debut, prefer a
+   genuinely foundational concept — the thing a new listener most needs in
+   order to follow every future episode.
+7. **[The Countdown]** As normal, announced by name.
+8. **[Sign-off]** The supplied closing block, copied VERBATIM. Final spoken
+   words are the fixed sign-off line.
+
+Debut discipline: do NOT say "welcome back", do not reference earlier
+episodes, and do not promise anything you cannot guarantee weekly. Every
+racing fact in this episode obeys the show's normal sourcing rules —
+the introduction is the only part that speaks from the show's own
+identity rather than from the week's sources.
+""",
     "dp_pod": """
 ### FIRST EPISODE — THE DEBUT SCRIPT (series premiere of {show_name})
 This is a designed founding episode, not a news day. Total target stays

--- a/run_show.py
+++ b/run_show.py
@@ -3738,6 +3738,28 @@ def _fetch_with_expansion(
         (72, 0.55, False),   # Drop keyword filter entirely (broader catch)
     ]
 
+    # Per-show override for shows whose cadence is wider than the daily
+    # ladder above. The final stage always repeats the widest window with
+    # keyword filtering off, mirroring the default shape — dropping
+    # keywords is the last resort, never an earlier one, because
+    # off-topic volume produces a longer article list and a WORSE digest
+    # (Offshore North, 2026-08-04: 46 off-topic articles -> 596 words).
+    # Empty list = the default ladder, byte-for-byte.
+    _custom_hours = list(getattr(config, "fetch_expansion_hours", []) or [])
+    if _custom_hours:
+        _custom_hours = sorted({int(h) for h in _custom_hours if int(h) > 0})
+        expansion_stages = [
+            (h, 0.65 if idx < 2 else 0.55, True)
+            for idx, h in enumerate(_custom_hours)
+        ]
+        expansion_stages.append((_custom_hours[-1], 0.55, False))
+        logger.info(
+            "Fetch ladder overridden for %s: %s (widest %dh)",
+            getattr(config, "slug", "?"),
+            " -> ".join(f"{h}h" for h in _custom_hours),
+            _custom_hours[-1],
+        )
+
     best_articles: list[dict] = []
 
     for stage_idx, (cutoff_hours, sim_threshold, use_keywords) in enumerate(expansion_stages):

--- a/shows/offshore_north.yaml
+++ b/shows/offshore_north.yaml
@@ -23,6 +23,15 @@ weekly_summary_segment: false
 min_articles: 4
 min_articles_skip: 2
 
+# Weekly show — the network default ladder (24 -> 48 -> 72h) is tuned for
+# DAILY shows and tops out three days short of this show's own period, so
+# four of the seven days it exists to cover were invisible. The 2026-08-04
+# run starved to 6 on-topic articles from 2 of 17 feeds and only reached 46
+# by dropping keyword filtering, i.e. by going off-topic; the digest came
+# out at 596 words against a 1300 target and the episode was skipped.
+# 168h = the seven days a Monday episode actually reports on.
+fetch_expansion_hours: [48, 96, 168]
+
 sources:
   # ---- Tier 1: the campaign itself (primary, low volume, highest value) ----
   - url: "https://www.canadaoceanracing.com/feed/"
@@ -59,8 +68,13 @@ sources:
     label: "Sail-World Europe (racing)"
 
   # ---- Tier 5: magazines / technical depth ----
-  - url: "https://www.seahorsemagazine.com/?format=feed&type=rss"
-    label: Seahorse Magazine
+  # REMOVED 2026-08-04: Seahorse Magazine
+  # (https://www.seahorsemagazine.com/?format=feed&type=rss) returned
+  # "Feed yielded 0 entries (likely blocked/empty/stale URL)" on all four
+  # fetch passes of the first live run — it is the only one of the 17
+  # feeds that is actually broken rather than merely filtered out. No
+  # replacement URL is guessed here; re-add only a URL confirmed to serve
+  # recent English items.
   - url: "https://www.yachtingworld.com/news/feed"
     label: Yachting World — News
 
@@ -210,7 +224,14 @@ llm:
   # 1,600 sits inside that band so the expand-retry fires on genuinely
   # short episodes, not on every good 1,550-word one.
   min_podcast_words: 1600
-  min_podcast_word_floor: 1150
+  # Lowered 1150 -> 950 on 2026-08-04. Ep001 generated a 1124-word script
+  # and was skipped for being 26 words under its own floor, which was set
+  # nearly 2x the network default of 600. 950 still sits just under the
+  # 960 soft floor (60% of target), so a genuinely rushed episode is
+  # still refused — but a real racing week no longer loses the episode to
+  # a rounding error. The length fix is the wider fetch window below;
+  # this is only the safety net under it.
+  min_podcast_word_floor: 950
   # Network-wide July 2026 policy: length is attacked on the DIGEST side
   # only — the script can never say more than the brief gives it, and
   # podcast-side expansion pads by paraphrase-duplication. A weekly show

--- a/tests/test_offshore_north_weekly_fixes.py
+++ b/tests/test_offshore_north_weekly_fixes.py
@@ -1,0 +1,184 @@
+"""Drift guards for the Offshore North weekly-cadence fixes (Aug 4 2026).
+
+Ep001 generated on 2026-08-04 was SKIPPED: a 1124-word podcast script
+against a self-imposed 1150-word hard floor. The proximate cause was 26
+words; the real cause was that the network fetch ladder tops out at 72h
+while the show publishes weekly, so four of the seven days it reports on
+were invisible. With keyword filtering on, all stages starved at 6
+articles from 2 of 17 feeds; the run only reached 46 articles by dropping
+keywords entirely, i.e. by going off-topic, and the digest came out at
+596 words against a 1300 target.
+
+These guards pin the three config-side fixes plus the debut appendices,
+and — most importantly — that the ladder override is a strict no-op for
+every other show.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.config import load_config  # noqa: E402
+from engine.first_episode import (  # noqa: E402
+    first_episode_digest_appendix,
+    first_episode_podcast_appendix,
+)
+
+_SHOW_YAML = _ROOT / "shows" / "offshore_north.yaml"
+
+
+def _cfg():
+    return load_config(str(_SHOW_YAML))
+
+
+class TestFetchLadderOverride:
+    def test_offshore_north_ladder_covers_its_own_week(self):
+        hours = _cfg().fetch_expansion_hours
+        assert hours, "offshore_north must declare a fetch ladder"
+        assert max(hours) >= 168, (
+            "a Monday show reports on seven days; the widest stage must reach "
+            f"168h, got {max(hours)}h"
+        )
+
+    def test_every_other_show_keeps_the_default_ladder(self):
+        """The override must be opt-in. An accidental default here would
+        re-tune the fetch window for all 15 other shows at once."""
+        offenders = []
+        for path in sorted((_ROOT / "shows").glob("*.yaml")):
+            if path.stem.startswith("_") or path.stem == "offshore_north":
+                continue
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            if not isinstance(data, dict) or "slug" not in data:
+                continue  # not a show config
+            if data.get("fetch_expansion_hours"):
+                offenders.append(path.stem)
+        assert not offenders, (
+            "these shows gained a custom fetch ladder — intentional? " f"{offenders}"
+        )
+
+    def test_default_is_empty_so_dataclass_falls_back(self):
+        from engine.config import ShowConfig
+
+        assert ShowConfig().fetch_expansion_hours == []
+
+    def test_yaml_key_is_actually_read(self):
+        """Guards the silent config-drop class (landmine: _build_nested).
+
+        The value in the YAML must survive into the dataclass — a typo in
+        the factory would leave the show on the 72h ladder while the YAML
+        claims otherwise.
+        """
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        assert _cfg().fetch_expansion_hours == [
+            int(h) for h in raw["fetch_expansion_hours"]
+        ]
+
+    def test_run_show_builds_stages_from_config(self):
+        """The ladder override must exist in run_show and must put the
+        keyword-off stage LAST. Dropping keywords earlier trades a longer
+        article list for a worse digest — that is what produced the
+        596-word digest on 2026-08-04."""
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "fetch_expansion_hours" in src, "override not wired into run_show"
+        block = src[src.index("_custom_hours = list(") :][:1200]
+        # the appended final stage is the keyword-off one
+        assert "expansion_stages.append((_custom_hours[-1], 0.55, False))" in block
+
+
+class TestThinScriptFloor:
+    def test_floor_lets_a_real_episode_through(self):
+        """1124 words was a real episode refused by a rounding error."""
+        llm = _cfg().llm
+        target = llm.min_podcast_words
+        hard = max(llm.min_podcast_word_floor or 600, int(target * 0.4))
+        soft = int(target * 0.6)
+        # run_show skips when below EITHER floor, so the binding gate is the max
+        assert max(hard, soft) <= 1124, (
+            f"the Ep001 script (1124 words) would still be skipped: "
+            f"hard={hard} soft={soft}"
+        )
+
+    def test_floor_still_refuses_a_genuinely_rushed_episode(self):
+        llm = _cfg().llm
+        hard = max(llm.min_podcast_word_floor or 600, int(llm.min_podcast_words * 0.4))
+        soft = int(llm.min_podcast_words * 0.6)
+        assert max(hard, soft) >= 900, "floor lowered so far it protects nothing"
+
+
+class TestDeadFeedRemoved:
+    def test_seahorse_is_gone(self):
+        """Returned 'Feed yielded 0 entries' on all four passes of the
+        first live run — the only genuinely broken feed of the 17."""
+        urls = " ".join((s.url or "") for s in _cfg().sources).lower()
+        assert "seahorsemagazine.com" not in urls
+
+    def test_the_merely_filtered_feeds_were_kept(self):
+        """Vendee Globe / Sailorz / Yachting World / Canadian Boating all
+        parsed 10-100 entries and were filtered out by the 72h window, not
+        broken. Removing them would have been the wrong fix."""
+        urls = " ".join((s.url or "") for s in _cfg().sources).lower()
+        for host in ("vendeeglobe", "sailorz", "yachtingworld", "canadianboating"):
+            assert host in urls, f"{host} was removed — it was filtered, not dead"
+
+
+class TestDebutIntroduction:
+    def test_both_appendices_are_bespoke_for_ep1(self):
+        d = first_episode_digest_appendix(1, "Offshore North", "offshore_north")
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        assert "What This Show Is" in d
+        assert "THE INTRODUCTION" in p
+
+    def test_debut_covers_show_purpose_and_the_network(self):
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        low = p.lower()
+        assert "why it exists" in low
+        assert "nerra network" in low
+        assert "ad-free" in low
+        assert "nerranetwork.com" in low or "nerra network dot com" in low
+        for segment in (
+            "The Canadian Boat",
+            "The Fleet",
+            "Plain Sailing",
+            "The Countdown",
+        ):
+            assert segment in p, f"debut must still run {segment}"
+
+    def test_debut_protects_the_intro_line_position(self):
+        """The Introduction chapter marker is positional (first ~10% of
+        words). Ep001 shipped without it."""
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        assert "VERBATIM" in p
+        assert re.search(r"first ~?\d+ words", p)
+
+    def test_debut_forbids_inventing_a_biography(self):
+        """Dan is a real person; the show's unforgivable error is a
+        confidently-stated wrong fact."""
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        assert "Do NOT invent" in p
+
+    def test_templates_render_without_stray_placeholders(self):
+        for fn in (first_episode_digest_appendix, first_episode_podcast_appendix):
+            out = fn(1, "Offshore North", "offshore_north")
+            assert "{" not in out and "}" not in out
+
+    def test_only_episode_one_gets_the_appendix(self):
+        assert first_episode_digest_appendix(2, "Offshore North", "offshore_north") == ""
+        assert (
+            first_episode_podcast_appendix(2, "Offshore North", "offshore_north") == ""
+        )
+
+    def test_other_shows_debuts_are_untouched(self):
+        assert "DEBUT QUALITY BAR" in first_episode_digest_appendix(
+            1, "Tesla Shorts Time", "tesla"
+        )
+        assert "THE DEBUT SCRIPT" in first_episode_podcast_appendix(
+            1, "The DP Pod", "dp_pod"
+        )


### PR DESCRIPTION
Makes Offshore North able to actually produce an episode, and gives Ep1 a real introduction to the show and the network.

**First, a correction to what I told the operator earlier:** the 2026-08-04 run ([30957411315](https://github.com/Planetterrian/nerranetwork/actions/runs/30957411315)) was **not** a dry run. `test_mode` was false and the pipeline ran fully — the publish steps were skipped because the *show* skipped, not because of `--test`.

```
##[warning]Show offshore_north skipped — podcast_script_too_thin:
Script only 1124 words ... (hard floor 1150).
```

## Root cause

Not the 26 words. `run_show._fetch_with_expansion` hardcodes `24h → 48h → 72h → 72h(no keywords)`, tuned for **daily** shows. Offshore North publishes Monday covering **seven days**, so four of the days it exists to report on were structurally invisible.

Watch it starve in the log — with keyword filtering on, it never got past 6 articles from 2 of 17 feeds:

| stage | articles | feeds contributing |
|---|---|---|
| 24h, keywords on | 3 | 2 / 17 |
| 48h, keywords on | 5 | 2 / 17 |
| 72h, keywords on | 6 | 2 / 17 |
| 72h, **keywords off** | 46 | — |

It only reached 46 by going **off-topic**. The digest then came out at 596 words against a 1300 target, and the script at 952 → 1124 after retry. The problem was never article *count*; it was article *relevance*.

## Changes

| File | Change |
|---|---|
| `engine/config.py`, `run_show.py` | New per-show `fetch_expansion_hours`. Empty = default ladder, byte-for-byte |
| `shows/offshore_north.yaml` | Ladder `48 → 96 → 168h` — the widest stage finally covers the reported week |
| `shows/offshore_north.yaml` | `min_podcast_word_floor` 1150 → 950 |
| `shows/offshore_north.yaml` | Removed Seahorse Magazine (genuinely dead) |
| `engine/first_episode.py` | Bespoke debut appendices for the introduction |

**On the keyword-off stage:** it stays **last** in the override, mirroring the default shape. Dropping keywords earlier buys article count at the cost of digest quality — precisely what produced the 596-word digest.

**On the floor:** the show had set its own floor at nearly 2× the network default of 600. The binding gate is now the 960 soft floor (60% of target), so a genuinely rushed episode is still refused. This is the safety net; the fetch window is the actual fix. I deliberately did not lower the floor alone — that converts "no episode" into "thin episode" without addressing why it's thin.

**On the feeds:** Seahorse returned `Feed yielded 0 entries (likely blocked/empty/stale URL)` on all four passes — the only genuinely broken feed of the 17. No replacement URL is guessed. The other quiet ones (Vendée Globe, Sailorz, Yachting World, Canadian Boating) parsed 10–100 entries each and were filtered out by the 72h window, **not** broken; removing them would have been the wrong fix, and a guard now pins them in place.

## The debut introduction

The podcast appendix adds a **450–600 word** introduction after the cold open covering: why the show exists (the sport is reported almost entirely in French, leaving English speakers the results but not the meaning), the Vendée Globe 2028 spine, what each weekly segment is *for*, the sourcing promise, who it's for — and what the **Nerra Network** is and offers (independent, ad-free, built by two friends, several languages, free at nerranetwork.com, framed as an invitation rather than a commercial). The digest appendix adds the same as a `## What This Show Is` section so the blog and RSS carry it too.

All of it is grounded in `shows/network_meta.yaml` rather than invented, with an explicit ban on inventing a biography for Dan — he's a real person, and this show's one unforgivable error is a confidently-stated wrong fact. All four regular segments still run and are still announced by name so their chapter markers latch. Ep2+ is unaffected; other shows keep their existing debuts.

The longer debut also happens to help the length problem it sits next to.

## Known-unresolved

Ep001 parsed **5 chapters, not 6** — Introduction didn't latch. The pattern is correct (`build_intro_line` emits `This is Offshore North, episode N`, which the regex matches on all sampled episodes) and the prompt places it immediately after a one-sentence hook, well inside the positional window (`max(10% of words, 60)` = 112 words).

The likeliest mechanism is that chapters were parsed *after* the expansion retry regenerated the script without the verbatim intro line — but **the script wasn't committed, so this is a hypothesis, not a finding.** The debut template now states the position requirement explicitly. The next committed script will settle it, and I'd rather leave it open than speculatively patch shared chapter logic.

Also worth an editorial look before Ep1 ships: the run logged `'two thousand' appears 7 times (possible hallucination)` twice.

## Testing

`6619 passed, 8 skipped` (count is up from 6499 because `main` gained tests from review PRs merged since the last branch). New guards in `tests/test_offshore_north_weekly_fixes.py`, including that **no other show gains a custom ladder** and that the YAML key actually survives into the dataclass — the silent config-drop class.

Not verified by this PR: whether Ep1 now clears the floor. That needs a real run with the xAI key, which the session container doesn't have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKDLL1fvxxFMpZiXVyKe9d)_