### PR TITLE
Complete headlines for dub window-Shorts + pre-staged Flight 14 / Q3 earnings specials

### DIFF
--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -616,15 +616,27 @@ def publish_lang_dub(
                             st = (_short_title(title, lang, body_limit=52)
                                   + lang.second_short_tail)
                     else:
-                        # Clause-aware: this branch titles the 2nd/3rd Short
-                        # from its window's opening speech, which is a
-                        # mid-sentence slice to begin with — a plain word
-                        # trim lands on a dangling article even more often
-                        # than the long-title path does.
-                        body = _clause_trim(
-                            opening_text.rstrip("…").rstrip(),
-                            min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX)),
-                            lang.code)
+                        # Aug 2026: window openings are mid-sentence slices
+                        # by construction — ask Grok for a complete headline
+                        # from the excerpt first (never-invent, same-language
+                        # validated); any failure keeps the legacy
+                        # clause-trim. Title-only metadata.
+                        _limit = min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX))
+                        body = ""
+                        try:
+                            from engine.translate import (
+                                headline_from_excerpt,
+                            )
+                            body = headline_from_excerpt(
+                                opening_text, lang.code, max_chars=_limit)
+                        except Exception:  # noqa: BLE001
+                            body = ""
+                        if body:
+                            body = _clause_trim(body, _limit, lang.code)
+                        else:
+                            body = _clause_trim(
+                                opening_text.rstrip("…").rstrip(),
+                                _limit, lang.code)
                         st = f"{body}{_SHORTS_SUFFIX}".strip()
 
                     _publish_at = (

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -817,13 +817,28 @@ def publish_ru_dub(
                             short_title = _ru_short_title(
                                 ru_title, body_limit=58) + " — ещё момент"
                     else:
-                        # Clause-aware — this titles the 2nd/3rd Short from
-                        # its window's opening speech, already a
-                        # mid-sentence slice.
-                        body = _clause_trim(
-                            opening_text.rstrip("…").rstrip(),
-                            min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX)),
-                            "ru")
+                        # Aug 2026: the 2nd/3rd Short's window opening is a
+                        # mid-sentence slice by construction, so first ask
+                        # Grok for a complete headline from that excerpt
+                        # (engine.translate.headline_from_excerpt — grounded
+                        # in the excerpt only, never-invent). Any failure
+                        # falls back to the legacy clause-trim so a Short
+                        # never ships untitled. Title-only metadata.
+                        _limit = min(70, _YT_TITLE_MAX - len(_SHORTS_SUFFIX))
+                        body = ""
+                        try:
+                            from engine.translate import headline_from_excerpt
+                            body = headline_from_excerpt(
+                                opening_text, "ru", max_chars=_limit)
+                        except Exception:  # noqa: BLE001
+                            body = ""
+                        if body:
+                            body = _clause_trim(body, _limit, "ru")
+                        else:
+                            # Legacy clause-aware trim of the raw excerpt.
+                            body = _clause_trim(
+                                opening_text.rstrip("…").rstrip(),
+                                _limit, "ru")
                         short_title = f"{body}{_SHORTS_SUFFIX}".strip()
 
                     _publish_at = (

--- a/engine/translate.py
+++ b/engine/translate.py
@@ -333,6 +333,63 @@ def translate_script(
     raise last_err
 
 
+def headline_from_excerpt(
+    excerpt: str,
+    lang: str,
+    *,
+    max_chars: int = 70,
+    model: str = _TRANSLATION_MODEL,
+) -> str:
+    """Turn a mid-sentence transcript excerpt into a complete headline.
+
+    Aug 2026: a dub channel's 2nd/3rd Shorts are titled from their window's
+    opening speech, which is a mid-sentence slice by construction — the
+    clause-trim keeps the cut grammatical but the title still *starts*
+    mid-thought («атмосферу. Успех станет…», ~2/3 of RU Short titles once
+    the 3-Short band shipped). This asks Grok for ONE natural, complete
+    headline in the excerpt's own language, grounded strictly in the
+    excerpt (the never-invent rule), and validates the result with the
+    same refusal/script guards as the other translation surfaces.
+
+    Returns ``""`` on ANY failure or doubt so the caller keeps its legacy
+    clause-trim path — a fragment title is bad, an invented or English
+    title on a Russian channel is worse. Title-only metadata: no audio is
+    touched (outside the landmine-#17 A/B gate, same contract as the
+    youtube_titles loop).
+    """
+    excerpt = _collapse_ws(excerpt or "")
+    if len(excerpt) < 15 or lang not in LANGUAGE_NAMES:
+        return ""
+    name = language_name(lang)
+    prompt = (
+        f"This is an excerpt from a {name} podcast transcript; it may begin "
+        f"mid-sentence:\n\n\"{excerpt[:400]}\"\n\n"
+        f"Write ONE natural, complete {name} headline for a YouTube Short "
+        f"made from this exact moment. Requirements: at most {max_chars} "
+        "characters; a grammatical, self-contained phrase or sentence that "
+        "never starts mid-thought; state the concrete fact or stake from "
+        "the excerpt; keep proper nouns, brand names and tickers intact; "
+        "no quotation marks, emoji, hashtags, or trailing ellipsis; do NOT "
+        "add facts that are not in the excerpt. Return ONLY the headline "
+        "text, nothing else."
+    )
+    try:
+        raw = _generate(prompt, model, 200)
+        raw = _collapse_ws(raw).strip().strip('"«»“”').strip()
+        # Same refusal + target-script guards the script path uses.
+        raw = validate_translation(raw, lang)
+        if len(raw) < 8:
+            return ""
+        # A wildly over-budget result means the model ignored the brief —
+        # treat as failure rather than hand a paragraph to the trimmer.
+        if len(raw) > int(max_chars * 1.6):
+            return ""
+        return raw
+    except Exception as exc:  # noqa: BLE001 — headline is best-effort
+        logger.warning("headline_from_excerpt (%s) failed: %s", lang, exc)
+        return ""
+
+
 def translate_metadata(
     title: str,
     description: str,

--- a/shows/deep_dives/spacex.yaml
+++ b/shows/deep_dives/spacex.yaml
@@ -39,3 +39,164 @@ queue:
     FRAMING RULES: this is the one episode where the business IS the headline — but keep the engineering heart: the numbers exist because of the hardware. Not financial advice; no price targets; no buy/sell framing. State beats/misses with attribution to reporting, state filing numbers as fact, label call quotes as call quotes, and label opinion as opinion. The episode should leave a listener — investor or engineer — feeling they understand what the first public quarter actually revealed: a launch monopoly funding a broadband profit engine funding an AI land grab, and the honest open question of whether the capex bet pays.
 
     '
+
+# ---------------------------------------------------------------------------
+# Pre-staged specials (Aug 2026). Both are MANUAL-FORCE ONLY (the show's
+# deep_dive.enabled stays false — no scheduling keys here, so the daily
+# cron can never pick them up). Run from Actions: "Run Podcast Show" ->
+# Run workflow -> show=spacex + the deep_dive id.
+#
+# Both events are IN THE FUTURE at authoring time, so unlike the Q2 entry
+# their briefs carry verified CONTEXT only — every fact about the event
+# itself must come from the {current_research} block pulled at generation
+# time. The briefs enforce that hard: if the research is thin, the host
+# says what is and is not known rather than inventing.
+# ---------------------------------------------------------------------------
+
+- id: flight-14-catch-reaction
+  title: 'Starship Flight 14 Special: The Tower Catch Attempt'
+  category: event_special
+  produced: false
+  episode_number: null
+  produced_date: null
+  # Run this the DAY OF or DAY AFTER the flight, whatever the outcome —
+  # success, partial, failure, or scrub. The research pulls what actually
+  # happened; the brief refuses to presume it.
+  web_search_queries:
+  - Starship Flight 14 launch result upper stage tower catch
+  - SpaceX Starship Flight 14 live coverage outcome
+  - Starship Flight 14 Mechazilla ship catch attempt analysis
+  - Starship Flight 14 booster catch upper stage reentry heat shield
+  - Elon Musk Starship Flight 14 reaction quotes
+  - SPCX stock reaction Starship Flight 14
+  - Starship Flight 14 engineering analysis what changed V3
+  - Starship flight cadence daily flights Musk projection
+  x_handles:
+  - SpaceX
+  - elonmusk
+  - NASASpaceflight
+  - SciGuySpace
+  - StarshipGazer
+  - thesheetztweetz
+  brief: >
+    A special standalone reaction episode on Starship Flight 14 — the
+    flight on which SpaceX said it would attempt, for the first time in
+    history, to CATCH THE SHIP (the upper stage) with the launch tower.
+    CRITICAL HONESTY RULE: this brief was written BEFORE the flight. The
+    outcome — success, partial success, failure, or scrub — is UNKNOWN
+    here and must be taken ENTIRELY from the {current_research} block and
+    reported exactly as it happened, with attribution. Do not presume
+    success; do not soften a failure; a scrub or delay is its own honest
+    episode ("what the hold tells us"). Name the stage in every recovery
+    reference — Super Heavy booster (first stage) versus Ship / upper
+    stage — and never blur the two.
+
+    VERIFIED CONTEXT (from the Q2 2026 earnings release and call, August
+    4, 2026 — safe to state as background): Starship V3 completed two
+    successful flight tests in the 90 days before the call. Flight 12 in
+    May was V3's first suborbital mission from the new Starbase pad, with
+    a precision upper-stage landing and deployment of modified V2
+    Starlink satellites. Flight 13 in July achieved all objectives: 20
+    production V3 satellites deployed, an in-space Raptor engine relight,
+    and the softest-ever Starship splashdown, returning an intact heat
+    shield. On the earnings call, Musk said the next flight — tentatively
+    end of August — would attempt to catch the Ship with the tower,
+    pending regulatory approval, and projected flight cadence reaching
+    "at least one flight a day, possibly more" within a year (attribute
+    call quotes as call coverage). The company frames Starship as the
+    path to cutting cost-to-orbit by 99% or more.
+
+    EPISODE SHAPE: (1) The moment — what was attempted and what happened,
+    from the research, minute by minute where the reporting supports it.
+    (2) Why a Ship catch is HARD, from first principles — the engineering
+    centerpiece: the upper stage returns from orbital velocity through
+    full reentry heating (unlike the booster's suborbital return), must
+    survive with a reusable heat shield, relight engines, decelerate to a
+    hover at a precise point, and be caught by the tower arms; walk the
+    physics of why SpaceX wants tower catches at all (no landing legs =
+    dry-mass savings = payload; rapid re-stack = cadence; the 99%
+    cost-to-orbit thesis needs BOTH stages back same-day). (3) What the
+    outcome — whichever it was — actually proves or disproves on the road
+    to full and rapid reusability, and what it means for the Starlink V3
+    deployment rate and the daily-flight projection. (4) The reaction:
+    the best attributed takes from the research (X commentary, analyst
+    reads, SPCX move if reported), labeled as opinion. (5) What to watch
+    next, concretely. Engineering-first, honest, never a stock promoter;
+    not financial advice.
+
+- id: q3-2026-earnings
+  title: 'SpaceX Quarterly Earnings Special: Q3 2026'
+  category: earnings_special
+  produced: false
+  episode_number: null
+  produced_date: null
+  # Run this AFTER the Q3 call (expected early November 2026 — confirm
+  # the actual date from the research; the Q2 call was August 4).
+  # OPERATOR PRE-FLIGHT (same playbook that made the Q2 special sharp):
+  # if you can, drop the Q3 press release / 10-Q numbers into this brief
+  # before dispatching — verified filing numbers beat scraped ones. The
+  # episode still works from research alone, with heavier attribution.
+  web_search_queries:
+  - SpaceX SPCX Q3 2026 earnings results revenue net loss
+  - SpaceX Q3 2026 earnings call highlights quotes Musk
+  - SPCX stock reaction Q3 earnings after hours
+  - SpaceX Q3 2026 AI capex compute gigawatts Colossus
+  - SpaceX Starlink subscribers ARPU Q3 2026
+  - SpaceX Q3 2026 analyst commentary beat miss estimates
+  - SpaceX Cursor acquisition close integration Q3
+  - SpaceX Starship program update Q3 earnings
+  - SPCX lockup insider selling supply Q3
+  x_handles:
+  - SpaceX
+  - elonmusk
+  - thesheetztweetz
+  - SciGuySpace
+  - xai
+  - cursor_ai
+  brief: >
+    A special standalone episode on SpaceX's SECOND quarterly earnings
+    report as a public company (Q3 2026, expected early November — confirm
+    the reporting date and all figures from {current_research}). CRITICAL
+    HONESTY RULE: this brief was written in August, BEFORE the quarter
+    closed. Every Q3 NUMBER must come from the research block with
+    attribution — never reuse a Q2 figure as if it were Q3, and never
+    invent a figure the research does not carry. Where the research gives
+    filing numbers, state them as fact; call quotes as call quotes;
+    analyst takes as opinion. If a number is missing, speak to the trend
+    and say the figure was not yet verified.
+
+    VERIFIED Q2 BASELINE (from the Q2 2026 release and 10-Q — the
+    comparison bar this episode measures Q3 against): revenue $7.814
+    billion (+92% YoY); net loss $541 million; adjusted EBITDA $3.538
+    billion; loss from operations $143 million (near breakeven — THE
+    number to re-check first in Q3); segments: Space $962 million revenue
+    with a $542 million operating loss (Starship R&D), Connectivity
+    $4.291 billion revenue with $1.656 billion operating income and 12.0
+    million Starlink subscribers at $66 ARPU, AI $2.561 billion revenue
+    (+247%) with its first positive adjusted EBITDA ($1.146 billion);
+    capex $18.369 billion in the quarter ($15.828 billion AI) with
+    management guiding the NEXT TWO QUARTERS similar — so Q3 capex
+    against that guidance is a headline question; ~$100 billion cash,
+    $47.5 billion backlog, $14.1 billion of Cloud Services Agreements
+    signed in Q2 with $6.7 billion more contracted to ramp from October
+    (per the CFO on the Q2 call); the CFO's "$100 billion annualized
+    recurring revenue pace by year end" projection is a CLAIM this
+    episode should score against Q3 actuals; Cursor ($60 billion
+    acquisition) was expected to close in Q3 — confirm whether it did
+    and how it reports; compute was 1.4 GW nameplate at Q2.
+
+    EPISODE SHAPE: (1) The headline Q3 numbers vs expectations and vs
+    the Q2 baseline above — did operating breakeven arrive? (2) Segment
+    by segment against Q2: Space (Starship flight cadence and R&D),
+    Connectivity (subscriber adds, ARPU trade, aviation/enterprise
+    momentum), AI (Cloud Services ramp including the October cohort,
+    compute GW growth, Cursor's first quarter inside if closed, X
+    advertising trend). (3) The capex question, round two: did the
+    "next two quarters look similar" guidance hold, what did operating
+    cash flow cover, and how did the market read it. (4) The
+    announcements and call moments, attributed. (5) The engineering
+    angle from first principles on whatever Q3's biggest build-out
+    number is. (6) The honest counterpoints: concentration, lockup /
+    supply, any cracks in the growth story the research surfaces. Same
+    voice as always: engineering-first, honest, never a stock promoter,
+    not financial advice.

--- a/tests/test_window_short_titles.py
+++ b/tests/test_window_short_titles.py
@@ -1,0 +1,117 @@
+"""Drift guards: complete headlines for window-titled dub Shorts (Aug 2026)
+plus the pre-staged spacex specials.
+
+Once the RU 3-Short band shipped, ~2/3 of @NerraRU's Short titles were
+mid-sentence transcript fragments («атмосферу. Успех станет…») — the
+2nd/3rd Short is titled from its window's opening speech, a mid-sentence
+slice by construction. ``engine.translate.headline_from_excerpt`` now asks
+Grok for ONE complete same-language headline grounded in the excerpt
+(never-invent), and both dub paths fall back to the legacy clause-trim on
+any failure. Title-only metadata — no audio touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import engine.translate as tr
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+RU_EXCERPT = (
+    "атмосферу. Успех станет первым возвращением верхней ступени с "
+    "орбитальной скорости с неповреждённым теплозащитным экраном, что "
+    "подтвердит текущий плиточный подход."
+)
+
+
+class TestHeadlineFromExcerpt:
+    def test_happy_path_returns_validated_headline(self, monkeypatch):
+        monkeypatch.setattr(
+            tr, "_generate",
+            lambda prompt, model, max_tokens:
+                "«Успех подтвердит плиточный теплозащитный экран Starship»")
+        out = tr.headline_from_excerpt(RU_EXCERPT, "ru", max_chars=70)
+        assert out == "Успех подтвердит плиточный теплозащитный экран Starship"
+
+    def test_wrong_script_result_rejected(self, monkeypatch):
+        # An English headline must never ship on @NerraRU — the same
+        # script guard the audio-translation path uses.
+        monkeypatch.setattr(
+            tr, "_generate",
+            lambda *a: "Starship heat shield survives first orbital return")
+        assert tr.headline_from_excerpt(RU_EXCERPT, "ru") == ""
+
+    def test_wildly_over_budget_rejected(self, monkeypatch):
+        monkeypatch.setattr(tr, "_generate", lambda *a: "х" * 300)
+        assert tr.headline_from_excerpt(RU_EXCERPT, "ru", max_chars=70) == ""
+
+    def test_short_excerpt_skips_llm_call(self, monkeypatch):
+        def _boom(*a):  # pragma: no cover
+            raise AssertionError("must not call the LLM for a stub excerpt")
+        monkeypatch.setattr(tr, "_generate", _boom)
+        assert tr.headline_from_excerpt("короткое", "ru") == ""
+        assert tr.headline_from_excerpt(RU_EXCERPT, "xx") == ""
+
+    def test_generate_failure_returns_empty(self, monkeypatch):
+        def _boom(*a):
+            raise RuntimeError("network down")
+        monkeypatch.setattr(tr, "_generate", _boom)
+        assert tr.headline_from_excerpt(RU_EXCERPT, "ru") == ""
+
+
+class TestDubWiring:
+    """Both dub paths try the headline first and KEEP the clause-trim
+    fallback — a Short must never ship untitled because Grok hiccuped."""
+
+    def test_ru_dub_uses_headline_with_fallback(self):
+        src = (PROJECT_ROOT / "engine" / "ru_dub.py").read_text()
+        assert "headline_from_excerpt" in src
+        # The legacy fallback trim of the raw excerpt must survive.
+        assert 'opening_text.rstrip("…").rstrip()' in src
+
+    def test_lang_dub_uses_headline_with_fallback(self):
+        src = (PROJECT_ROOT / "engine" / "lang_dub.py").read_text()
+        assert "headline_from_excerpt" in src
+        assert 'opening_text.rstrip("…").rstrip()' in src
+
+
+class TestPreStagedSpecials:
+    def test_queue_carries_both_specials_unproduced(self):
+        data = yaml.safe_load(
+            (PROJECT_ROOT / "shows" / "deep_dives" / "spacex.yaml").read_text())
+        by_id = {e["id"]: e for e in data["queue"]}
+        assert by_id["q2-2026-earnings"]["produced"] is True  # history intact
+        for eid in ("flight-14-catch-reaction", "q3-2026-earnings"):
+            e = by_id[eid]
+            assert e["produced"] is False
+            assert e["title"] and e["brief"]
+            assert e["web_search_queries"] and e["x_handles"]
+            # Manual-force only: no scheduling keys, so even if
+            # deep_dive.enabled ever flips true these cannot hijack a
+            # daily episode on their own.
+            assert "date" not in e and "when" not in e
+
+    def test_future_event_briefs_enforce_honesty(self):
+        """Both events post-date the brief's authorship — each brief must
+        pin its facts to the live research, never presume the outcome."""
+        data = yaml.safe_load(
+            (PROJECT_ROOT / "shows" / "deep_dives" / "spacex.yaml").read_text())
+        by_id = {e["id"]: e for e in data["queue"]}
+        f14 = by_id["flight-14-catch-reaction"]["brief"]
+        assert "{current_research}" in f14
+        assert "UNKNOWN" in f14
+        assert "Do not presume success" in f14
+        q3 = by_id["q3-2026-earnings"]["brief"]
+        assert "{current_research}" in q3
+        assert "never reuse a Q2 figure" in q3
+
+    def test_forced_pick_finds_both_and_unforced_finds_none(self):
+        from engine.topic_queue import pick_deep_dive_topic
+        q = PROJECT_ROOT / "shows" / "deep_dives" / "spacex.yaml"
+        assert pick_deep_dive_topic(q, "2026-08-07") is None
+        for eid in ("flight-14-catch-reaction", "q3-2026-earnings"):
+            t = pick_deep_dive_topic(q, "2026-08-07", force_id=eid)
+            assert t and t["id"] == eid


### PR DESCRIPTION
Implements the two operator-approved improvements from today's performance review.

## 1. RU/FR window-Short titles: complete headlines, not fragments

The 2nd/3rd Short on a dub channel is titled from its window's opening speech — a **mid-sentence slice by construction** — so once the RU 3-Short band shipped, ~2/3 of @NerraRU's daily Short titles were fragments («атмосферу. Успех станет…», «всего на 40% выше, чем…»). The clause-trim kept the *cut* grammatical but the title still *started* mid-thought. Same defect class as the EN fragment titles the July retitle pass fixed (11% → 1%), now on the network's highest-reach surface.

- New **`engine.translate.headline_from_excerpt(excerpt, lang, max_chars)`**: one cheap Grok call that turns the window's excerpt into a natural, complete same-language headline — grounded strictly in the excerpt (the never-invent rule), validated with the same refusal + wrong-script guards as the audio-translation path (an English title must never ship on @NerraRU), and rejected if wildly over budget.
- **Both dub paths** (`ru_dub.py` + `lang_dub.py`) try the headline first, then run the result through the existing clause-trim for the char budget; **any failure keeps the legacy fragment-trim path** so a Short never ships untitled.
- Title-only metadata — no audio touched (outside the landmine-#17 A/B gate, same contract as the `youtube_titles` loop). Cost ≈ one ~200-token call per window-titled Short, ~5/day network-wide.

## 2. Two pre-staged specials in the spacex deep-dive queue

The Q2 earnings special validated the playbook (queue entry + verified brief + live web/X research + one Actions dispatch); these bank the two known upcoming catalysts. Both are **manual-force only** — `deep_dive.enabled` stays false and neither entry carries `date`/`when` keys, so the daily cron can never fire them:

- **`flight-14-catch-reaction`** — the historic upper-stage tower-catch attempt (tentatively end of August, per the Q2 call). Run it day-of, *whatever happens*: the brief carries only verified context (Flights 12/13, the catch plan, the cadence quote) and hard-requires the outcome to come from `{current_research}` — explicit "Do not presume success; do not soften a failure; a scrub is its own honest episode" rules, plus the name-the-stage discipline. The engineering centerpiece (why a Ship catch is orders harder than a booster catch, and why no-legs + same-day re-stack is the 99% cost-to-orbit thesis) is pre-written since that physics doesn't depend on the outcome.
- **`q3-2026-earnings`** — the second public quarter (expected early Nov; date confirmed from research at run time). The brief's spine is the **verified Q2 baseline as the comparison bar** — including the near-breakeven operating loss to re-check first, the "next two quarters look similar" capex guidance to score, the $6.7B October cloud-revenue ramp, and the CFO's $100B-ARR-pace claim to grade against actuals — with a hard "never reuse a Q2 figure as if it were Q3" rule. Operator pre-flight note included: paste the Q3 filing numbers into the brief before dispatching if available, exactly like Q2.

Dispatch for either: **Actions → Run Podcast Show → `show: spacex` + `deep_dive: <id>`**.

## Verification

- New `tests/test_window_short_titles.py`: headline validation (happy path, wrong-script rejection, over-budget rejection, stub-excerpt short-circuit, network-failure fallback), fallback wiring pinned in both dub paths, queue shape (q2 history intact, both specials unproduced with no scheduling keys, honesty rules present in the briefs, forced/unforced pick semantics).
- 239 tests pass across the affected suites (`test_ru_dub`, `test_lang_dub`, `test_deep_dive`, `test_multilingual`, `test_spacex_show`, new file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_