### PR TITLE
Publication-floor re-roll: fresh regeneration before a thin-script skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,14 @@ today's work, not just explain yesterday's):
   are banned network-wide (July 18 playbook `do_not_retry`: ~10 misses vs
   1 hit) and were switched off in the show YAMLs on 2026-07-29 wherever a
   digest-side lever exists. Chronic under-length on FF / PT / UC / Tesla /
-  EI is a DIGEST ceiling — do not re-attack it at the script.
+  EI is a DIGEST ceiling — do not re-attack it at the script. The
+  **publication-floor re-roll** (Aug 2026, `engine/generator.py`) is NOT
+  that lever: it fires only inside run_show's 60%-of-target skip band —
+  where the alternative is losing the whole day (Tesla Ep564 skipped
+  2026-08-06; the identical 2026-07-31 skip was recovered by a manual
+  rerun) — and regenerates the full prompt fresh instead of expanding the
+  short draft. Guarded by `tests/test_podcast_floor_reroll.py`; do not
+  remove it as a "banned retry", and do not widen it above the band.
 - **De-seed by shape, never with a quotable example.** Every seeded
   template tic in this network's history came from a prompt supplying the
   literal sentence it wanted; three generations of them are in the

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -2472,6 +2472,92 @@ def generate_podcast_script(
                 config.name, word_count, word_count2,
             )
 
+    # Publication-floor re-roll (Aug 2026, Tesla Ep564). When the script is
+    # STILL inside the skip band after the expansion retry, the episode is
+    # about to be thrown away: run_show skips anything under 60% of target.
+    # Tesla lost the whole 2026-08-06 slot this way \u2014 954-word first pass,
+    # expansion retry reached only 1119 against the 1200 floor \u2014 and the
+    # identical 2026-07-31 skip was recovered by a MANUAL workflow rerun
+    # that produced a normal 1500-word script from the same news day. A
+    # fresh full-prompt regeneration recovers a low-tail sampling draw far
+    # more reliably than asking the model to expand its own short draft
+    # (the expansion retry's ledger record is ~10 misses to 1 hit). This is
+    # NOT the banned podcast-side length lever: the gate is the publication
+    # soft floor (+ the same 10% dedup margin the expansion threshold
+    # uses), never the word TARGET, so it cannot fire on a merely
+    # below-target script \u2014 it only decides between "an episode ships" and
+    # "the day is lost". Costs one extra LLM call, only on would-be-skipped
+    # days. The longer candidate wins; a shorter or refused re-roll keeps
+    # the original (and the runner's skip gate still has the final say).
+    _pub_band = max(600, int(int(min_words * 0.6) * 1.1))
+    _current_words = len(text.split())
+    if _current_words < _pub_band:
+        logger.warning(
+            "Podcast script for '%s' is still in the publication skip band "
+            "(%d words < %d) after the expansion retry \u2014 re-rolling the full "
+            "prompt once (fresh generation) to avoid losing the episode ...",
+            config.name, _current_words, _pub_band,
+        )
+        try:
+            text_fresh, meta_fresh = _call_grok(
+                prompt,
+                model=script_model,
+                system_prompt=system_prompt,
+                temperature=config.llm.podcast_temperature,
+                max_tokens=podcast_tokens,
+                cache_key=_show_cache_key(config),
+                reasoning_effort=_llm_reasoning_effort(config),
+            )
+            if tracker and "usage" in meta_fresh:
+                try:
+                    from engine.tracking import record_llm_usage
+                    record_llm_usage(
+                        tracker,
+                        "podcast_script_floor_reroll",
+                        meta_fresh["usage"].get("prompt_tokens", 0),
+                        meta_fresh["usage"].get("completion_tokens", 0),
+                        model=script_model,
+                        cached_tokens=meta_fresh["usage"].get("cached_tokens", 0),
+                    )
+                except Exception as e:
+                    logger.warning("Failed to record re-roll LLM usage: %s", e)
+            # A fresh draw can still degenerate into self-restatement —
+            # strip intra-script near-duplicates before comparing so a
+            # doubled script can't "win" on raw length (same guard the
+            # expansion retry uses; a clean script loses nothing here).
+            text_fresh, _fresh_dups = _dedup_expansion_sentences(text_fresh)
+            if _fresh_dups:
+                logger.warning(
+                    "Publication-floor re-roll for '%s' repeated itself — "
+                    "stripped %d near-duplicate sentence(s)",
+                    config.name, _fresh_dups,
+                )
+            fresh_words = len(text_fresh.split())
+            if fresh_words > _current_words:
+                # Validate BEFORE accepting \u2014 a refusal raises here and the
+                # except below keeps the original draft.
+                _rep_count = _validate_llm_output(
+                    text_fresh, stage="podcast_script", show_name=config.name,
+                    min_podcast_words=min_words,
+                    known_entities=tuple(getattr(config, "keywords", ()) or ()),
+                )
+                logger.info(
+                    "Publication-floor re-roll recovered '%s' (%d \u2192 %d "
+                    "words)", config.name, _current_words, fresh_words,
+                )
+                text = text_fresh
+            else:
+                logger.warning(
+                    "Publication-floor re-roll for '%s' was no longer than "
+                    "the current draft (%d vs %d words) \u2014 keeping original",
+                    config.name, fresh_words, _current_words,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Publication-floor re-roll failed for '%s' (%s) \u2014 keeping "
+                "original draft", config.name, exc,
+            )
+
     # If the script has severe repetition, retry with lower temperature
     if _rep_count >= 3:
         logger.warning(

--- a/tests/test_podcast_floor_reroll.py
+++ b/tests/test_podcast_floor_reroll.py
@@ -1,0 +1,159 @@
+"""Publication-floor re-roll (Aug 2026, Tesla Ep564).
+
+When a podcast script is still inside run_show's skip band (< 60% of
+``min_podcast_words``, plus the 10% dedup margin) AFTER the expansion
+retry, the episode is about to be thrown away entirely — Tesla lost the
+whole 2026-08-06 slot this way (954-word first pass, expansion retry
+reached only 1119 against the 1200 floor), and the identical 2026-07-31
+skip was recovered by a MANUAL workflow rerun that produced a normal
+1500-word script from the same digest. ``generate_podcast_script`` now
+re-rolls the FULL original prompt once (a fresh sampling draw, not an
+expansion of the short draft) before letting the runner skip the day.
+
+These tests pin the safety properties:
+
+* the re-roll fires ONLY inside the publication skip band — a merely
+  below-target script never triggers it (it is NOT the banned
+  podcast-side length lever from the July 18 playbook ``do_not_retry``);
+* the fresh draw wins only when it is longer; a shorter re-roll keeps
+  the current draft;
+* a re-roll failure (exception / refusal) keeps the current draft.
+"""
+
+import random
+from types import SimpleNamespace
+
+import pytest
+
+import engine.generator as gen
+
+
+def _words(n: int, prefix: str = "w") -> str:
+    """Build an n-word script whose sentences are seeded-random gibberish
+    — textually diverse enough that neither the repetition detector nor
+    ``_dedup_expansion_sentences`` (similarity >= 0.85) strips anything.
+    The first word is a ``<prefix>marker`` token so tests can assert
+    which candidate shipped."""
+    rng = random.Random(prefix)
+    out = [f"{prefix}marker"]
+    sentence_len = rng.randint(9, 15)
+    for i in range(1, n):
+        word = "".join(
+            rng.choice("abcdefghijklmnopqrstuvwxyz")
+            for _ in range(rng.randint(3, 10))
+        )
+        if len(out) % sentence_len == 0:
+            word += "."
+            sentence_len = rng.randint(9, 15)
+        out.append(word)
+    return " ".join(out)
+
+
+def _config(min_words: int = 2000, expand_below_target: bool = False):
+    return SimpleNamespace(
+        name="Tesla Shorts Time",
+        llm=SimpleNamespace(
+            model="grok-4.3",
+            podcast_prompt_file="x",
+            system_prompt_file="",
+            podcast_temperature=0.7,
+            max_tokens=5000,
+            podcast_max_tokens=12000,
+            min_podcast_words=min_words,
+            podcast_expand_below_target=expand_below_target,
+            podcast_chain=False,
+        ),
+    )
+
+
+def _run(monkeypatch, responses):
+    """Drive generate_podcast_script with a scripted _call_grok.
+
+    ``responses`` maps call index (0-based) -> text to return. Records
+    every prompt so tests can assert which retry paths fired.
+    """
+    calls = []
+
+    def fake_call_grok(prompt, **kwargs):
+        idx = len(calls)
+        calls.append(prompt)
+        return responses[idx], {"finish_reason": "stop"}
+
+    monkeypatch.setattr(gen, "_call_grok", fake_call_grok)
+    monkeypatch.setattr(gen, "load_prompt", lambda *a, **k: "PROMPT")
+    result = gen.generate_podcast_script(
+        {"digest": "Top stories...", "episode_num": 564},
+        _config(),
+    )
+    return result, calls
+
+
+class TestPublicationFloorReroll:
+    # Tesla shape: min_podcast_words=2000 → soft floor 1200 → band 1320.
+
+    def test_reroll_fires_and_recovers_the_episode(self, monkeypatch):
+        """Ep564 shape: 950-word first pass, expansion retry lands at
+        ~1150 (still in the skip band) — the fresh re-roll's 1500-word
+        draw must ship."""
+        result, calls = _run(monkeypatch, {
+            0: _words(950),
+            1: _words(1150, prefix="x"),   # expansion retry — accepted, still thin
+            2: _words(1500, prefix="y"),   # fresh re-roll
+        })
+        assert len(calls) == 3, "publication-floor re-roll did not fire"
+        # The re-roll is a FRESH generation: the full original prompt,
+        # not an expand-your-own-draft instruction.
+        assert calls[2] == calls[0]
+        assert "script you just wrote" not in calls[2]
+        assert len(result.split()) >= 1400
+
+    def test_shorter_reroll_keeps_current_draft(self, monkeypatch):
+        result, calls = _run(monkeypatch, {
+            0: _words(950),
+            1: _words(1150, prefix="x"),
+            2: _words(900, prefix="y"),    # fresh draw came up SHORTER
+        })
+        assert len(calls) == 3
+        assert "xmarker" in result and "ymarker" not in result
+
+    def test_reroll_failure_keeps_current_draft(self, monkeypatch):
+        calls = []
+
+        def fake_call_grok(prompt, **kwargs):
+            idx = len(calls)
+            calls.append(prompt)
+            if idx == 2:
+                raise RuntimeError("boom")
+            return {0: _words(950), 1: _words(1150, prefix="x")}[idx], \
+                {"finish_reason": "stop"}
+
+        monkeypatch.setattr(gen, "_call_grok", fake_call_grok)
+        monkeypatch.setattr(gen, "load_prompt", lambda *a, **k: "PROMPT")
+        result = gen.generate_podcast_script(
+            {"digest": "Top stories...", "episode_num": 564}, _config(),
+        )
+        assert len(calls) == 3
+        assert "xmarker" in result
+
+    def test_no_reroll_above_the_skip_band(self, monkeypatch):
+        """A below-target but publishable script (1400 words vs the
+        2000 target, band 1320) must NOT trigger any extra call — the
+        re-roll is a skip-rescue, never a target-chasing length lever
+        (July 18 playbook do_not_retry)."""
+        result, calls = _run(monkeypatch, {
+            0: _words(1400),
+        })
+        assert len(calls) == 1, (
+            "re-roll fired above the publication skip band — this is the "
+            "banned podcast-side length-lever shape"
+        )
+
+    def test_reroll_only_after_expansion_retry_still_thin(self, monkeypatch):
+        """When the expansion retry itself clears the band, no re-roll
+        fires (two calls total)."""
+        result, calls = _run(monkeypatch, {
+            0: _words(950),
+            1: _words(1450, prefix="x"),   # expansion retry clears the band
+        })
+        assert len(calls) == 2
+        assert "xmarker" in result


### PR DESCRIPTION
## What happened

Tesla lost the entire 2026-08-06 slot: the scheduled run generated a 954-word first pass against the 2,000-word target, the near-floor expansion retry reached only 1,119 words (1,067 after cleaning), and run_show skipped the episode at the 1,200-word publication floor (`podcast_script_too_thin`). The same skip hit on 2026-07-31 and was recovered by a **manual workflow rerun that produced a normal 1,500-word script from the same news day**.

Two facts frame the fix:

- The digest was healthy (1,750 words, above the 1,600 target after the digest-side retry), and the last 19 shipped Tesla scripts run 1,347–1,927 words — so these are **low-tail sampling draws**, not the known digest ceiling.
- The expand-your-own-draft retry is the wrong recovery for them: its ledger record is ~10 misses to 1 hit, and today it added only +165 words. A fresh full-prompt draw is what actually works (that's exactly what the July 31 manual rerun was).

## The change

`engine/generator.py:generate_podcast_script` now re-rolls the **full original prompt once** (a fresh generation, not an expansion of the short draft) when the script is still inside the skip band — 60% of `min_podcast_words` plus the same 10% dedup margin the expansion threshold uses — after the expansion retry. The fresh draw goes through the same intra-script near-duplicate strip as the expansion retry (a degenerate doubled draw collapses back and is rejected), only replaces the current draft when it is longer, and any failure/refusal keeps the original. run_show's skip gate still has the final say. Usage is recorded as `podcast_script_floor_reroll`.

**This is not the banned podcast-side length lever** (July 18 playbook `do_not_retry`): the gate is the publication skip band, never the word target, so it cannot fire on a merely below-target script. It only decides between "an episode ships" and "the day is lost", at the cost of one extra LLM call (~$0.015) on would-be-skipped days. A CLAUDE.md note in the live-constraints bullet documents the distinction so a future pass doesn't remove it as a banned retry.

## Drift guards

`tests/test_podcast_floor_reroll.py` (5 tests) pins:
- the re-roll fires on the Ep564 shape and the fresh draw ships;
- the re-roll prompt is the original prompt, not an expand instruction;
- a shorter or failed re-roll keeps the current draft;
- **no extra call ever fires above the skip band** (the banned-lever shape);
- no re-roll when the expansion retry itself clears the band.

Also fixed a hole the first iteration opened in `TestExpansionRetryDedup::test_degenerate_expansion_falls_back_to_original` (a doubled restatement could win on raw length) — now green. `test_generator.py`, `test_generator_postprocess.py`, `test_editorial_pass_fixes.py` (retry classes), and `test_cost_efficiency_pass.py` all pass; the `TestSourceScaffoldScrub`/`TestSpokenUrlTripwire` failures in this environment pre-exist the change (fail on a clean checkout too).

## Not in scope / operator note

- No audio-affecting prompt changes — the re-roll reuses the exact production prompt, so there is nothing to A/B-listen beyond the normal episode.
- **Today's Ep564 is still missing.** A manual `workflow_dispatch` of Run Podcast Show for `tesla` will recover it (the duplicate re-check only blocks *scheduled* reruns), same as the 2026-07-31 recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPDmcG9JtHmSnG5VFNqupG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPDmcG9JtHmSnG5VFNqupG)_