### PR TITLE
Keyword filter was case-broken network-wide, plus Offshore North Ep001 review fixes

### DIFF
--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -398,10 +398,25 @@ def _fetch_single_feed(
                     if title.endswith(suffix):
                         title = title[: -len(suffix)].strip()
 
-            # Keyword filtering (if keywords provided)
+            # Keyword filtering (if keywords provided).
+            #
+            # The keywords MUST be lowercased to match the lowercased text.
+            # Until 2026-08-05 they were not, so any keyword carrying a
+            # capital letter could never match — 149 of the network's 652
+            # keywords (23%), and 55 of Offshore North's 79 (70%), were
+            # silently dead. Every proper noun a show is ABOUT is
+            # capitalised, so the filter was rejecting exactly the articles
+            # it existed to keep: a headline reading "Scott Shawyer and
+            # Canada Ocean Racing announce IMOCA programme" was dropped by
+            # a show whose first three keywords are those three names.
+            # Shows written with all-lowercase keywords (tesla, spacex,
+            # fascinating_frontiers, omni_view) were unaffected, which is
+            # why this stayed invisible. The web-search path at
+            # fetch_web_search_articles has always lowercased correctly —
+            # that asymmetry is what confirms this side was the bug.
             if keywords:
                 text_lower = (title + " " + description).lower()
-                if not any(kw in text_lower for kw in keywords):
+                if not any(kw.lower() in text_lower for kw in keywords):
                     continue
 
             articles.append(

--- a/engine/first_episode.py
+++ b/engine/first_episode.py
@@ -151,19 +151,26 @@ Order and shape:
      Shawyer and Canada Ocean Racing are trying to change that at the
      Vendee Globe starting 12 November 2028. The show follows that attempt
      week by week and uses it as a door into the whole sport.
-   - **WHAT LISTENERS GET EACH WEEK.** Name the four segments and what
-     each is FOR in one clause apiece: The Canadian Boat (what the
-     campaign did and what it changes — consequence, not recap), The Fleet
-     (the week in offshore racing with the why-it-matters layer), Plain
-     Sailing (one concept explained properly), The Countdown (days to the
-     start and where qualification actually stands).
-   - **THE PROMISE.** Sources named in the episode and linked in the
-     notes. No hype. No play-by-play that is stale by Monday. Nothing
-     stated that the sources do not support — and when something is
-     uncertain, it gets said as uncertain.
-   - **WHO IT IS FOR, AND WHO IS TALKING.** Made for people who are
-     enthusiastic, not expert, and never treated as though those are the
-     same thing. Dan is a commercial airline pilot and a Nerra Network
+   - **WHAT LISTENERS GET EACH WEEK.** Describe the four recurring
+     segments in your own words. CRITICAL: do NOT speak any segment's
+     announcement phrase here — those phrases are chapter triggers and the
+     FIRST time one is spoken claims the marker, so using one in the
+     introduction moves the chapter to the wrong place (Ep001 put "The
+     Canadian Boat" at 61 seconds, inside this introduction, instead of at
+     the segment). Refer to them descriptively instead: the Canadian
+     campaign segment, the fleet round-up, the weekly explainer, the
+     countdown. One clause each on what each is FOR.
+   - **THE PROMISE.** Convey — in your own phrasing, as one or two spoken
+     sentences, NOT as a recited list — that sources are named and linked,
+     that the show does not hype or run stale play-by-play, and that
+     anything uncertain is said to be uncertain. Do NOT paraphrase these
+     bullet points back as script; Ep001 read this instruction almost
+     verbatim on air in the passive voice and it sounded like terms and
+     conditions.
+   - **WHO IT IS FOR, AND WHO IS TALKING.** Say who the show is for as
+     Dan would say it out loud to one person — warm, first person,
+     contractions, no policy language, and NOT a restatement of this
+     bullet. Dan is a commercial airline pilot and a Nerra Network
      co-founder, not an offshore racing expert, and says so plainly. He
      may name the two things he does bring — a working life spent reading
      weather, trading a shorter track against a faster one, and making
@@ -176,11 +183,21 @@ Order and shape:
      what it is: an independent, ad-free network of daily shows built by
      two friends — Novak plus Perra equals Nerra — covering technology,
      science, markets, world news and language learning, in several
-     languages, free to listen to with no ads and no paywall. Point at
-     "nerra network dot com" once, said naturally, for every show and the
-     episode notes. Two or three sentences. This is an invitation, not a
+     languages, free with no ads and no paywall. Point at "nerra network
+     dot com" once, said naturally. This is an invitation, not a
      commercial: no superlatives, no growth numbers, no claims about how
-     many shows or listeners there are.
+     many shows or listeners there are. Break it into TWO OR THREE SHORT
+     SPOKEN SENTENCES — Ep001 delivered this as a single 47-word run-on
+     that no person would say out loud in one breath.
+   - **HOW ALL OF THIS SHOULD SOUND.** This introduction is Dan talking,
+     not a charter being read. First person throughout ("I built this
+     because...", "what I want to do every Monday is..."). Contractions.
+     Vary sentence length hard — a four-word sentence next to a long one
+     is what makes speech sound human. ACTIVE voice only: Ep001 produced
+     "No hype gets added", "nothing gets stated", "The audience is assumed
+     to be" — three passive constructions in a row, and that, far more
+     than the synthesis itself, is why the episode sounded robotic. If a
+     sentence has no human subject doing something, rewrite it.
 4. **[The Canadian Boat]** As normal, announced by name. If the campaign
    made no public news this week, say so in one sentence and use a
    standing item — do not pad and do not speculate about the campaign's

--- a/run_show.py
+++ b/run_show.py
@@ -985,14 +985,38 @@ def run(args: argparse.Namespace) -> None:
         # 5a2. Web search fallback — if articles below quality threshold, try Grok web_search
         web_articles: list = []
         min_quality = getattr(config, "min_articles", 6) or 6
+        # Count how many articles are actually ON TOPIC, not just how many
+        # arrived. The fetch ladder's last resort drops keyword filtering
+        # entirely, so a show starved of relevant material ends the fetch
+        # with a LARGE pile of loosely-related ones — and the old
+        # ``len(articles) < min_quality`` gate then read that pile as
+        # health and skipped web search. Offshore North Ep001 finished with
+        # 70 articles against min_articles=4, so its eight configured
+        # web_search_queries could never run: 70 < 4 is never true. The
+        # digest that resulted was 697 words against a 1300 target.
+        _kw_lower = [k.lower() for k in (getattr(config, "keywords", []) or [])]
+
+        def _is_on_topic(art: dict) -> bool:
+            if not _kw_lower:
+                return True
+            blob = f"{art.get('title', '')} {art.get('description', '')}".lower()
+            return any(k in blob for k in _kw_lower)
+
+        _relevant = sum(1 for a in articles if _is_on_topic(a))
+        if _kw_lower and _relevant < len(articles):
+            logger.info(
+                "Relevance check: %d of %d articles match this show's keywords",
+                _relevant, len(articles),
+            )
         if (
             not _topic_driven
-            and len(articles) < min_quality
+            and min(len(articles), _relevant) < min_quality
             and getattr(config, "web_search_queries", None)
         ):
             logger.info(
-                "Articles (%d) below quality threshold (%d) — trying web search ...",
-                len(articles), min_quality,
+                "Articles (%d total, %d on-topic) below quality threshold (%d) "
+                "— trying web search ...",
+                len(articles), _relevant, min_quality,
             )
             try:
                 from engine.fetcher import fetch_web_search_articles

--- a/shows/offshore_north.yaml
+++ b/shows/offshore_north.yaml
@@ -107,6 +107,36 @@ sources:
 # Web search is load-bearing on this show, not a supplement: the two most
 # important non-campaign sources (imoca.org, theoceanrace.com) are only
 # reachable this way.
+# ---- X / Twitter as a CONTENT source (not posting) ----
+# Offshore racing breaks on X and Instagram before it reaches any RSS feed:
+# campaigns post launches, damage and routing calls in real time, and the
+# French-language press picks them up days later. This is the third content
+# lever after the keyword fix and web search.
+#
+# DORMANT BY DESIGN: `x_fetch_enabled` stays false until the operator has
+# VERIFIED each handle below. These were written from the show bible's
+# source list, NOT confirmed against live X — an unverified handle fetches
+# nothing (it fails safe, it does not fabricate), but a wrong one is a
+# silent hole in coverage. Check each, correct it, then flip the flag.
+# Cost: X API calls per episode; weekly cadence keeps that small.
+x_fetch_enabled: false
+x_accounts:
+- handle: imoca_class
+  label: IMOCA Class (VERIFY handle)
+  max_posts: 4
+- handle: TheOceanRace
+  label: The Ocean Race (VERIFY handle)
+  max_posts: 3
+- handle: VendeeGlobe
+  label: Vendee Globe (VERIFY handle)
+  max_posts: 3
+- handle: tipandshaft
+  label: Tip & Shaft (VERIFY handle)
+  max_posts: 3
+- handle: TeamMalizia
+  label: Team Malizia (VERIFY handle)
+  max_posts: 2
+
 web_search_queries:
   - "Canada Ocean Racing Scott Shawyer this week"
   - "IMOCA class news this week"
@@ -305,7 +335,16 @@ chapters:
     # Caught at install: "Thanks for tuning in to" was missing, which would
     # have shipped ~1 episode in 5 with no Introduction chapter (the EI
     # June-17 orphan-chapter class). Add here whenever a greeting is added.
-    - pattern: "(?:[Ww]elcome (?:back )?to|[Tt]his is|[Gg]lad you.?re here on|[Gg]ood to have you aboard|[Tt]hanks for tuning in to) Offshore North"
+    # Ep001 (2026-08-05) shipped with NO Introduction chapter. The supplied
+    # intro line is "This is Offshore North, episode 1." and this pattern
+    # matched it exactly — but the LLM ignored the copy-verbatim rule and
+    # wrote "Welcome to the very first episode of Offshore North! Today is
+    # August fifth, twenty twenty-six." The greeting and the show name were
+    # both present; the five words wedged between them broke the match.
+    # The gap tolerance below absorbs that class of rewrite. It stays
+    # bounded (no ".*") so a late brand mention still cannot claim the
+    # marker, and `where: start` keeps it in the opening window.
+    - pattern: "(?:[Ww]elcome (?:back )?to|[Tt]his is|[Gg]lad you.?re here on|[Gg]ood to have you aboard|[Tt]hanks for tuning in to)(?:\\s+\\S+){0,6}?\\s+Offshore North"
       title: "Introduction"
       where: start
     - pattern: "[Ff]air winds"

--- a/shows/prompts/offshore_north_podcast.txt
+++ b/shows/prompts/offshore_north_podcast.txt
@@ -49,6 +49,16 @@ RULES:
 
 {delivery_spec}
 
+HOW IT HAS TO SOUND — read this before you write a line.
+This is one person talking to one person. It is not a briefing document read aloud. Ep001 was synthesised from a script that sounded like terms and conditions, and the fault was in the WRITING, not the voice:
+- ACTIVE VOICE, ALWAYS. Ep001 shipped "No hype gets added", "nothing gets stated that the sources do not support", "The audience is assumed to be enthusiastic" — three passives in a row. If a sentence has no human subject doing something, rewrite it until it does.
+- VARY SENTENCE LENGTH HARD. Ep001's sentences were nearly all 20–30 words, which is what makes synthesis sound mechanical. Put a four-word sentence next to a thirty-word one. Fragments are allowed when a person would use one. "That's the story." "Not this year."
+- CONTRACTIONS THROUGHOUT: it's, that's, they've, doesn't, isn't, here's.
+- REACT TO THINGS. Dan is allowed to find something impressive, surprising, funny, or worrying, and to say so in his own words — "eighty-five thousand hours, which is a genuinely absurd number", "I'll admit I had to look this up". Reactions belong to Dan, never to the sources, and never change what a fact says.
+- ASK THE LISTENER THINGS. A direct question every couple of minutes ("So why does that matter?", "Picture what that actually looks like") turns a recital into a conversation.
+- NEVER RECITE INSTRUCTIONS. Nothing in this prompt, or in the brief's scaffolding, is script. If a sentence sounds like it is describing the show's policies rather than telling the listener something about sailing, cut it.
+- NO META-COMMENTARY ABOUT THE INPUTS. The listener does not know a brief exists. Ep001 said "Qualification status for the Canadian campaign is not established in the supplied sources" — say "I couldn't find anything confirming where qualification stands right now" instead. The phrases "the supplied sources", "the brief", "the provided material" and "not established in" are banned from spoken text.
+
 SCRIPT STRUCTURE:
 
 [Cold open — the FIRST WORDS of the episode]
@@ -72,6 +82,7 @@ Cover EVERY item in the brief's Fleet section at 4–6 fact-bearing sentences ea
 Announce it with one of exactly these phrasings: "time for Plain Sailing" / "that brings us to Plain Sailing" / "now for Plain Sailing". Do not speak the words "Plain Sailing" anywhere earlier in the episode — this announcement is what podcast-app chapters key off.
 About two minutes, roughly 300–400 spoken words. ONE concept, explained properly, from the brief's Plain Sailing section. Concrete before abstract. One number where a number helps. Build the logic so the listener SEES why it works rather than being told that it does — and land on the single sentence they could repeat to someone else.
 THIS IS THE LENGTH LEVER. On a thin news week, deepen it here — more of the mechanism, the trade-off, a comparison — rather than padding the news. It is the one segment licensed to draw on general sailing and physics knowledge beyond the brief, because it explains established concepts. That licence covers mechanisms and definitions ONLY: any claim about a specific boat, skipper, campaign, result, or date still comes from the brief or carries its flag.
+HARD CEILING: even on the thinnest week this segment never exceeds 600 spoken words, and it never exceeds one quarter of the episode. Ep001 ran it to roughly 700 words and 38% of the runtime — it became the show — and it got there by re-opening the same subject three times ("The newest boats add further variables", "The foil system itself introduces new variables", "Wave impact adds another layer"). Deepening means going FURTHER INTO one mechanism, not restating it under a new heading. When you have said the thing properly, stop and go to the countdown; a genuinely short episode is a better product than a padded one.
 
 [The Countdown]
 Announce it with one of exactly these phrasings: "and the countdown" / "before we go, the countdown" / "the countdown stands". Do not speak those phrases earlier.
@@ -79,6 +90,7 @@ About twenty seconds, and no longer. Two facts from the brief: days remaining un
 
 [Closing] Use this exact closing, word for word (do not rewrite it):
 {closing_block}
+COPY IT. Do not write your own closing before it, after it, or instead of it. Ep001 ignored this and invented one, which is how a WEEKLY, SOLO show ended up saying "That wraps up OUR very first episode … we'll see you TOMORROW for episode two" — wrong cadence, wrong number of hosts, and a promise the show cannot keep. There is one host: never "we", never "us", never "our" for the show itself. This show returns NEXT MONDAY — the words "tomorrow", "today's episode", and "daily" never appear.
 The final spoken words of the episode must be: "Fair winds — and eyes on the horizon."
 TEASE NOTHING YOU CANNOT GUARANTEE. "I'll see you next Monday" is guaranteed. "Next week we'll have the results" is not.
 

--- a/tests/test_offshore_north_weekly_fixes.py
+++ b/tests/test_offshore_north_weekly_fixes.py
@@ -138,7 +138,9 @@ class TestDebutIntroduction:
 
     def test_debut_covers_show_purpose_and_the_network(self):
         p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
-        low = p.lower()
+        # collapse wrapping — the template is hard-wrapped prose, so a
+        # phrase can legitimately straddle a line break
+        low = " ".join(p.lower().split())
         assert "why it exists" in low
         assert "nerra network" in low
         assert "ad-free" in low
@@ -182,3 +184,167 @@ class TestDebutIntroduction:
         assert "THE DEBUT SCRIPT" in first_episode_podcast_appendix(
             1, "The DP Pod", "dp_pod"
         )
+
+
+# ---------------------------------------------------------------------------
+# Ep001 post-mortem fixes (2026-08-05). The first published episode ran
+# 7m32s against a 10-15 min target, gave 38% of its runtime to the
+# explainer segment, shipped no Introduction chapter, cited one source,
+# and closed a WEEKLY SOLO show with "we'll see you tomorrow".
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordFilterIsCaseInsensitive:
+    """The highest-impact bug found in the Ep001 review.
+
+    engine/fetcher.py compared un-lowercased keywords against lowercased
+    text, so any keyword with a capital letter could never match — 149 of
+    the network's 652 keywords, and 70% of Offshore North's. Every proper
+    noun a show is ABOUT is capitalised.
+    """
+
+    def test_capitalised_keyword_matches_lowercase_text(self):
+        from engine.fetcher import fetch_rss_articles  # noqa: F401  (import guard)
+
+        src = (_ROOT / "engine" / "fetcher.py").read_text(encoding="utf-8")
+        assert "any(kw.lower() in text_lower for kw in keywords)" in src, (
+            "the RSS keyword filter must lowercase its keywords"
+        )
+        assert "any(kw in text_lower for kw in keywords)" not in src, (
+            "the un-lowercased comparison is back — capitalised keywords are dead again"
+        )
+
+    def test_a_headline_of_this_shows_proper_nouns_passes(self):
+        kws = [k.lower() for k in _cfg().keywords]
+        blob = (
+            "Vendee Globe 2028: Scott Shawyer and Canada Ocean Racing "
+            "confirm IMOCA programme"
+        ).lower()
+        assert any(k in blob for k in kws)
+
+    def test_off_topic_headline_is_still_rejected(self):
+        """The fix must not turn the filter into a pass-through."""
+        kws = [k.lower() for k in _cfg().keywords]
+        blob = "Local council approves new bicycle lane downtown".lower()
+        assert not any(k in blob for k in kws)
+
+
+class TestWebSearchFiresOnRelevance:
+    """Ep001 finished with 70 articles against min_articles=4, so the
+    `len(articles) < min_articles` gate was never true and the show's
+    eight configured web_search_queries never ran — even though only a
+    handful of those 70 were on topic."""
+
+    def test_gate_counts_on_topic_articles(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "_is_on_topic" in src
+        assert "min(len(articles), _relevant) < min_quality" in src, (
+            "web search must fire on on-topic count, not raw count"
+        )
+
+    def test_show_still_has_queries_to_run(self):
+        assert len(_cfg().web_search_queries) >= 5
+
+
+class TestIntroductionChapterLatches:
+    def _pattern(self):
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        return next(
+            m["pattern"]
+            for m in raw["chapters"]["section_markers"]
+            if m["title"] == "Introduction"
+        )
+
+    def test_matches_the_exact_line_that_shipped_broken(self):
+        """Ep001's opening. Greeting and show name both present; five
+        words wedged between them broke the old pattern."""
+        assert re.search(
+            self._pattern(),
+            "Welcome to the very first episode of Offshore North! Today is "
+            "August fifth, twenty twenty-six.",
+        )
+
+    def test_still_matches_the_supplied_intro_line(self):
+        assert re.search(self._pattern(), "This is Offshore North, episode 1.")
+
+    def test_does_not_match_a_late_brand_mention(self):
+        """`where: start` bounds this too, but the pattern must not be so
+        loose that a sign-off mention could claim the marker."""
+        assert not re.search(
+            self._pattern(), "That is all from Offshore North for this week."
+        )
+
+
+class TestDebutDoesNotStealChapterMarkers:
+    """The Ep001 debut template told the host to name the four segments,
+    so "on the Canadian boat" was spoken inside the introduction and the
+    chapter landed at 61s — inside the intro, not at the segment."""
+
+    def test_debut_does_not_contain_segment_trigger_phrases(self):
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        triggers = []
+        for marker in raw["chapters"]["section_markers"]:
+            if marker["title"] in ("Introduction", "Sign-Off"):
+                continue
+            triggers += [t.strip() for t in marker["pattern"].split("|")]
+        # the template may NAME a segment, but must never hand the model a
+        # ready-made announcement phrase to speak early
+        spoken = p.lower()
+        for trig in triggers:
+            plain = trig.replace("[Ff]", "f").replace(",?", ",")
+            if plain.startswith("on the canadian boat") and plain in spoken:
+                raise AssertionError(
+                    f"debut template contains chapter trigger {plain!r}"
+                )
+
+    def test_debut_warns_about_the_trigger_phrases(self):
+        p = first_episode_podcast_appendix(1, "Offshore North", "offshore_north")
+        assert "chapter trigger" in p.lower()
+
+
+class TestScriptNaturalness:
+    """The operator's note was that Ep001 sounded robotic. The script was
+    passive-voice and near-uniform sentence length; the prompt now says so
+    explicitly, quoting the actual failures."""
+
+    def _prompt(self):
+        return (_ROOT / "shows" / "prompts" / "offshore_north_podcast.txt").read_text(
+            encoding="utf-8"
+        )
+
+    def test_prompt_demands_active_voice_and_varied_rhythm(self):
+        src = self._prompt().lower()
+        assert "active voice" in src
+        assert "vary sentence length" in src
+        assert "contractions" in src
+
+    def test_prompt_bans_meta_commentary_about_the_brief(self):
+        """Ep001 said "not established in the supplied sources" on air."""
+        assert "the supplied sources" in self._prompt()
+
+    def test_prompt_bans_daily_cadence_language(self):
+        """A weekly solo show said "we'll see you tomorrow for episode two"."""
+        src = self._prompt()
+        assert "tomorrow" in src and "NEXT MONDAY" in src
+
+    def test_plain_sailing_has_a_hard_ceiling(self):
+        src = self._prompt()
+        assert "HARD CEILING" in src
+        assert "600 spoken words" in src
+
+
+class TestXSourcingIsScaffoldedButDormant:
+    def test_accounts_present_but_fetch_disabled(self):
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        assert raw.get("x_fetch_enabled") is False, (
+            "handles are unverified — must not fetch until the operator checks them"
+        )
+        assert len(raw.get("x_accounts") or []) >= 3
+
+    def test_every_handle_is_flagged_for_verification(self):
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        for acct in raw["x_accounts"]:
+            assert "VERIFY" in acct["label"], (
+                f"{acct['handle']}: handle was never confirmed against live X"
+            )


### PR DESCRIPTION
Review of Offshore North Ep001 (published 2026-08-05, 7m32s, $0.155). It shipped — but thin, and the review turned up a bug affecting the whole network.

## The big one: the RSS keyword filter never matched capital letters

`engine/fetcher.py` compared **un-lowercased** keywords against **lowercased** text:

```python
text_lower = (title + " " + description).lower()
if not any(kw in text_lower for kw in keywords):   # kw still "Vendée Globe"
```

Any keyword carrying a capital could never match. Measured across the network:

| show | keywords | unmatchable | % |
|---|---:|---:|---:|
| **offshore_north** | 79 | 55 | **70%** |
| finansy_prosto | 61 | 31 | 51% |
| models_agents | 64 | 20 | 31% |
| modern_investing | 28 | 8 | 29% |
| models_agents_beginners | 57 | 16 | 28% |
| env_intel | 63 | 13 | 21% |
| planetterrian | 86 | 6 | 7% |
| **network total** | **652** | **149** | **23%** |

Every proper noun a show is *about* is capitalised, so the filter was rejecting precisely the articles it existed to keep. A headline reading `Scott Shawyer and Canada Ocean Racing announce IMOCA programme` was dropped by a show whose first three keywords are those three names — which is exactly why `Google News — Canada Ocean Racing: parsed 46 entries but 0 passed` appeared on every run.

tesla, spacex, fascinating_frontiers and omni_view happen to use all-lowercase keywords, so they were unaffected — which is why this stayed invisible. **The web-search path has always lowercased correctly**; that asymmetry is what confirms the RSS side was the bug rather than the intent.

## The second one: web search could never fire

The gate was `len(articles) < min_articles`. But the fetch ladder's last resort drops keyword filtering entirely, so a show starved of *relevant* material ends up with a large pile of *loosely related* material — and the gate reads that pile as health.

Ep001 finished with **70 articles against `min_articles: 4`**. `70 < 4` is never true, so the show's eight carefully-written `web_search_queries` have **never run once**. The gate now counts on-topic articles, so deep search fires when relevance is thin rather than when volume is thin.

## Episode-shape fixes

- **No Introduction chapter.** The supplied line (`This is Offshore North, episode 1.`) matches the pattern exactly — but the model ignored copy-verbatim and wrote `Welcome to the very first episode of Offshore North!`. Greeting and show name both present; five words wedged between them. Pattern now tolerates a bounded gap (no `.*`, so a late brand mention still can't claim it).
- **My debut template caused two of the defects it was meant to prevent.** Telling the host to name the four segments put "on the Canadian boat" *inside* the introduction, stealing that chapter to 61s; and the bullets were recited near-verbatim on air as passive prose. Rewritten to describe shape, not supply phrasing — the de-seed-by-shape rule I should have followed the first time.
- **Plain Sailing became the show** — 38% of runtime. It had a licence to expand on thin weeks and no ceiling. Capped at 600 words / one quarter of runtime, with the observed padding pattern named (it re-opened the same subject three times under new headings).
- **Closing invented rather than copied** — `our`/`we` on a solo show, `tomorrow` on a weekly one, and a promise of "episode two" tomorrow. Banned explicitly, quoting the failure.
- **Meta-commentary about the inputs** — Ep001 said `not established in the supplied sources` aloud. The listener doesn't know a brief exists.

## Naturalness

The evidence says this is the **script**, not the synthesis. Ep001 shipped three consecutive passives — `No hype gets added`, `nothing gets stated`, `The audience is assumed to be` — and near-uniform 20–30 word sentences. That reads as mechanical no matter how good the voice is.

The prompt now requires active voice, hard variation in sentence length, contractions, genuine reactions, and direct address — quoting the real lines that failed. **No TTS parameter was touched**, deliberately: landmine #17 records a 100% regression rate for theory-driven voice changes on this clone, and the script is the cause with actual evidence behind it.

## X as a content source

`x_accounts` scaffolded but **dormant**. The handles were written from the show bible, not confirmed against live X — an unverified handle fails safe (fetches nothing) but is a silent hole. A guard fails if any loses its `VERIFY` marker or if `x_fetch_enabled` is flipped before they're checked.

## Testing

`6637 passed, 6 skipped`. New guards include the network-wide keyword regression, the relevance-based web-search gate, the exact broken Ep001 opening line, and that the debut template can't hand the model a chapter trigger to speak early.

## Notes

- **Prompt edits change shipped audio — A/B-listen per landmine #17.**
- Not verified here: whether the next episode is longer, better-sourced, or less robotic. That needs a real run.
- Ep001 emitted **zero `[VERIFY:]` flags** and cited **one source**. Both should change once the keyword fix restores on-topic volume; if they don't, the digest prompt is the next place to look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKDLL1fvxxFMpZiXVyKe9d)_