### PR TITLE
Staggered Shorts publishing — Short #1 at episode time, the rest at each channel's optimal hours

### DIFF
--- a/.github/workflows/multilingual.yml
+++ b/.github/workflows/multilingual.yml
@@ -279,6 +279,23 @@ jobs:
           python scripts/publish_lang_dubs.py "${{ matrix.show }}" --lang fr --latest "$LATEST" </dev/null || \
             echo "::warning::FR dub publish failed for ${{ matrix.show }} (non-fatal)"
 
+      - name: Post due scheduled-Short comments
+        if: always()
+        # Staggered Shorts (Aug 2026): comments can't be posted on a
+        # private (publishAt-scheduled) Short, so the publish paths queue
+        # them in digests/<slug>/scheduled_comments.json. This sweep posts
+        # every queued comment whose Short has gone public. Best-effort;
+        # entries stay queued when their channel token is absent here.
+        env:
+          YOUTUBE_CLIENT_ID: ${{ secrets.YOUTUBE_CLIENT_ID }}
+          YOUTUBE_CLIENT_SECRET: ${{ secrets.YOUTUBE_CLIENT_SECRET }}
+          YOUTUBE_REFRESH_TOKEN_EN: ${{ secrets.YOUTUBE_REFRESH_TOKEN_EN }}
+          YOUTUBE_REFRESH_TOKEN_RU: ${{ secrets.YOUTUBE_REFRESH_TOKEN_RU }}
+          YOUTUBE_REFRESH_TOKEN_FR: ${{ secrets.YOUTUBE_REFRESH_TOKEN_FR }}
+        run: |
+          python scripts/post_scheduled_short_comments.py || \
+            echo "::warning::scheduled-Short comment sweep failed (non-fatal)"
+
       - name: Build ${{ matrix.show }} language feeds
         if: always()
         env:

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -130,6 +130,11 @@ jobs:
         run: |
           python scripts/fetch_youtube_analytics.py --out api/youtube_stats.json --days 90 || true
           python scripts/update_youtube_performance.py || true
+          # Staggered Shorts (Aug 2026): post funnel comments queued for
+          # publishAt-scheduled Shorts that have since gone public —
+          # catches the late-evening slots the 14:07/18:07 multilingual
+          # sweeps run too early for. Same tokens as the fetch above.
+          python scripts/post_scheduled_short_comments.py || true
 
       - name: Update adaptive YouTube publishing policy
         # Velocity-gated per-channel publish tiers (long-form on/off +
@@ -288,6 +293,7 @@ jobs:
             *.video.rss
             digests/**/video_assets.json
             digests/**/channel_i18n.json
+            digests/**/scheduled_comments.json
             api/dashboard.json
             api/daily-show-health.json
             api/youtube_stats.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,6 +481,25 @@ single-Short behaviour byte-for-byte. Drift guards in
 `tests/test_shorts_selector.py` under the
 `pick_top_n_engaging_windows` block.
 
+**Staggered Shorts publishing (Aug 2026, operator-directed).** Short #1
+publishes with the episode; the 2nd/3rd upload PRIVATE with
+`status.publishAt` at the channel's next optimal UTC slots
+(`youtube.shorts_stagger_slots_utc` in `_defaults.yaml` — EN 17/21/23,
+RU 15/18/20, FR 17/19/21; audience-timezone priors, hand-tuned because
+the Analytics API has no hour-of-day dimension), so one episode's Shorts
+spread through the day on every channel, manual runs included. YouTube's
+own scheduler flips them public — no new infra, dead runners can't
+strand a Short. Engine: [`engine/shorts_stagger.py`](engine/shorts_stagger.py);
+wired in `run_show._publish_youtube`, `engine/ru_dub.py`,
+`engine/lang_dub.py`. The video index records the **publishAt** date so
+policy vpd math stays honest. Funnel comments can't be posted on a
+private video, so they queue to `digests/<slug>/scheduled_comments.json`
+and `scripts/post_scheduled_short_comments.py` (multilingual sweep +
+nightly, which hold the channel tokens; sidecar is in nightly's
+add-paths whitelist) posts them once public. `shorts_stagger_enabled:
+false` per show reverts to publish-all-now. Drift guards:
+`tests/test_shorts_stagger.py`.
+
 **Auto-hashtag injection on Shorts descriptions.** Every Shorts
 upload now carries entity-derived hashtags in its description
 (via [`engine.shorts_hashtags.extract_hashtags`](engine/shorts_hashtags.py)).

--- a/engine/config.py
+++ b/engine/config.py
@@ -886,6 +886,18 @@ class YouTubeConfig:
     # offset so they ignore this knob and always produce 1 Short.
     shorts_per_episode: int = 1
 
+    # ---- Staggered Shorts publishing (Aug 2026) ----
+    # Short #1 publishes with the episode; later Shorts upload PRIVATE with
+    # ``status.publishAt`` set to the channel's next optimal slots
+    # (engine/shorts_stagger.py), so one episode's Shorts spread through the
+    # day instead of competing with each other at publish time. Applies to
+    # scheduled AND manual runs. Dataclass default False for backwards
+    # compat (the x_cross_promo pattern); the network default lives in
+    # shows/_defaults.yaml. Slots map channel → list of UTC hours; empty
+    # falls back to engine.shorts_stagger.DEFAULT_SLOT_HOURS_UTC.
+    shorts_stagger_enabled: bool = False
+    shorts_stagger_slots_utc: Dict[str, list] = field(default_factory=dict)
+
     # ---- Multi-platform distribution (Instagram Reels / TikTok / etc.) ----
     # When true, each published Short additionally gets (1) a "safe-zone"
     # variant MP4 with overlays lifted out of the bottom/right bands that IG

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -535,6 +535,35 @@ def publish_lang_dub(
                 logger.warning("lang_dub[%s]: end-card failed (%s)",
                                lang.code, exc)
 
+            # Staggered Shorts (Aug 2026): Short #1 publishes now; later
+            # Shorts upload private with publishAt at this language
+            # audience's evening slots. Failure = legacy publish-all-now.
+            _stagger_times: list = []
+            if len(short_plan) > 1 and bool(
+                getattr(yt, "shorts_stagger_enabled", False)
+            ):
+                try:
+                    from engine.shorts_stagger import (
+                        resolve_slot_hours,
+                        stagger_publish_times,
+                    )
+                    import datetime as _sdt
+                    _stagger_times = stagger_publish_times(
+                        _sdt.datetime.now(_sdt.timezone.utc),
+                        len(short_plan) - 1,
+                        slot_hours=resolve_slot_hours(yt, lang.channel),
+                    )
+                    logger.info(
+                        "lang_dub[%s]: Shorts stagger — #1 now, %d scheduled "
+                        "at %s", lang.code, len(_stagger_times),
+                        ", ".join(t.strftime("%Y-%m-%dT%H:%MZ")
+                                  for t in _stagger_times))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("lang_dub[%s]: stagger scheduling failed "
+                                   "— all Shorts publish immediately: %s",
+                                   lang.code, exc)
+                    _stagger_times = []
+
             short_urls_out: List[str] = []
             for short_idx, (start_offset, opening_text,
                             window_label) in enumerate(short_plan):
@@ -598,6 +627,12 @@ def publish_lang_dub(
                             lang.code)
                         st = f"{body}{_SHORTS_SUFFIX}".strip()
 
+                    _publish_at = (
+                        _stagger_times[short_idx - 1]
+                        if short_idx >= 1
+                        and (short_idx - 1) < len(_stagger_times)
+                        else None
+                    )
                     sup = upload_video(
                         short_mp4, credentials=creds,
                         title=st,
@@ -608,12 +643,17 @@ def publish_lang_dub(
                         category_id=int(getattr(yt, "category_id", 28)),
                         default_language=lang.default_language,
                         privacy_status=getattr(yt, "privacy_status",
-                                               "public"))
+                                               "public"),
+                        publish_at=_publish_at)
                     short_urls_out.append(sup.watch_url)
                     record_video(
                         video_id=sup.video_id, show_slug=config.slug,
                         episode=episode_num, kind="short", title=st,
-                        hook=title, published=date_str,
+                        # Scheduled Shorts go public at publishAt — record
+                        # that date so policy vpd math stays honest.
+                        hook=title,
+                        published=(f"{_publish_at:%Y-%m-%d}"
+                                   if _publish_at else date_str),
                         watch_url=sup.watch_url,
                         channel=lang.channel, window=window_label,
                         index_path=idx_path)
@@ -628,11 +668,26 @@ def publish_lang_dub(
                     # this run (never link a different-language video).
                     if long_url and bool(getattr(yt, "auto_comment", True)):
                         try:
-                            post_video_comment(
-                                credentials=creds,
-                                video_id=sup.video_id,
-                                text=lang.comment_full_episode.format(
-                                    url=long_url))
+                            _cmt_text = lang.comment_full_episode.format(
+                                url=long_url)
+                            if _publish_at is not None:
+                                # Can't comment on a private (scheduled)
+                                # video — queue for the post-publish sweep.
+                                from engine.shorts_stagger import (
+                                    queue_comment,
+                                )
+                                queue_comment(
+                                    PROJECT_ROOT
+                                    / config.episode.output_dir,
+                                    video_id=sup.video_id,
+                                    channel=lang.channel,
+                                    text=_cmt_text,
+                                    publish_at=_publish_at)
+                            else:
+                                post_video_comment(
+                                    credentials=creds,
+                                    video_id=sup.video_id,
+                                    text=_cmt_text)
                         except Exception:  # noqa: BLE001
                             pass
                     result["status"] = "done"

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -737,6 +737,34 @@ def publish_ru_dub(
             except Exception as exc:  # noqa: BLE001
                 logger.warning("ru_dub: end-card render failed (%s)", exc)
 
+            # Staggered Shorts (Aug 2026): Short #1 publishes now; later
+            # Shorts upload private with publishAt at the RU audience's
+            # evening slots. Failure = legacy publish-all-now.
+            _stagger_times: list = []
+            if len(short_plan) > 1 and bool(
+                getattr(yt, "shorts_stagger_enabled", False)
+            ):
+                try:
+                    from engine.shorts_stagger import (
+                        resolve_slot_hours,
+                        stagger_publish_times,
+                    )
+                    import datetime as _sdt
+                    _stagger_times = stagger_publish_times(
+                        _sdt.datetime.now(_sdt.timezone.utc),
+                        len(short_plan) - 1,
+                        slot_hours=resolve_slot_hours(yt, "ru"),
+                    )
+                    logger.info(
+                        "ru_dub: Shorts stagger — #1 now, %d scheduled at %s",
+                        len(_stagger_times),
+                        ", ".join(t.strftime("%Y-%m-%dT%H:%MZ")
+                                  for t in _stagger_times))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: stagger scheduling failed — all "
+                                   "Shorts publish immediately: %s", exc)
+                    _stagger_times = []
+
             short_urls_out: list = []
             for short_idx, (start_offset, opening_text,
                             window_label) in enumerate(short_plan):
@@ -798,6 +826,12 @@ def publish_ru_dub(
                             "ru")
                         short_title = f"{body}{_SHORTS_SUFFIX}".strip()
 
+                    _publish_at = (
+                        _stagger_times[short_idx - 1]
+                        if short_idx >= 1
+                        and (short_idx - 1) < len(_stagger_times)
+                        else None
+                    )
                     sup = upload_video(
                         short_mp4, credentials=creds,
                         title=short_title,
@@ -807,7 +841,8 @@ def publish_ru_dub(
                         tags=list(getattr(config, "keywords", []) or []),
                         category_id=int(getattr(yt, "category_id", 28)),
                         default_language="ru",
-                        privacy_status=getattr(yt, "privacy_status", "public"))
+                        privacy_status=getattr(yt, "privacy_status", "public"),
+                        publish_at=_publish_at)
                     short_urls_out.append(sup.watch_url)
                     # July 18 2026 (operator-approved): RU funnel comment.
                     # A Russian Short must never link an English video, so
@@ -844,7 +879,15 @@ def publish_ru_dub(
                                     + "\n🔔 Подпишитесь — новые выпуски "
                                       "каждый день"
                                 ) if _dest else ""
-                            if _text:
+                            if _text and _publish_at is not None:
+                                # Can't comment on a private (scheduled)
+                                # video — queue for the post-publish sweep.
+                                from engine.shorts_stagger import queue_comment
+                                queue_comment(
+                                    PROJECT_ROOT / config.episode.output_dir,
+                                    video_id=sup.video_id, channel="ru",
+                                    text=_text, publish_at=_publish_at)
+                            elif _text:
                                 post_video_comment(
                                     credentials=creds,
                                     video_id=sup.video_id,
@@ -858,7 +901,11 @@ def publish_ru_dub(
                     record_video(
                         video_id=sup.video_id, show_slug=config.slug,
                         episode=episode_num, kind="short", title=short_title,
-                        hook=ru_title, published=date_str,
+                        hook=ru_title,
+                        # Scheduled Shorts go public at publishAt — record
+                        # that date so policy vpd math stays honest.
+                        published=(f"{_publish_at:%Y-%m-%d}"
+                                   if _publish_at else date_str),
                         watch_url=sup.watch_url,
                         channel="ru",
                         window=window_label,

--- a/engine/shorts_stagger.py
+++ b/engine/shorts_stagger.py
@@ -1,0 +1,284 @@
+"""Staggered Shorts publishing — spread one episode's Shorts through the day.
+
+Operator directive (Aug 2026): when an episode publishes N Shorts, only
+Short #1 should go public with the episode; the rest should land at the
+channel's high-traffic hours later in the day instead of all competing
+with each other (and with the long-form) in the same minute. This applies
+to every channel (EN / RU / FR) and to manual runs too.
+
+Mechanism: **YouTube's own scheduler** (``status.publishAt``). Later
+Shorts are uploaded at run time exactly as before — same render, same
+metadata, same thumbnail, same playlist — but with ``privacyStatus:
+private`` + a ``publishAt`` timestamp, and YouTube flips them public at
+the scheduled moment. No new infrastructure, nothing to babysit: a dead
+runner can't strand a Short because the upload already happened.
+
+Slot hours are per-channel (UTC), tuned to each audience's evening:
+
+- ``en`` — US-centric: 17 UTC (~1pm ET / 10am PT lunch scroll),
+  21 UTC (~5pm ET commute), 23 UTC (~7pm ET evening).
+- ``ru`` — Moscow (UTC+3): 15 UTC (6pm MSK), 18 UTC (9pm MSK),
+  20 UTC (11pm MSK).
+- ``fr`` — Central Europe (UTC+2 summer): 17 UTC (7pm CEST),
+  19 UTC (9pm CEST), 21 UTC (11pm CEST).
+
+Override per show/network via ``youtube.shorts_stagger_slots_utc`` in the
+YAML (mapping channel → list of UTC hours). These are heuristics, not
+analytics-derived — the YouTube Analytics API exposes no hour-of-day
+views dimension — so they encode audience-timezone priors and are cheap
+to retune.
+
+One real trade-off is handled here too: the channel funnel comment
+("▶ Full episode: …") cannot be posted on a still-private video, so for
+a scheduled Short the comment is QUEUED to a per-show sidecar
+(``digests/<slug>/scheduled_comments.json``) and posted by
+``scripts/post_scheduled_short_comments.py`` (wired into the multilingual
+sweep + nightly maintenance, both of which already hold the channel
+tokens) once the publish time has passed. Losing those comments silently
+would degrade the network's strongest Shorts→long funnel placement — the
+July 2026 RU pilot exists because of exactly that class of silent gap.
+
+Everything in this module is best-effort by contract: any failure must
+leave the caller publishing all Shorts immediately (the legacy behavior),
+never block an upload.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Per-channel preferred publish hours, UTC. See module docstring for the
+# audience-timezone rationale. Operator-tunable via
+# ``youtube.shorts_stagger_slots_utc`` without touching code.
+DEFAULT_SLOT_HOURS_UTC: Dict[str, List[int]] = {
+    "en": [17, 21, 23],
+    "ru": [15, 18, 20],
+    "fr": [17, 19, 21],
+}
+
+# A scheduled time closer than this to "now" is pointless (the Short would
+# publish before the first one has had any run at the feed) and risks
+# YouTube rejecting a past timestamp after a slow upload.
+MIN_LEAD_MINUTES = 90
+
+# When the slot list can't supply enough future times (e.g. a run at
+# 23:30 UTC), fall back to fixed offsets so the Shorts still spread out.
+FALLBACK_GAP_HOURS = 3
+
+# A queued comment older than this is dropped (loudly) instead of posted
+# onto a week-old Short nobody will scroll past again.
+COMMENT_MAX_AGE_DAYS = 7
+
+_SIDECAR_NAME = "scheduled_comments.json"
+
+
+def resolve_slot_hours(youtube_config, channel: str) -> List[int]:
+    """Slot hours for *channel*, from YAML override or the defaults.
+
+    Invalid entries (non-int, out of 0-23) are dropped; an empty result
+    falls back to the ``en`` defaults so the caller always gets a usable
+    list.
+    """
+    raw = getattr(youtube_config, "shorts_stagger_slots_utc", None) or {}
+    hours = raw.get(channel) if isinstance(raw, dict) else None
+    if not hours:
+        hours = DEFAULT_SLOT_HOURS_UTC.get(channel)
+    if not hours:
+        hours = DEFAULT_SLOT_HOURS_UTC["en"]
+    out = []
+    for h in hours:
+        try:
+            h = int(h)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= h <= 23:
+            out.append(h)
+    return sorted(set(out)) or list(DEFAULT_SLOT_HOURS_UTC["en"])
+
+
+def stagger_publish_times(
+    now: _dt.datetime,
+    count: int,
+    *,
+    slot_hours: List[int],
+    min_lead_minutes: int = MIN_LEAD_MINUTES,
+    fallback_gap_hours: int = FALLBACK_GAP_HOURS,
+) -> List[_dt.datetime]:
+    """Return *count* future UTC publish times for the 2nd..Nth Shorts.
+
+    Takes the next unelapsed slot hours (today's remaining, then
+    tomorrow's) that are at least *min_lead_minutes* away; when the slot
+    list runs dry inside that window, fills with ``now + k*gap`` so the
+    Shorts always spread even on a late-night run. Result is sorted and
+    strictly increasing.
+    """
+    if count <= 0:
+        return []
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=_dt.timezone.utc)
+    lead = _dt.timedelta(minutes=min_lead_minutes)
+
+    candidates: List[_dt.datetime] = []
+    for day_offset in (0, 1):
+        day = (now + _dt.timedelta(days=day_offset)).date()
+        for h in sorted(slot_hours):
+            t = _dt.datetime(day.year, day.month, day.day, h,
+                             tzinfo=_dt.timezone.utc)
+            if t >= now + lead:
+                candidates.append(t)
+    times = sorted(candidates)[:count]
+
+    k = 1
+    while len(times) < count:
+        t = now + _dt.timedelta(hours=fallback_gap_hours * k)
+        if not times or t > times[-1]:
+            times.append(t)
+        k += 1
+    return times[:count]
+
+
+def format_publish_at(t: _dt.datetime) -> str:
+    """RFC3339 UTC string for ``status.publishAt``."""
+    if t.tzinfo is not None:
+        t = t.astimezone(_dt.timezone.utc).replace(tzinfo=None)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Deferred funnel comments (a comment can't be posted on a private video)
+# ---------------------------------------------------------------------------
+
+def queue_comment(
+    digests_dir: Path,
+    *,
+    video_id: str,
+    channel: str,
+    text: str,
+    publish_at: _dt.datetime,
+) -> bool:
+    """Queue a funnel comment for a scheduled Short. Best-effort."""
+    if not (video_id and text):
+        return False
+    try:
+        path = Path(digests_dir) / _SIDECAR_NAME
+        data = {"schema_version": 1, "pending": []}
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            data.setdefault("pending", [])
+        # Idempotent per video — a rerun must not double-queue.
+        data["pending"] = [
+            e for e in data["pending"] if e.get("video_id") != video_id
+        ]
+        data["pending"].append({
+            "video_id": video_id,
+            "channel": channel or "en",
+            "text": text,
+            "publish_at": format_publish_at(publish_at),
+        })
+        path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=1) + "\n",
+            encoding="utf-8",
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — never block a publish
+        logger.warning("scheduled-comment queue failed for %s: %s",
+                       video_id, exc)
+        return False
+
+
+def post_due_comments(
+    project_root: Path,
+    now: Optional[_dt.datetime] = None,
+) -> Dict[str, int]:
+    """Post every queued comment whose Short has gone public. Sweep entry
+    point for ``scripts/post_scheduled_short_comments.py``.
+
+    Returns counters: posted / kept (not yet due) / dropped (too old or
+    repeatedly failing past max age). Missing credentials for a channel
+    keep its entries queued for the next sweep.
+    """
+    from engine.youtube import (
+        get_channel_credentials_from_env,
+        post_video_comment,
+    )
+
+    now = now or _dt.datetime.now(_dt.timezone.utc)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=_dt.timezone.utc)
+    stats = {"posted": 0, "kept": 0, "dropped": 0}
+    creds_cache: Dict[str, object] = {}
+
+    for path in sorted(Path(project_root).glob(f"digests/*/{_SIDECAR_NAME}")):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("scheduled-comments sidecar unreadable %s: %s",
+                           path, exc)
+            continue
+        keep = []
+        changed = False
+        for entry in data.get("pending", []):
+            try:
+                due = _dt.datetime.strptime(
+                    entry.get("publish_at", ""), "%Y-%m-%dT%H:%M:%SZ"
+                ).replace(tzinfo=_dt.timezone.utc)
+            except ValueError:
+                logger.warning("dropping malformed scheduled-comment entry "
+                               "in %s: %r", path, entry)
+                stats["dropped"] += 1
+                changed = True
+                continue
+            if due > now:
+                keep.append(entry)
+                stats["kept"] += 1
+                continue
+            if now - due > _dt.timedelta(days=COMMENT_MAX_AGE_DAYS):
+                logger.warning(
+                    "::warning::scheduled comment for %s is > %dd overdue — "
+                    "dropping (video %s)", path.parent.name,
+                    COMMENT_MAX_AGE_DAYS, entry.get("video_id"))
+                stats["dropped"] += 1
+                changed = True
+                continue
+            ch = entry.get("channel", "en")
+            if ch not in creds_cache:
+                creds_cache[ch] = get_channel_credentials_from_env(ch)
+            creds = creds_cache[ch]
+            if creds is None:
+                keep.append(entry)  # no token in this environment — retry later
+                stats["kept"] += 1
+                continue
+            try:
+                cid = post_video_comment(
+                    credentials=creds,
+                    video_id=entry["video_id"],
+                    text=entry["text"],
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("deferred comment failed for %s: %s — "
+                               "keeping for next sweep",
+                               entry.get("video_id"), exc)
+                cid = None
+            if cid:
+                stats["posted"] += 1
+                changed = True
+            else:
+                keep.append(entry)
+                stats["kept"] += 1
+        if changed or len(keep) != len(data.get("pending", [])):
+            try:
+                data["pending"] = keep
+                path.write_text(
+                    json.dumps(data, ensure_ascii=False, indent=1) + "\n",
+                    encoding="utf-8",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("scheduled-comments sidecar write failed "
+                               "%s: %s", path, exc)
+    return stats

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -29,6 +29,7 @@ project quota is 10,000 units/day. ``thumbnails.set`` adds another
 
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import re
@@ -178,8 +179,28 @@ def _build_video_body(
     privacy_status: str,
     contains_synthetic_media: bool,
     made_for_kids: bool,
+    publish_at: Optional["datetime.datetime"] = None,
 ) -> dict:
-    """Construct the request body for ``youtube.videos().insert()``."""
+    """Construct the request body for ``youtube.videos().insert()``.
+
+    ``publish_at`` engages YouTube's own scheduler: the API requires the
+    video to be PRIVATE at insert time, then flips it public at the
+    RFC3339 timestamp. Used by staggered Shorts publishing
+    (engine/shorts_stagger.py) so one episode's Shorts spread through the
+    day instead of all landing in the same minute.
+    """
+    status = {
+        "privacyStatus": privacy_status,
+        "selfDeclaredMadeForKids": made_for_kids,
+        "containsSyntheticMedia": contains_synthetic_media,
+        # Skip YouTube's gradual rollout to subscribers' homepages
+        # (we have RSS + X for that). False = publish to subs feed.
+        "publishToSubscriptions": True,
+    }
+    if publish_at is not None:
+        from engine.shorts_stagger import format_publish_at
+        status["privacyStatus"] = "private"  # API requirement for publishAt
+        status["publishAt"] = format_publish_at(publish_at)
     return {
         "snippet": {
             "title": title,
@@ -189,14 +210,7 @@ def _build_video_body(
             "defaultLanguage": default_language,
             "defaultAudioLanguage": default_language,
         },
-        "status": {
-            "privacyStatus": privacy_status,
-            "selfDeclaredMadeForKids": made_for_kids,
-            "containsSyntheticMedia": contains_synthetic_media,
-            # Skip YouTube's gradual rollout to subscribers' homepages
-            # (we have RSS + X for that). False = publish to subs feed.
-            "publishToSubscriptions": True,
-        },
+        "status": status,
     }
 
 
@@ -249,6 +263,7 @@ def upload_video(
     thumbnail_path: Optional[Path] = None,
     contains_synthetic_media: bool = True,
     made_for_kids: bool = False,
+    publish_at: Optional[datetime.datetime] = None,
 ) -> "UploadResult":
     """Upload a single video and (optionally) its custom thumbnail.
 
@@ -273,6 +288,10 @@ def upload_video(
     made_for_kids:
         ``status.selfDeclaredMadeForKids``. Default ``False``; flip per
         show in the YAML if a show is targeted at < 13.
+    publish_at:
+        When set, the video uploads PRIVATE with ``status.publishAt`` and
+        YouTube makes it public at that UTC time (staggered Shorts —
+        engine/shorts_stagger.py). Overrides ``privacy_status``.
 
     Returns
     -------
@@ -302,6 +321,7 @@ def upload_video(
         privacy_status=privacy_status,
         contains_synthetic_media=contains_synthetic_media,
         made_for_kids=made_for_kids,
+        publish_at=publish_at,
     )
 
     media = MediaFileUpload(
@@ -315,7 +335,8 @@ def upload_video(
         "Uploading to YouTube: %s (%.1f MiB, privacy=%s, AI-disclosed)",
         video_path.name,
         video_path.stat().st_size / (1024 * 1024),
-        privacy_status,
+        (f"scheduled@{body['status']['publishAt']}"
+         if publish_at is not None else privacy_status),
     )
 
     insert_request = youtube.videos().insert(

--- a/run_show.py
+++ b/run_show.py
@@ -5858,6 +5858,42 @@ def _publish_youtube(
                 except Exception as exc:  # pragma: no cover — best-effort
                     logger.debug("Transcript word load skipped: %s", exc)
 
+            # ---- Staggered Shorts publishing (Aug 2026) ----
+            # Short #1 goes public with the episode; later Shorts upload
+            # private with status.publishAt at the channel's next optimal
+            # slots so they spread through the day (manual runs included).
+            # Any failure here degrades to the legacy publish-all-now.
+            _stagger_times: "list" = []
+            if len(shorts_plan) > 1 and bool(
+                getattr(config.youtube, "shorts_stagger_enabled", False)
+            ):
+                try:
+                    from engine.shorts_stagger import (
+                        resolve_slot_hours,
+                        stagger_publish_times,
+                    )
+                    _stagger_times = stagger_publish_times(
+                        datetime.datetime.now(datetime.timezone.utc),
+                        len(shorts_plan) - 1,
+                        slot_hours=resolve_slot_hours(
+                            config.youtube, _yt_channel),
+                    )
+                    result["shorts_scheduled_times"] = [
+                        t.strftime("%Y-%m-%dT%H:%M:%SZ")
+                        for t in _stagger_times
+                    ]
+                    logger.info(
+                        "Shorts stagger: #1 publishes now; %d later Short(s) "
+                        "scheduled at %s",
+                        len(_stagger_times),
+                        ", ".join(result["shorts_scheduled_times"]),
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "Shorts stagger scheduling failed — all Shorts "
+                        "publish immediately: %s", exc)
+                    _stagger_times = []
+
             # ---- Per-Short loop ----
             short_urls_out: "list[str]" = []
             short_video_ids_out: "list[str]" = []
@@ -6108,6 +6144,14 @@ def _publish_youtube(
                         if this_short_thumb_path and Path(this_short_thumb_path).exists()
                         else thumbnail_path
                     )
+                    # Staggered publishing: Short #1 is immediate; later
+                    # Shorts carry publishAt (upload_video flips them to
+                    # private + scheduled).
+                    _publish_at = (
+                        _stagger_times[short_idx - 1]
+                        if short_idx >= 1 and (short_idx - 1) < len(_stagger_times)
+                        else None
+                    )
                     this_upload = upload_video(
                         this_short_video_path,
                         credentials=credentials,
@@ -6118,6 +6162,7 @@ def _publish_youtube(
                         default_language=meta["default_language"],
                         privacy_status=config.youtube.privacy_status,
                         thumbnail_path=upload_thumb,
+                        publish_at=_publish_at,
                     )
                     short_urls_out.append(this_upload.watch_url)
                     short_video_ids_out.append(this_upload.video_id)
@@ -6130,7 +6175,11 @@ def _publish_youtube(
                             kind="short",
                             title=meta.get("title", ""),
                             hook=(this_hook or hook),
-                            published=f"{today:%Y-%m-%d}",
+                            # A scheduled Short's velocity clock starts when
+                            # it goes PUBLIC, not when it uploads — record
+                            # the publishAt date so policy vpd math is honest.
+                            published=(f"{_publish_at:%Y-%m-%d}"
+                                       if _publish_at else f"{today:%Y-%m-%d}"),
                             watch_url=this_upload.watch_url,
                             channel=(getattr(config.youtube, "channel", "en") or "en"),
                             # The arm this Short ACTUALLY shipped —
@@ -6192,7 +6241,22 @@ def _publish_youtube(
                             _cmt = ("\u25b6 Full episode: " + _cmt_target
                                     + "\n\U0001f514 Subscribe for daily "
                                       "episodes") if _cmt_target else ""
-                            if _cmt and post_video_comment(
+                            if _cmt and _publish_at is not None:
+                                # Comments can't be posted on a private
+                                # (scheduled) video \u2014 queue it; the sweep
+                                # (scripts/post_scheduled_short_comments.py)
+                                # posts it once the Short is public.
+                                from engine.shorts_stagger import queue_comment
+                                if queue_comment(
+                                        digests_dir,
+                                        video_id=this_upload.video_id,
+                                        channel=_yt_channel,
+                                        text=_cmt,
+                                        publish_at=_publish_at):
+                                    result["yt_comments_queued"] = (
+                                        int(result.get(
+                                            "yt_comments_queued", 0)) + 1)
+                            elif _cmt and post_video_comment(
                                     credentials=credentials,
                                     video_id=this_upload.video_id,
                                     text=_cmt):

--- a/scripts/post_scheduled_short_comments.py
+++ b/scripts/post_scheduled_short_comments.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Post queued funnel comments on Shorts that have gone public.
+
+Staggered Shorts publishing (engine/shorts_stagger.py) uploads an
+episode's 2nd/3rd Shorts private with ``status.publishAt``. A comment
+cannot be posted on a private video, so the publish paths queue each
+Short's funnel comment ("▶ Full episode: …" — the strongest Shorts→long
+placement after the description) to
+``digests/<slug>/scheduled_comments.json``. This sweep posts every queued
+comment whose publish time has passed, using the channel's own
+credentials, and removes it from the sidecar.
+
+Wired into the multilingual sweep (14:07 / 18:07 UTC — right after the EN
+17:00 and RU 15:00/18:00 slots... the next run always covers a slot) and
+nightly maintenance (catches the late-evening slots). Safe to run any
+time: not-yet-due entries are kept, entries whose channel has no token in
+this environment are kept for the next sweep, and entries > 7 days
+overdue are dropped loudly. Always exits 0 — a comment is never worth
+failing a workflow over.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout,
+                    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logger = logging.getLogger("post_scheduled_short_comments")
+
+
+def main() -> int:
+    from engine.shorts_stagger import post_due_comments
+
+    stats = post_due_comments(PROJECT_ROOT)
+    logger.info(
+        "Scheduled-Short comments: %d posted, %d kept for a later sweep, "
+        "%d dropped.", stats["posted"], stats["kept"], stats["dropped"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -390,6 +390,21 @@ youtube:
   # fact, and why it matters. Below 30 the clip starts truncating
   # mid-thought, which costs the completion it buys.
   short_duration_seconds: 35
+  # ---- Staggered Shorts publishing (Aug 2026, operator-directed) ----
+  # Short #1 publishes with the episode; the 2nd/3rd upload private with
+  # status.publishAt at the channel's next slot below (UTC hours), so one
+  # episode's Shorts spread through the day on every channel — scheduled
+  # and manual runs alike. Slots are audience-timezone priors (EN: US
+  # lunch/commute/evening; RU: Moscow evening; FR: CEST evening) — the
+  # Analytics API has no hour-of-day views dimension, so tune by hand.
+  # Funnel comments for scheduled Shorts are queued to
+  # digests/<slug>/scheduled_comments.json and posted by the multilingual
+  # sweep / nightly maintenance once the Short is public.
+  shorts_stagger_enabled: true
+  shorts_stagger_slots_utc:
+    en: [17, 21, 23]
+    ru: [15, 18, 20]
+    fr: [17, 19, 21]
   description_prompt_file: shows/prompts/youtube_description_intro.txt
   pinned_comment_template: |
     🎧 Full episode + show notes: {show_page_url}

--- a/tests/test_shorts_stagger.py
+++ b/tests/test_shorts_stagger.py
@@ -1,0 +1,230 @@
+"""Drift guards for staggered Shorts publishing (Aug 2026).
+
+Operator directive: Short #1 publishes with the episode; later Shorts
+upload private with ``status.publishAt`` at the channel's optimal hours so
+one episode's Shorts spread through the day — on every channel (EN/RU/FR)
+and on manual runs too. Core logic: engine/shorts_stagger.py; upload
+plumbing: engine/youtube.py; wiring: run_show + ru_dub + lang_dub;
+deferred funnel comments: sidecar + scripts/post_scheduled_short_comments.py.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+import pytest
+
+from engine.shorts_stagger import (
+    DEFAULT_SLOT_HOURS_UTC,
+    format_publish_at,
+    post_due_comments,
+    queue_comment,
+    resolve_slot_hours,
+    stagger_publish_times,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+UTC = dt.timezone.utc
+
+
+def _at(h, m=0, day=5):
+    return dt.datetime(2026, 8, day, h, m, tzinfo=UTC)
+
+
+class TestStaggerTimes:
+    def test_morning_run_uses_same_day_slots(self):
+        # EN run at 11:30 UTC → 17:00 and 21:00 today.
+        times = stagger_publish_times(_at(11, 30), 2,
+                                      slot_hours=[17, 21, 23])
+        assert times == [_at(17), _at(21)]
+
+    def test_min_lead_skips_too_close_slot(self):
+        # Run at 16:00: the 17:00 slot is only 60 min away (< 90 lead).
+        times = stagger_publish_times(_at(16, 0), 1,
+                                      slot_hours=[17, 21, 23])
+        assert times == [_at(21)]
+
+    def test_late_night_run_rolls_to_tomorrow(self):
+        times = stagger_publish_times(_at(23, 30), 2,
+                                      slot_hours=[17, 21, 23])
+        assert times == [_at(17, day=6), _at(21, day=6)]
+
+    def test_fallback_offsets_when_slots_exhausted(self):
+        # Only one slot configured but three Shorts to schedule.
+        times = stagger_publish_times(_at(11, 0), 3, slot_hours=[17])
+        assert times[0] == _at(17)
+        assert times[1] == _at(17, day=6)  # tomorrow's same slot
+        assert len(times) == 3
+        assert times[2] > times[1]
+
+    def test_zero_count_returns_empty(self):
+        assert stagger_publish_times(_at(11), 0, slot_hours=[17]) == []
+
+    def test_strictly_increasing(self):
+        times = stagger_publish_times(_at(3, 15), 3,
+                                      slot_hours=[15, 18, 20])
+        assert times == sorted(times)
+        assert len(set(times)) == 3
+
+
+class TestResolveSlotHours:
+    class _Cfg:
+        def __init__(self, slots):
+            self.shorts_stagger_slots_utc = slots
+
+    def test_yaml_override_wins(self):
+        assert resolve_slot_hours(self._Cfg({"ru": [12, 16]}), "ru") == [12, 16]
+
+    def test_defaults_per_channel(self):
+        assert resolve_slot_hours(self._Cfg({}), "ru") == \
+            sorted(DEFAULT_SLOT_HOURS_UTC["ru"])
+        assert resolve_slot_hours(self._Cfg(None), "fr") == \
+            sorted(DEFAULT_SLOT_HOURS_UTC["fr"])
+
+    def test_unknown_channel_falls_back_to_en(self):
+        assert resolve_slot_hours(self._Cfg({}), "zh") == \
+            sorted(DEFAULT_SLOT_HOURS_UTC["en"])
+
+    def test_invalid_entries_dropped(self):
+        assert resolve_slot_hours(
+            self._Cfg({"en": ["x", -1, 25, 18]}), "en") == [18]
+
+
+class TestUploadBodyPublishAt:
+    def test_publish_at_forces_private_and_sets_timestamp(self):
+        from engine.youtube import _build_video_body
+        body = _build_video_body(
+            title="t", description="d", tags=[], category_id=28,
+            default_language="en", privacy_status="public",
+            contains_synthetic_media=True, made_for_kids=False,
+            publish_at=_at(17),
+        )
+        assert body["status"]["privacyStatus"] == "private"
+        assert body["status"]["publishAt"] == "2026-08-05T17:00:00Z"
+
+    def test_no_publish_at_is_byte_identical_legacy(self):
+        from engine.youtube import _build_video_body
+        body = _build_video_body(
+            title="t", description="d", tags=[], category_id=28,
+            default_language="en", privacy_status="public",
+            contains_synthetic_media=True, made_for_kids=False,
+        )
+        assert body["status"]["privacyStatus"] == "public"
+        assert "publishAt" not in body["status"]
+
+    def test_format_publish_at_rfc3339(self):
+        assert format_publish_at(_at(15, 30)) == "2026-08-05T15:30:00Z"
+
+
+class TestConfigPlumbing:
+    """The silent-config-drop landmine: fields must exist on the dataclass
+    AND the network default must be on with all three channels mapped."""
+
+    def test_dataclass_declares_stagger_fields(self):
+        from engine.config import YouTubeConfig
+        cfg = YouTubeConfig()
+        assert cfg.shorts_stagger_enabled is False  # dataclass default
+        assert cfg.shorts_stagger_slots_utc == {}
+
+    def test_network_default_enables_stagger_with_all_channels(self):
+        from engine.config import load_config
+        cfg = load_config(PROJECT_ROOT / "shows" / "spacex.yaml")
+        assert cfg.youtube.shorts_stagger_enabled is True
+        slots = cfg.youtube.shorts_stagger_slots_utc
+        for ch in ("en", "ru", "fr"):
+            assert slots.get(ch), f"channel {ch} missing stagger slots"
+            assert all(0 <= int(h) <= 23 for h in slots[ch])
+
+
+class TestDeferredComments:
+    def test_queue_and_post_due(self, tmp_path, monkeypatch):
+        ddir = tmp_path / "digests" / "spacex"
+        ddir.mkdir(parents=True)
+        assert queue_comment(ddir, video_id="vid1", channel="ru",
+                             text="▶ link", publish_at=_at(15))
+        # Re-queue same video → no duplicate.
+        assert queue_comment(ddir, video_id="vid1", channel="ru",
+                             text="▶ link", publish_at=_at(15))
+        assert queue_comment(ddir, video_id="vid2", channel="ru",
+                             text="▶ link2", publish_at=_at(20))
+        data = json.loads((ddir / "scheduled_comments.json").read_text())
+        assert len(data["pending"]) == 2
+
+        posted = []
+        import engine.youtube as yt
+        monkeypatch.setattr(yt, "get_channel_credentials_from_env",
+                            lambda ch: object())
+        monkeypatch.setattr(
+            yt, "post_video_comment",
+            lambda *, credentials, video_id, text: posted.append(video_id)
+            or "cid")
+        # At 16:00 only vid1 (15:00) is due; vid2 (20:00) stays queued.
+        stats = post_due_comments(tmp_path, now=_at(16))
+        assert posted == ["vid1"]
+        assert stats["posted"] == 1 and stats["kept"] == 1
+        data = json.loads((ddir / "scheduled_comments.json").read_text())
+        assert [e["video_id"] for e in data["pending"]] == ["vid2"]
+
+    def test_missing_credentials_keep_entry(self, tmp_path, monkeypatch):
+        ddir = tmp_path / "digests" / "tesla_shorts_time"
+        ddir.mkdir(parents=True)
+        queue_comment(ddir, video_id="v", channel="fr", text="t",
+                      publish_at=_at(15))
+        import engine.youtube as yt
+        monkeypatch.setattr(yt, "get_channel_credentials_from_env",
+                            lambda ch: None)
+        stats = post_due_comments(tmp_path, now=_at(16))
+        assert stats == {"posted": 0, "kept": 1, "dropped": 0}
+        data = json.loads((ddir / "scheduled_comments.json").read_text())
+        assert len(data["pending"]) == 1
+
+    def test_stale_entries_dropped(self, tmp_path, monkeypatch):
+        ddir = tmp_path / "digests" / "spacex"
+        ddir.mkdir(parents=True)
+        queue_comment(ddir, video_id="old", channel="en", text="t",
+                      publish_at=_at(15))
+        import engine.youtube as yt
+        monkeypatch.setattr(yt, "get_channel_credentials_from_env",
+                            lambda ch: object())
+        monkeypatch.setattr(yt, "post_video_comment",
+                            lambda **kw: pytest.fail("must not post stale"))
+        stats = post_due_comments(tmp_path, now=_at(15, day=14))
+        assert stats["dropped"] == 1
+        data = json.loads((ddir / "scheduled_comments.json").read_text())
+        assert data["pending"] == []
+
+
+class TestWiring:
+    """Source-scan guards: every publish path passes publish_at, and the
+    comment sweep is wired into workflows that hold the channel tokens."""
+
+    def test_run_show_passes_publish_at(self):
+        src = (PROJECT_ROOT / "run_show.py").read_text()
+        assert "publish_at=_publish_at" in src
+        assert "stagger_publish_times" in src
+        assert "yt_comments_queued" in src
+
+    def test_ru_dub_passes_publish_at(self):
+        src = (PROJECT_ROOT / "engine" / "ru_dub.py").read_text()
+        assert "publish_at=_publish_at" in src
+        assert "stagger_publish_times" in src
+        assert "queue_comment" in src
+
+    def test_lang_dub_passes_publish_at(self):
+        src = (PROJECT_ROOT / "engine" / "lang_dub.py").read_text()
+        assert "publish_at=_publish_at" in src
+        assert "stagger_publish_times" in src
+        assert "queue_comment" in src
+
+    def test_comment_sweep_wired_into_workflows(self):
+        ml = (PROJECT_ROOT / ".github" / "workflows"
+              / "multilingual.yml").read_text()
+        nightly = (PROJECT_ROOT / ".github" / "workflows"
+                   / "nightly-maintenance.yml").read_text()
+        assert "post_scheduled_short_comments.py" in ml
+        assert "post_scheduled_short_comments.py" in nightly
+        # The nightly add-paths whitelist landmine: the sweep edits the
+        # sidecar, and a whitelist gap silently drops that edit for days.
+        assert "digests/**/scheduled_comments.json" in nightly


### PR DESCRIPTION
## What this does

Operator-directed: instead of all of an episode's Shorts publishing in the same minute (competing with each other and the long-form for the same audience), **Short #1 goes public with the episode and the 2nd/3rd Shorts upload PRIVATE with `status.publishAt`** set to the channel's next optimal slots. YouTube's own scheduler flips them public — no new infrastructure, nothing to babysit, and a dead runner can't strand a Short because the upload already happened. Applies to **scheduled and manual runs alike**, on all three channels (EN / RU dubs / FR dubs).

## How the times are chosen

Per-channel UTC slot hours, audience-timezone priors (the YouTube Analytics API exposes no hour-of-day views dimension, so these are hand-tunable heuristics in `shows/_defaults.yaml`, overridable per show):

| Channel | Slots (UTC) | Rationale |
|---|---|---|
| `en` | 17, 21, 23 | ~1pm ET lunch scroll, ~5pm ET commute, ~7pm ET evening |
| `ru` | 15, 18, 20 | 6pm / 9pm / 11pm Moscow |
| `fr` | 17, 19, 21 | 7pm / 9pm / 11pm CEST |

`engine/shorts_stagger.py` picks the next unelapsed slots (≥90 min lead so a Short never publishes before the first has had a run), rolls to tomorrow's slots on a late-night run, and falls back to fixed +3h offsets if the slot list runs dry. Times are strictly increasing.

## Wiring

- **`engine/youtube.py`** — `upload_video(..., publish_at=)`: sets `privacyStatus: private` + RFC3339 `publishAt` (API requirement). Without the param the request body is byte-identical legacy.
- **`run_show._publish_youtube`**, **`engine/ru_dub.py`**, **`engine/lang_dub.py`** — compute the stagger plan before each Shorts loop; Short #1 immediate, later Shorts scheduled. Any scheduling failure degrades to legacy publish-all-now.
- **Video index honesty** — a scheduled Short's `published` date records the *publishAt* date, not the upload date, so the adaptive policy's views-per-day math and the analytics window stay correct.
- **Funnel comments** — a comment can't be posted on a private video, and silently losing the "▶ Full episode" comment would degrade the strongest Shorts→long placement (the July RU pilot exists because of exactly that gap). Scheduled Shorts queue their comment to `digests/<slug>/scheduled_comments.json`; new `scripts/post_scheduled_short_comments.py` posts due comments using the channel's own token, wired into the **multilingual sweep** (14:07/18:07 UTC crons + after-show runs) and **nightly maintenance**. Entries >7 days overdue drop loudly. The sidecar is added to nightly's `add-paths` whitelist (the `youtube_channel_history` silent-drop class).
- **Config** — `youtube.shorts_stagger_enabled` (dataclass default `False`, network default **true** in `_defaults.yaml` — the `x_cross_promo` pattern) + `shorts_stagger_slots_utc`. Per-show opt-out is one YAML flag.

## What this affects in practice

Today's beneficiaries are the multi-Short surfaces: EN tesla/spacex/FF (2 Shorts), RU spacex/FF (3 Shorts — the network's highest-reach surface now gets three separate prime-time drops instead of one afternoon dump), RU tesla/MIT (2). Single-Short shows are untouched. Render, metadata, thumbnails, playlists, quota cost: all unchanged — only *when the video goes public* moves.

## Verification

- `tests/test_shorts_stagger.py` — 22 new tests: scheduler edge cases (min-lead, tomorrow rollover, slot exhaustion), publishAt body shape + legacy byte-identity, config plumbing (incl. the silent-config-drop landmine), sidecar queue/sweep (due, not-due, missing-token, stale), and source-scan wiring guards for all three publish paths + both workflows.
- Full suite: **6,331 passed**; the 22 pre-existing failures are sandbox-environment dep gaps (yfinance etc.) and are byte-identical with the change stashed.
- Both workflow YAMLs parse; all touched modules compile.

## Rollback

`shorts_stagger_enabled: false` per show (or in `_defaults.yaml` network-wide) restores publish-all-now exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_