### PR TITLE
run-show.yml: deep_dive dispatch input — give the earnings special an actual production path

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -96,6 +96,11 @@ on:
         required: false
         type: boolean
         default: false
+      deep_dive:
+        description: 'Deep-dive topic id — runs a standalone SPECIAL episode via --deep-dive (bypasses the news fetch; single-show dispatch only, ignored for show=all). Example: show=spacex, deep_dive=q2-2026-earnings'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -413,6 +418,16 @@ jobs:
           if [ "${{ github.event.inputs.test_mode }}" = "true" ]; then
             EXTRA_FLAGS="--test"
             echo "::notice::test_mode=true — running with --test (fetch + digest only, no TTS/R2/RSS/X/commit)"
+          fi
+          # Deep-dive special (Aug 2026): the ONLY production path to a
+          # manual-force special (queue entries with deep_dive.enabled: false
+          # never fire on their own — the Q2-2026 earnings special shipped as
+          # a plain daily because dispatch had no way to pass this flag).
+          # Single-show dispatches only: with show=all every other show would
+          # graceful-skip on deep_dive_unconfigured.
+          if [ -n "${{ github.event.inputs.deep_dive }}" ] && [ "${{ github.event.inputs.show }}" != "all" ]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS --deep-dive ${{ github.event.inputs.deep_dive }}"
+            echo "::notice::deep_dive=${{ github.event.inputs.deep_dive }} — forcing a standalone deep-dive special"
           fi
           python run_show.py ${{ matrix.show }} $EXTRA_FLAGS 2>&1
           EXIT_CODE=$?

--- a/tests/test_deep_dive.py
+++ b/tests/test_deep_dive.py
@@ -195,6 +195,20 @@ class TestShippedMITDeepDive:
             "alongside shows/topic_queues/, or deep dives re-fire."
         )
 
+    def test_run_show_workflow_exposes_deep_dive_dispatch_input(self):
+        """workflow_dispatch MUST carry a ``deep_dive`` input wired to
+        ``--deep-dive``. This is the ONLY production path to a manual-force
+        special: queue entries under ``deep_dive.enabled: false`` never fire
+        on their own, and secrets live in Actions — without this input the
+        Q2-2026 SpaceX earnings special dispatched as a plain daily (Ep058,
+        2026-08-05) because the operator had no way to pass the flag."""
+        wf = Path(".github/workflows/run-show.yml").read_text()
+        assert "deep_dive:" in wf, "run-show.yml lost the deep_dive dispatch input"
+        assert "--deep-dive ${{ github.event.inputs.deep_dive }}" in wf, (
+            "run-show.yml must append --deep-dive <id> to EXTRA_FLAGS when "
+            "the deep_dive dispatch input is set."
+        )
+
     def test_deep_dive_prompts_exist_and_reference_topic(self):
         digest = Path("shows/prompts/modern_investing_deep_dive.txt").read_text()
         podcast = Path(


### PR DESCRIPTION
## What happened this morning (root cause of Ep058)

The Q2 2026 earnings special (#964) is **manual-force only** by design — `deep_dive.enabled: false` so a queue entry can never hijack a scheduled daily, with `--deep-dive q2-2026-earnings` as the trigger. That design was correct, but it had a gap: **the Actions workflow had no way to pass the flag**. `workflow_dispatch` only exposed `show` and `test_mode`, and the run step hardcodes `python run_show.py <show> $EXTRA_FLAGS` with `EXTRA_FLAGS` only ever set to `--test`.

So the 13:08 UTC dispatch of spacex ran a plain daily: the deep-dive gate was never armed, the news fetch ran, and Ep058 shipped as a second regular episode (the post-concurrency duplicate re-check is deliberately schedule-only, so the dispatch went through). The CLI command documented in #964 was only runnable locally — where the secrets aren't.

## The fix

- New `workflow_dispatch` input **`deep_dive`** (string, default empty). When set on a single-show dispatch, the run step appends `--deep-dive <id>` to `EXTRA_FLAGS` with a `::notice::` annotation. Ignored for `show=all` (every other show would graceful-skip on `deep_dive_unconfigured`).
- Drift guard in `tests/test_deep_dive.py` pinning both the input and the `--deep-dive ${{ github.event.inputs.deep_dive }}` wiring, with the Ep058 story in the docstring.
- The schedule-only duplicate re-check is untouched — a same-day dispatch of the special stays possible (needed today, since Ep057 and Ep058 already exist for 2026-08-05).

## To produce the special (after merging this)

**Actions → Run Podcast Show → Run workflow** with:
- `show`: `spacex`
- `deep_dive`: `q2-2026-earnings`

It will bypass the news fetch, run the live web+X earnings-commentary research, generate off the verified 10-Q/press-release brief, and publish as **Ep059** with the "SpaceX Q2 2026 Earnings Special:" title through all normal surfaces (RSS, YouTube, newsletter, RU dub). The runner marks the queue entry `produced` (staged by the existing `git add -A shows/deep_dives/` commit step), so it can't re-fire.

## Verification

- Workflow YAML parses; `tests/test_deep_dive.py` 21 passed; `test_scheduling_punctuality` / `test_workflow_efficiency` / `test_schedule` all pass.

Note: Ep058 itself validated and published cleanly as a normal (if redundant) second daily — leaving it up vs unpublishing is your call; nothing in this PR touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_