### PR TITLE
SpaceX Q2 2026 Earnings Special (manual deep dive) + YouTube RU/EN/FR viewer review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,11 @@ today's work, not just explain yesterday's):
   voice. X posting on via the @planetterrian account.
 - **SpaceX** (SpaceX Daily) runs via `run_show.py` + `shows/spacex.yaml`;
   engineering-first daily on SpaceX as a public company (Nasdaq: SPCX),
-  `memory_enabled`, X disabled.
+  `memory_enabled`, X disabled. Has a **manual-force-only deep-dive queue**
+  (`shows/deep_dives/spacex.yaml`, `deep_dive.enabled: false` so the daily
+  cron never scans it): `python run_show.py spacex --deep-dive <id>` runs a
+  standalone special through the spacex_deep_dive prompts (first entry:
+  `q2-2026-earnings`, the Q2 2026 earnings special, Aug 2026).
 - **DP** (The DP Pod: The Do Positive Podcast) runs via `run_show.py` +
   `shows/dp_pod.yaml`; the network's **two-host dialogue** show (July 2026
   launch) — Dan Perra + Patrick Novak, daily ~10 min of good news in science/

--- a/docs/reviews/youtube_review_2026_08_05.md
+++ b/docs/reviews/youtube_review_2026_08_05.md
@@ -1,0 +1,155 @@
+# YouTube pipeline & viewer review — RU vs EN vs FR (2026-08-05)
+
+Operator-requested review of the full YouTube pipeline and viewer
+statistics, focused on: how to increase reach and viewers, which shows to
+adjust, why the Russian channel outperforms the English channel on
+views/watch-time-per-video, and why the French channel is doing so poorly.
+
+Data: `api/youtube_stats.json` (90-day window, generated 2026-08-04),
+`api/youtube_policy.json`, `api/youtube_channel_history.json`,
+`api/funnel.json`, per-show `youtube_videos.<lang>.json` indexes. The
+30-day slices below cover 2026-07-06 → 2026-08-04. Honesty caveats are
+flagged inline — the FR channel has only ~2 weeks of clean data.
+
+## Channel scorecard (30 days)
+
+| Channel | Subs | Views/30d | Net subs/30d | Uploads in window | Views per video |
+|---|---|---|---|---|---|
+| EN @NerraNetwork | 273 | 20,272 | +102 | 534 | ~30 (shorts) / ~26 (long) |
+| RU @NerraRU | 88 | 38,135 | +49 | 243 | **192 (shorts)** / 11 (long) |
+| FR @NerraFR | 2 | 39 | +2 | ~72 since 07-21 launch | ~2 |
+
+RU delivers **1.9× EN's total views on 45% as many uploads**. FR is
+effectively invisible.
+
+## RU vs EN — what the numbers actually say
+
+**RU Shorts are the network's single best surface, and it's concentrated.**
+30-day short views by show×channel: spacex-RU 15,483 (337/video), FF-RU
+12,115 (327/video), tesla-RU 5,132 (132/video), MIT-RU 1,541 (43/video).
+spacex + FF alone are 80% of all RU views. The RU audience is a
+**space-content audience** — the shows that aren't space (MIT, FP, PR)
+do EN-typical numbers.
+
+**EN still owns the two metrics that compound.** Watch time: EN long-form
+8,333 min/30d is the largest watch-time block in the network (RU shorts
+7,659, EN shorts 2,104, RU long 990). Subscribers: EN +102 net vs RU +49
+— and within EN, long-form on the big three (tesla 8.9 long-vpd, spacex
+7.2, M&A 5.2) is what converts. RU long-form remains dead (11 views/video,
+11% median retention) — the policy's RU long freeze is correct; do not
+revisit.
+
+**Retention is now format-driven, not channel-driven.** Median short AVP
+is ~44% on both EN and RU (the 35s cut working as designed); long-form
+median AVP is ~11% on both. The July-30 cold-open change targets exactly
+this — its first full week isn't in this window yet, so **hold further
+retention surgery until ~08-15 data reads out**.
+
+### Recommendations (RU/EN)
+
+1. **Feed the RU spacex/FF machine.** The supply ladder already grants
+   them 3 Shorts each (short_vpd 52/61) — verify 3 actually ship
+   (`yt_policy_shorts` metric) now that the two silent caps are fixed.
+   Today's earnings special will flow to @NerraRU automatically via
+   ru_dub — RU spacex at 337 views/short makes it the special's
+   highest-reach surface.
+2. **Don't cut EN long-form on the big three.** It's the subscriber and
+   watch-time engine even at 11% retention. The velocity-gated policy is
+   doing the right per-show pruning (omni_view is one streak away from
+   earning long-form back; env_intel/planetterrian/UC/first_principles
+   correctly held at shorts-only).
+3. **Weakest EN surfaces, watch-list not action-list:** MAB shorts (0.54
+   vpd, 4.8 views/video) and env_intel (13 videos → 88 views). Policy
+   already holds both at minimum supply. If MAB is still flat at the
+   September review, re-pausing its YouTube (as before June 26) saves
+   render+image cost with near-zero reach loss.
+4. **Measure the cold-open effect before the next retention change** —
+   one variable at a time; the 08-15 window will say if long AVP moves
+   off 11%.
+
+## Why FR is doing so poorly
+
+The honest headline: **53 of 72 FR uploads have zero recorded views** (a
+video with no activity gets no analytics row at all — only 19 have rows).
+This is not "low CTR"; it's "the algorithm isn't surfacing the channel to
+anyone."
+
+Diagnosis, in order of weight:
+
+1. **Cold start with no seed, vs RU's warm start.** @NerraRU launched
+   with two *native* Russian shows (FP/PR, full format since June) plus
+   four dub shows and had ~61 subscribers before the July window. @NerraFR
+   launched 07-21 with dubs only, zero native content, zero subscribers,
+   zero external traffic. A new channel with no engagement signal gets no
+   impressions to fail at.
+2. **Market structure.** Russian-language space content is structurally
+   underserved, so the algorithm had demand and no supply — RU spacex
+   shorts found 337 views/video almost immediately. Francophone space
+   content has strong native incumbents; a dubbed 35s clip competes
+   against them directly.
+3. **Metadata quality at launch.** Until the 07-30 clause-trim fix, 26%
+   of FR short titles ended on a dangling preposition (worst of the three
+   languages — FR runs 15-20% longer than its EN source so the 70-char
+   cut hit mid-clause). The first-impression window of the channel shipped
+   with the worst titles it will ever have.
+4. **Retention of the few views it gets is half of RU's** (19.4% vs 43.8%
+   median short AVP). Small n, but consistent with dub quality being
+   noticeable — the FR track is the EN cloned voice speaking French.
+   Operator should A/B-listen one FR dub (landmine #17 ears apply to
+   dubs too).
+5. *(Not a cause of zero views, but of blindness:)* the analytics glob
+   bug hid FR from the feedback loop until 07-29, so tiers froze at seed
+   and nothing could be learned. Clean data only exists since then —
+   which is why this review sets a decision date instead of a verdict.
+
+### FR recommendations
+
+- **Set a decision date, don't kill it today: 2026-08-25** (~5 weeks
+  post-launch, ~4 weeks of clean analytics). Criteria to keep going: any
+  show reaching short_vpd ≥ 1.0, or visible organic subscriber traction.
+  Below that on all four shows → pause FR dubs (`dub_languages: []` in
+  the four YAMLs — one-line, reversible).
+- **Within the window, only cheap fixes:** operator listens to one FR
+  short for dub quality; confirm post-07-30 FR titles are clause-clean;
+  FR-language hashtags/keywords in descriptions. Do **not** build a FR
+  funnel lander yet — there is no traffic to convert (the RU lander was
+  justified by 25k+ views/30d).
+- **Decouple the two FR bets.** FR *YouTube dubs* (this channel) and FR
+  *podcast tracks* (~$20/mo, 7 shows) are separate instruments: the
+  per-language OP3 `language_feeds` data decides the podcast tracks
+  independently. Zero FR YouTube traction does not by itself condemn the
+  FR podcast feeds — and vice versa.
+- **The structural lesson from RU:** a language channel works here when
+  the niche is underserved AND there's an anchor building channel-level
+  engagement. If FR is to be retried seriously later, the RU playbook
+  says: pick the underserved francophone niche first, consider a native
+  FR show (or FR-first metadata at minimum), don't lead with dubs alone.
+
+## Pipeline health notes (incidental findings from today's run log)
+
+- The 08-05 spacex run shipped clean end-to-end (Ep057, 2 Shorts, video
+  podcast, RU/FR handled downstream), with two non-fatal warts worth a
+  look: **long-form thumbnail upload failed 403** ("request might not be
+  properly authorized" — Short thumbnails succeeded, so this looks like
+  the long-form video's thumbnail-set call hitting a permission/timing
+  issue, worth watching for recurrence), and the **gallery public CDN
+  rejected reads (HTTP 403)** forcing the authenticated-R2 fallback all
+  run — check the `gallery.nerranetwork.com` public-access / custom-domain
+  config on the bucket.
+- Podcast script came in at 1,147 words vs the 1,300 target with the
+  expansion retry correctly off (digest-side lever is the sanctioned
+  path) — consistent with the known digest ceiling, no action.
+
+## What was shipped alongside this review
+
+The **SpaceX Quarterly Earnings Special Q2 2026** is set up as a
+manual-force deep dive on the spacex show (the MIT deep-dive mechanism):
+`shows/deep_dives/spacex.yaml` (queue entry `q2-2026-earnings` with the
+verified 10-Q/press-release numbers + live web/X research queries),
+`shows/prompts/spacex_deep_dive{,_podcast}.txt`, and a forced-only
+`deep_dive:` block in `shows/spacex.yaml`. Run it with:
+
+    python run_show.py spacex --deep-dive q2-2026-earnings
+
+It publishes as the next SpaceX Daily episode through every normal
+surface (RSS, YouTube, newsletter, blog, multilingual, RU dub).

--- a/shows/deep_dives/spacex.yaml
+++ b/shows/deep_dives/spacex.yaml
@@ -1,0 +1,188 @@
+# Deep-dive queue for SpaceX Daily.
+#
+# SPECIAL standalone single-subject episodes, distinct from the daily news
+# show. Same mechanism as Modern Investing's deep dives (the network's
+# original deep-dive show): run_show.py checks this queue via the show's
+# ``deep_dive:`` config block. Because SpaceX Daily's ``deep_dive.enabled``
+# is FALSE, entries here NEVER fire on a scheduled daily run — a special
+# only happens when the operator forces it:
+#
+#   python run_show.py spacex --deep-dive <id>
+#
+# (Forced runs work with enabled: false by design — see run_show.py's
+# deep-dive gate. This protects the daily cadence: a stale queue entry can
+# never hijack tomorrow's news episode.)
+#
+# When one fires, the episode bypasses the news fetch, swaps in the
+# spacex_deep_dive prompts, runs the live web+X research below, and
+# publishes into the normal SpaceX Daily feed/YouTube/newsletter surfaces
+# as the next episode number. The runner flips ``produced`` when done.
+#
+# Entry schema: see shows/deep_dives/modern_investing.yaml.
+
+queue:
+  - id: q2-2026-earnings
+    title: "SpaceX Quarterly Earnings Special: Q2 2026 — The First Report Card"
+    category: earnings_special
+    produced: false
+    episode_number: null
+    produced_date: null
+    # Live grounding pulled at generation time (web + X) and injected into
+    # the brief prompt's {current_research} block. This is where the
+    # freshest analyst / X commentary comes from — the static brief below
+    # carries the verified filing numbers, the research carries the react.
+    web_search_queries:
+      - "SpaceX SPCX Q2 2026 earnings results reaction"
+      - "SpaceX first earnings call August 4 2026 highlights quotes"
+      - "SPCX stock price after hours earnings capex"
+      - "SpaceX earnings call Musk Starship Flight 14 catch quotes"
+      - "SpaceX CFO Bret Johnsen annualized recurring revenue cloud"
+      - "SpaceX Q2 2026 analyst commentary AI capex concern"
+      - "SpaceX Anthropic Colossus compute agreement commentary"
+      - "SpaceX Cursor acquisition 60 billion analyst reaction"
+      - "SPCX share lockup expiration IPO investors"
+    x_handles:
+      - SpaceX
+      - elonmusk
+      - thesheetztweetz
+      - SciGuySpace
+      - xai
+      - cursor_ai
+    brief: >
+      A special standalone episode: SpaceX's FIRST quarterly earnings report
+      as a public company (Q2 2026, reported after market close August 4,
+      2026 — the 10-Q filed the same day). This is a landmark moment — the
+      first time in history the public has seen SpaceX's audited quarterly
+      numbers — and the episode should treat it with the significance it
+      deserves while keeping the show's engineering-first, honest,
+      never-a-stock-promoter voice. Everything below is verified from the
+      company's Q2 2026 earnings press release and Form 10-Q (period ended
+      June 30, 2026; filed August 4, 2026) unless marked otherwise.
+
+      THE HEADLINE NUMBERS (all vs Q2 2025 unless noted): Revenue $7.814
+      billion, up 92% from $4.071 billion — and a beat against the roughly
+      $6.9 billion analysts expected (per CNBC/Yahoo Finance reporting).
+      Net loss $541 million, an improvement of $467 million from the $1.008
+      billion loss a year ago; loss per share $0.09 against roughly $0.26
+      expected. Adjusted EBITDA $3.538 billion, up 191% from $1.214
+      billion. Loss from operations narrowed to $143 million from $970
+      million — the company is within sight of operating breakeven.
+      Six-month net loss was $4.817 billion, which includes a $1.545
+      billion loss on debt extinguishment and a $671 million deemed
+      dividend from the pre-IPO capital structure — one-time items worth
+      explaining honestly.
+
+      SEGMENTS (the company reports three): SPACE — revenue $962 million,
+      up 29% YoY and 55% sequentially; operating loss $542 million as
+      Starship R&D accelerated ($1.076 billion of R&D, up 55% YoY); 38
+      launches in the quarter (10 customer, 28 internal), 485 metric tons
+      to orbit; H1 totals 78 launches and 1,041 tons. CONNECTIVITY — the
+      profit engine: revenue $4.291 billion, up 66% YoY; income from
+      operations $1.656 billion, up 79%; Adjusted EBITDA $2.597 billion.
+      Starlink subscribers reached 12.0 million, DOUBLING year-over-year
+      and up 1.7 million in the quarter, with ARPU steady at $66/month
+      (down from $85 a year ago — a deliberate reach-for-scale trade
+      worth noting). Consumer revenue $2.485 billion (+44% YoY);
+      Enterprise & Government $1.806 billion (+108% YoY). AI — revenue
+      $2.561 billion, up 247% YoY and 213% sequentially; AI solutions &
+      infrastructure revenue jumped to $2.194 billion from $311 million a
+      year ago on new Cloud Services Agreements; advertising (the X ads
+      business) declined to $367 million from $426 million. The AI segment
+      posted its FIRST positive Adjusted EBITDA: $1.146 billion (vs
+      negative $276 million a year ago), while still running a $1.257
+      billion operating loss on huge depreciation and R&D.
+
+      THE BIG ANNOUNCEMENTS FROM THE RELEASE AND CALL: (1) Starship V3 —
+      two successful flight tests in 90 days: Flight 12 in May (first
+      suborbital mission from the new Starbase pad, precision upper-stage
+      landing, modified V2 Starlink satellite deployment) and Flight 13 in
+      July (all objectives achieved: 20 production V3 satellites deployed,
+      in-space Raptor relight, softest-ever Starship splashdown with an
+      intact heat shield). On the call, Musk said the next flight —
+      tentatively end of August — will attempt to CATCH THE SHIP with the
+      tower, pending regulatory approval, and projected the cadence
+      reaching "at least one flight a day, possibly more" within a year
+      (per Space.com's call coverage — attribute call quotes). (2) Cloud
+      Services Agreements totaling $14.1 billion in contracted sales,
+      which drove $1.6 billion of incremental AI infrastructure revenue in
+      the quarter; compute capacity expanded to 1.4 GW nameplate (from 1.0
+      GW in Q1 and 0.4 GW a year ago) with Colossus II building out.
+      Reporting around the call noted a Google agreement for AI capacity
+      (reported at roughly $920 million/month) and that Anthropic
+      contracted all of Colossus 1's capacity in Memphis — attribute these
+      to the call coverage / {current_research}. (3) Agreement to acquire
+      Cursor (Anysphere) for $60 billion, expected to close in Q3 2026,
+      to accelerate AI enterprise offerings. (4) Grok 4.5 released in
+      July — the company's largest model, trained alongside Cursor,
+      incorporating the 1.5-trillion-parameter V9 foundation model. (5)
+      Over $6 billion in multi-year U.S. government Starshield contracts,
+      primarily two Space Force awards for LEO communications and sensing.
+      (6) Starlink aviation/enterprise wins: American Airlines agreement;
+      activations on Southwest, Virgin Atlantic, Iberia, Aer Lingus;
+      mobile partnerships with SoftBank, NTT Docomo, Spark NZ; FCC
+      approval of the EchoStar license transfer (65 MHz of US spectrum
+      plus global MSS licenses).
+
+      THE BALANCE SHEET AND THE CAPEX QUESTION (the honest counterpoint —
+      give this real weight): The IPO closed June 15 (638.9 million Class
+      A shares, ~$85.7 billion net proceeds — trading began June 12 under
+      SPCX); a $25 billion inaugural investment-grade bond deal closed
+      June 26 (five tranches 2031–2056, weighted average coupon 5.855%).
+      The company ended the quarter with roughly $100 billion of cash and
+      marketable securities and $47.5 billion of backlog. But capex was
+      $18.369 billion in the QUARTER — $15.828 billion of it AI
+      infrastructure, roughly 39% above analyst estimates (per
+      Investing.com/indmoney call coverage), and management signaled the
+      next two quarters could look similar. Operating cash flow for the
+      HALF was $3.466 billion against $28.476 billion of H1 capex — the
+      company is spending far ahead of what operations generate, funded by
+      the IPO and bonds. The market reaction told that story: SPCX rose
+      ~9.4% into the print, then fell ~7% after hours (hovering near $117
+      — below the $135 IPO price and the $150 opening trade, and well off
+      the ~$225 high). The earnings date also triggers the first big
+      share-lockup expiration (per CNBC) — flag as a supply overhang to
+      watch. Other honest flags: customer concentration (two customers
+      were ~19.5% and ~18.3% of Q2 revenue — the Cloud Services
+      Agreements concentrate revenue in a few AI counterparties), Starlink
+      ARPU down $85→$66 YoY, X advertising still shrinking, and CFO Bret
+      Johnsen's "$100 billion annualized recurring revenue pace by year
+      end" claim (per Yahoo Finance call coverage) deserves scrutiny —
+      report it as a management projection with the definition caveats,
+      not as fact.
+
+      THE ENGINEERING ANGLE (the show's signature — do this from first
+      principles): what does $15.8 billion of quarterly AI capex actually
+      buy? Servers and networking equipment on the balance sheet grew from
+      $22.7 billion to $34.8 billion in six months; construction in
+      progress nearly tripled to $12.6 billion; nameplate compute went 0.4
+      → 1.4 GW in a year. Walk the power math (a gigawatt-class datacenter
+      versus what a Starship launch consumes), the depreciation reality
+      (AI segment D&A of $1.885 billion per quarter — chips depreciate
+      like rockets don't), and the vertical-integration thesis: the same
+      company building Raptor engines is building gigawatt datacenters,
+      and Starship's promised 99%+ cost-to-orbit reduction is the same
+      idiot-index playbook applied to compute. Explain why Connectivity's
+      operating leverage works (satellites are launched on internal
+      Falcon flights at marginal cost — 28 of 38 Q2 launches were
+      internal). Keep it concrete and honest about what is engineering
+      fact versus management projection.
+
+      USE OF LIVE RESEARCH: the {current_research} block carries TODAY'S
+      best analyst and X commentary on the report — weave the strongest
+      2-4 takes into the reaction segment WITH attribution (name the
+      outlet or @handle), clearly labeled as opinion. Prioritize
+      commentary that adds insight (the capex debate, the AI-revenue
+      quality question, the Starship cadence skepticism or excitement)
+      over cheerleading. If research is empty, rely on the attributed
+      reactions already in this brief.
+
+      FRAMING RULES: this is the one episode where the business IS the
+      headline — but keep the engineering heart: the numbers exist because
+      of the hardware. Not financial advice; no price targets; no buy/sell
+      framing. State beats/misses with attribution to reporting, state
+      filing numbers as fact, label call quotes as call quotes, and label
+      opinion as opinion. The episode should leave a listener — investor
+      or engineer — feeling they understand what the first public quarter
+      actually revealed: a launch monopoly funding a broadband profit
+      engine funding an AI land grab, and the honest open question of
+      whether the capex bet pays.

--- a/shows/prompts/spacex_deep_dive.txt
+++ b/shows/prompts/spacex_deep_dive.txt
@@ -1,0 +1,71 @@
+[PRODUCTION NOTES — DO NOT COPY INTO OUTPUT]
+This stage produces the EPISODE BRIEF for a SPECIAL standalone episode of SpaceX Daily. It is NOT a daily news episode: there is no fetched news, no Community Buzz from today's feeds, no Tomorrow Teaser about the news cycle. The whole episode is one subject, explored in depth. The brief is structured with section markers; the downstream podcast prompt turns those sections into flowing narration. Do not include this production-notes block in your output.
+[END PRODUCTION NOTES]
+
+# SpaceX Daily — Special Episode Brief
+
+**Date:** {today_str}
+**Topic:** {topic_title}
+
+**HOOK:** [One sentence under 130 characters. It MUST begin with "SpaceX Q2 2026 Earnings Special:" and then lead with the single most striking verified fact or stake. Plain prose, no blockquote, no emoji. This becomes the RSS / Apple / Spotify / YouTube episode title.]
+
+━━━━━━━━━━━━━━━━━━━━
+
+ABOUT THE HOOK LINE (CRITICAL — read before writing anything):
+The ``**HOOK:**`` line above is the episode title in podcast apps. It is a SEPARATE field from the opening segment. Both must appear:
+  • ``**HOOK:**`` — one sentence, under 130 characters, plain prose, on its own line BEFORE the ━━━ divider.
+  • ``### Segment 1 — The Open`` — the spoken opening framing.
+Do NOT merge them, do NOT omit the ``**HOOK:**`` label.
+
+You are writing the brief for a special episode of "SpaceX Daily," hosted by Patrick in Vancouver — engineer-storyteller, honest about setbacks, never a stock promoter. The audience is SPCX investors, spaceflight enthusiasts, and engineers. Use the topic brief below as your factual backbone and the current research for today's reactions. This is education and reporting, not financial advice.
+
+TOPIC TITLE: {topic_title}
+TOPIC BRIEF (verified facts from the company's Q2 2026 earnings press release and Form 10-Q, plus attributed call/press reactions — this defines exactly what to cover): {topic_brief}
+TOPIC CATEGORY: {topic_category}
+
+CURRENT RESEARCH (live web + X results retrieved TODAY — the freshest reactions and commentary):
+{current_research}
+
+HOW TO USE THE CURRENT RESEARCH (critical):
+- The topic brief's filing numbers are VERIFIED — state them as fact. The current research is for the REACTION: analyst takes, X commentary, the after-hours stock move, anything that happened after the call. Attribute every reaction to its outlet or @handle and label opinion as opinion.
+- If the research contradicts a brief number, prefer the brief for filing figures (they come from the 10-Q itself) and note the discrepancy for anything else.
+- Carry [UNCONFIRMED] labels through. If the research is empty, rely on the attributed reactions already in the brief and do NOT invent fresher commentary.
+
+Produce a written, essay-style brief covering ALL segments below, in this order. Prose paragraphs under each marker, not bullet spam. The downstream podcast prompt turns this into a ~16–20 minute episode, so give every segment real substance — a thin brief produces a thin special.
+
+### Segment 1 — The Open
+2–3 sentences. Frame the moment: the first time the public has ever seen SpaceX's quarterly numbers, and what this episode will do with them. Separate from the HOOK line.
+
+### Segment 2 — The Headline Numbers
+6–10 sentences. Revenue, growth rate, the beat vs expectations (attributed), net loss and the improvement, EPS vs expected, Adjusted EBITDA, loss from operations and the near-breakeven story. Explain the one-time items in the six-month loss honestly (debt extinguishment, deemed dividend) so the scary H1 number is contextualized, not hidden.
+
+### Segment 3 — Segment by Segment
+12–18 sentences, one block per reported segment in this order: Space (revenue, R&D acceleration, launches and mass to orbit, why the operating loss grew), Connectivity (the profit engine — revenue, operating income, Starlink subscribers doubling to 12 million, ARPU trade-off, Consumer vs Enterprise & Government growth), AI (the rocket ship — revenue up 247%, the Cloud Services Agreements, first positive segment Adjusted EBITDA, the advertising decline, the operating loss and why).
+
+### Segment 4 — The Big Announcements
+10–16 sentences. Starship V3 Flights 12 and 13 and the Flight 14 tower-catch plan with the Musk cadence quote (attributed as call coverage); the $14.1 billion Cloud Services Agreements and 1.4 GW compute with Colossus II; the reported Google and Anthropic agreements (attributed); the $60 billion Cursor acquisition and Q3 close; Grok 4.5 and the V9 foundation model; the $6 billion+ Starshield awards; the airline and spectrum wins.
+
+### Segment 5 — The Balance Sheet & The Capex Question
+8–14 sentences. The IPO and bond proceeds, the ~$100 billion war chest, the $47.5 billion backlog — then the honest other side: $18.4 billion quarterly capex ($15.8 billion AI, ~39% above estimates, attributed), guidance that the next two quarters look similar, operating cash flow vs capex, the after-hours stock drop and where SPCX trades vs the IPO price, the lockup expiration overhang, customer concentration, the ARPU decline, and how to hear the CFO's "$100 billion annualized recurring revenue pace" claim (management projection, with caveats).
+
+### Segment 6 — The Street & The Community React
+6–10 sentences. The strongest attributed reactions from the current research and the brief: what bulls are saying, what bears are saying, the sharpest X takes — named, dated where possible, and labeled as opinion. Pick insight over noise; the capex debate and AI-revenue-quality question are the center of gravity.
+
+### Segment 7 — The Engineering Angle
+10–16 sentences. The show's signature, from first principles: what $15.8 billion of quarterly AI capex physically buys (servers line item growth, construction in progress, 0.4 → 1.4 GW), the power and depreciation math, why Connectivity's operating leverage works (internal launches at marginal cost), and the vertical-integration thesis connecting Raptor economics to gigawatt datacenters — the idiot-index playbook applied to compute. Concrete numbers, honest about fact vs projection.
+
+### Segment 8 — Market Watch & What to Watch Next
+4–6 sentences. Where SPCX trades (in words-friendly figures), then the concrete forward catalysts: the Flight 14 catch attempt window, the Cursor close in Q3, the next two capex quarters, the lockup calendar, subscriber and compute trajectories.
+
+### Segment 9 — The Takeaways
+3–5 sentences. Two or three durable conclusions a listener should carry — phrased plainly, stated once. End on the honest open question the quarter leaves.
+
+CRITICAL CONSTRAINTS:
+- Filing numbers from the brief are fact; call quotes are "on the call / per [outlet]"; analyst and X takes are opinion with attribution. NEVER blur these tiers.
+- Do NOT fabricate numbers, quotes, dates, or price levels not present in the brief or the research. If a figure is missing, speak to the mechanism instead.
+- This is a public-company episode: no financial advice, no price targets, no buy/sell framing. "Not financial advice" is part of the show's DNA.
+- The company is ALWAYS spelled "SpaceX"; the ticker is SPCX.
+- Keep all ``### Segment`` markers so the podcast writer sees the structure; write each segment as prose.
+- Length target: 2,000–2,800 words for the brief. This is a flagship special — go deep on every segment rather than summarizing.
+
+Output the brief now.

--- a/shows/prompts/spacex_deep_dive_podcast.txt
+++ b/shows/prompts/spacex_deep_dive_podcast.txt
@@ -1,0 +1,77 @@
+[PRODUCTION NOTES — DO NOT READ ALOUD]
+CRITICAL: This block is for you (the writer). Never narrate, read aloud, reference, or echo any of it. Your script must contain ONLY the words spoken to listeners. Specifically NEVER include: word counts or length targets, segment labels like "[The Numbers]" or "Segment 3:", production notes, or instructions from this prompt. If you are about to write any of these, stop and rewrite that line as pure spoken content.
+
+PRONUNCIATION GUIDE:
+- Keep ALL acronyms in their standard written form (NASA, FAA, FCC, IPO, EBITDA, ARPU, GW, R&D, SEC)
+- Keep ALL proper nouns in their standard spelling (SpaceX, Starship, Raptor, Starlink, Colossus, Cursor, Anysphere, Musk, Shotwell)
+- DO NOT attempt phonetic spellings
+- DO spell out numbers as words ("seven point eight billion dollars" not "$7.8B"; "ninety-two percent" not "92%")
+- Expand an acronym on first use where it isn't universally known ("average revenue per user, or ARPU"; "adjusted earnings before interest, taxes, depreciation, and amortization — adjusted EBITDA")
+[END PRODUCTION NOTES]
+
+BRAND NAME & SHOW TITLE RULES (ZERO TOLERANCE):
+- The company is ALWAYS spelled "SpaceX" — never "Space X", "SpaceEx", or any variant.
+- The show name is ALWAYS exactly "SpaceX Daily" in title case.
+- When an {intro_line} or {closing_block} is supplied, copy the show name portion verbatim. Do not rephrase it.
+[END BRAND RULES]
+
+You are writing a SPECIAL standalone episode of "SpaceX Daily," Episode {episode_num}: the SpaceX Quarterly Earnings Special for Q2 2026 — the company's FIRST earnings report as a public company. This is NOT a daily news episode: no daily news roundup, no Community Buzz section, no Tomorrow Teaser about the news cycle. The entire episode is the earnings report, explored with depth, energy, and honesty.
+
+HOST: Patrick in Vancouver — an engineer-storyteller. Curious, genuinely excited about great engineering, able to make a hard idea feel obvious in hindsight. Lively but grounded — never a hype man, never a stock promoter, honest about the bear case. This is the one episode where the business IS the headline, but the engineering heart stays: every number exists because of hardware. Today's energy: a landmark event — history's first look inside SpaceX's books — reported with the excitement it deserves and the skepticism it demands.
+
+TARGET: a rich 16–20 minute special (roughly 2,400–3,000 spoken words). Reach the length by covering every part of the brief at real depth — walking through the numbers, explaining the mechanisms, giving the reactions room — never by padding or repetition. A thin, rushed special is a failure; this is a flagship episode.
+
+RULES:
+- Start every line with "Patrick:"
+- Use ONLY information from the episode brief below — do NOT invent statistics, quotes, price levels, or dates that are not in the brief.
+- 1–2 sentences per "Patrick:" line (natural TTS pauses).
+- Numbers as words, always ("five hundred forty-one million dollars", "twelve million subscribers").
+- Attribution discipline, three tiers: filing numbers are stated as fact ("SpaceX reported…"); call quotes carry "on the call" or "per [outlet]'s call coverage"; analyst and X commentary is opinion with a named source ("per CNBC", "one widely shared take on X argued…"). Never blur the tiers.
+- No financial advice, no price targets, no buy/sell framing. Include one natural not-financial-advice line near the market discussion.
+- No URLs, datelines, emoji, markdown, or section headers read aloud. Mention sources conversationally.
+- Never repeat a fact you already stated — each sentence adds NEW information.
+- Never use the same transition phrase twice in the episode.
+- Every Starship stage reference names WHICH stage — Super Heavy booster (first stage) or Ship / upper stage. Never a bare "the catch" without the stage.
+
+SCRIPT STRUCTURE (do NOT announce these as labelled sections — flow naturally):
+
+{cold_open_spec}
+
+{delivery_spec}
+
+[Cold open — the FIRST WORDS of the episode]
+Patrick: {hook}
+This is the first thing anyone hears. Nothing precedes it.
+Then give the identity line below, then a one-sentence framing that this is a special episode — the first quarterly earnings SpaceX has ever reported as a public company — before diving in.
+
+[Identity — one short line, immediately after the cold open]
+Your script MUST use this exact line, word for word — never rewrite, paraphrase, or replace it, and never add a date:
+{intro_line}
+
+[The Headline Numbers] The report card, with momentum: revenue and growth, the beat, the narrowing loss, adjusted EBITDA, near-breakeven operations. Contextualize the six-month loss's one-time items plainly — no burying, no alarmism.
+
+[Segment by Segment] Space, then Connectivity, then AI — each with its numbers AND its story. Give Connectivity's profit-engine mechanics and the Starlink subscriber doubling real energy; give the AI segment's two-hundred-forty-seven percent growth and first positive adjusted EBITDA the "something just changed" treatment it deserves; be honest about the Space segment's growing loss and why (Starship R&D is the point, not a problem to hide).
+
+[The Big Announcements] The reveal reel — punchy, building: Starship V3's two flights and the upper-stage tower-catch attempt planned for the next flight, the Musk cadence projection (attributed, and flagged as a Musk timeline), the fourteen-point-one billion in Cloud Services Agreements, the reported Google and Anthropic deals, Cursor at sixty billion, Grok four point five, the Starshield awards, the airline wins.
+
+[The Counterpoint — the capex question] REQUIRED: open this segment with the words "One thing worth watching" or "Worth keeping an eye on" — podcast-app chapters key off this phrase. Then give the bear case its full, fair weight: the quarterly capex number and how far above estimates it landed, the next-two-quarters signal, operating cash flow versus spend, the after-hours drop and where SPCX sits versus its IPO price, the lockup overhang, customer concentration, the ARPU trade, and how to hear management's annualized-recurring-revenue claim. Direct and constructive, never dismissive, never alarmist.
+
+[The Street & The Community React] The strongest attributed takes from the brief — bulls, bears, and the sharpest X commentary, clearly labeled as opinion. Let disagreement stand as disagreement.
+
+[The Engineering Angle] REQUIRED: the segment's first sentence must contain "from an engineering standpoint" or "the engineering angle" — podcast-app chapters key off this phrase. The centerpiece, from first principles: what fifteen point eight billion dollars of quarterly AI capex physically buys, the gigawatt power math, why chips depreciate like rockets don't, why Connectivity's internal-launch economics create operating leverage, and the vertical-integration thesis — the idiot-index playbook applied to compute. Let the logic build with genuine momentum; this is where the episode earns its keep.
+
+[Market Watch] A short, calm note: where SPCX trades in words, the honest framing of the day's swing, one not-financial-advice line if not already given. Do not dwell.
+
+[What to Watch Next] The concrete catalysts ahead — the Flight fourteen upper-stage catch window, the Cursor close, the next capex quarters, the lockup calendar. Specific, forward-looking, no platitudes.
+
+[Closing] Use this exact closing (do not rewrite it):
+{closing_block}
+
+CROSS-PROMO (ONLY in the closing, one sentence max, only if natural):
+- First-principles engineering thinking → "First Principles Daily digs into exactly this kind of reasoning."
+- Investing mechanics → "Modern Investing Techniques covers the investing side daily."
+If nothing fits naturally, omit it.
+
+Here is the complete episode brief. Use ONLY this content:
+
+{digest}

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -173,6 +173,23 @@ funnel:
   # (scripts/send_ru_spacex_weekly.py) has exactly one audience to send to.
   capture_tag: ru-spacex
 
+# ---- Deep-dive specials (Aug 2026) ----
+# Manual-force ONLY: enabled stays false so the daily cron never scans the
+# queue and a stale entry can never hijack a news episode (run_show's gate
+# still honors an explicit --deep-dive force with enabled: false). To run a
+# special:  python run_show.py spacex --deep-dive <id>
+# First entry: q2-2026-earnings (SpaceX Quarterly Earnings Special Q2 2026).
+# The queue entry carries live web+X research queries so the reaction
+# segment reflects commentary pulled at generation time.
+deep_dive:
+  enabled: false
+  queue_file: shows/deep_dives/spacex.yaml
+  digest_prompt_file: shows/prompts/spacex_deep_dive.txt
+  podcast_prompt_file: shows/prompts/spacex_deep_dive_podcast.txt
+  # A special is a flagship-length episode, not a daily (the MIT Ep059
+  # lesson: without this the length gate accepts a daily-sized script).
+  min_podcast_words: 2400
+
 llm:
   provider: xai
   system_prompt_file: shows/prompts/spacex_system.txt


### PR DESCRIPTION
## What this PR does

Two operator-requested pieces (2026-08-05):

### 1. SpaceX Quarterly Earnings Special Q2 2026 — ready to run manually

Set up as a **manual-force deep dive** on the spacex show, reusing the proven MIT deep-dive mechanism. To produce the special:

```
python run_show.py spacex --deep-dive q2-2026-earnings
```

It publishes as the next SpaceX Daily episode (Ep058) through every normal surface — RSS, YouTube (tier A: long + 2 Shorts), newsletter, blog, video podcast, multilingual tracks, and the @NerraRU dub (RU spacex Shorts are the network's highest-reach surface at ~337 views/video, so the special gets the network's best distribution automatically).

- **`shows/deep_dives/spacex.yaml`** — new queue. The `q2-2026-earnings` entry carries the verified numbers extracted from the operator-supplied 10-Q (EDGAR .xls) and the Q2 earnings press release PDF: revenue $7.814B (+92%), net loss $541M (EPS −$0.09 vs ~−$0.26 expected), Adjusted EBITDA $3.538B (+191%), per-segment detail (Connectivity income $1.656B, AI revenue +247% with first positive segment EBITDA, Space R&D acceleration), Starlink 12M subs / $66 ARPU, Starship V3 Flights 12–13 + the Flight 14 upper-stage tower-catch plan, $14.1B Cloud Services Agreements, 1.4 GW compute / Colossus II, Cursor $60B acquisition, Grok 4.5, $6B+ Starshield awards, IPO ($85.7B net) + $25B bonds, ~$100B cash / $47.5B backlog — and the honest counterpoints (capex $18.4B/quarter, ~39% above estimates; after-hours drop below IPO price; lockup overhang; customer concentration; ARPU decline).
- The entry also carries **live web + X research queries + handles** (`engine.deep_dive_research`), so the reaction segment pulls fresh analyst/X commentary at generation time with attribution (this sandbox has no Grok key; GitHub Actions does — the queries include the capex debate, Musk's call quotes, the Anthropic/Colossus and Google compute agreements, the CFO's $100B-ARR-pace claim).
- **`shows/prompts/spacex_deep_dive.txt`** + **`spacex_deep_dive_podcast.txt`** — special-episode prompts in the show's engineering-first, never-a-stock-promoter voice; 16–20-minute target (`deep_dive.min_podcast_words: 2400`); attribution tiers (filing fact / call quote / opinion) enforced; the HOOK is pinned to start with "SpaceX Q2 2026 Earnings Special:" so podcast/YouTube titles carry the special's identity.
- **`shows/spacex.yaml`** — `deep_dive:` block with `enabled: false`: the daily cron **never scans the queue** (a stale entry can never hijack tomorrow's news episode — verified `pick_deep_dive_topic` returns `None` unforced); only an explicit `--deep-dive` force fires it.

### 2. YouTube pipeline + viewer review (RU vs EN vs FR)

**`docs/reviews/youtube_review_2026_08_05.md`** — full analysis from `api/youtube_stats.json` / `youtube_policy.json` / channel history / funnel. Headlines:

- **RU Shorts are the network's best surface**: 38.1k views/30d off 243 uploads (192 views/video) vs EN's 20.3k off 534 — and 80% concentrated in spacex-RU (337/video) + FF-RU (327/video). The RU audience is a space audience; the supply ladder's 3-Short band for both is correct.
- **EN still owns what compounds**: watch time (EN long-form 8,333 min/30d is the biggest block) and subscribers (+102 vs +49). Keep long-form on tesla/spacex/M&A; RU long-form stays frozen (11 views/video, 11% AVP).
- **FR diagnosis**: 53 of 72 uploads since the 07-21 launch have **zero recorded views** — the algorithm isn't surfacing the channel at all. Root causes ranked: cold start with no native anchor (vs RU's warm start with FP/PR + 61 subs), competitive francophone space niche (vs underserved Russian), worst-in-network launch titles (26% dangling-preposition clause trims, fixed only 07-30), and half-of-RU retention on the few views it gets (worth an operator listen of one FR dub). Recommendation: **decision date 2026-08-25** with explicit criteria (any show at short_vpd ≥ 1.0), cheap fixes only in the window, and the FR *podcast* tracks decided independently via the per-language OP3 instrument — not condemned by the YouTube channel.
- Incidental from today's run log: long-form thumbnail upload 403 (Shorts thumbnails fine — watch for recurrence) and gallery public-CDN 403 forcing the R2 fallback (check bucket public-access config).

Also adds a short structural note to CLAUDE.md's SpaceX bullet documenting the deep-dive queue.

## Verification

- `pytest tests/test_deep_dive.py tests/test_spacex_show.py tests/test_prompt_fidelity.py tests/test_config.py tests/test_schedule.py` — **209 passed**
- Forced pick returns the entry; unforced pick returns `None` (daily cadence safe); both prompts render brace-safe through `load_prompt`.

## Operator notes

- Run the special today with the command above (needs the usual production env). The runner marks the queue entry `produced` and the workflow's `git add shows/deep_dives/` already stages it.
- The queue is reusable: future specials (Q3 earnings, Flight 14 catch reaction) are one YAML entry each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_