### PR TITLE
Dashboard: Growth levers section — channel trends, experiments register, stagger health, specials queue, freshness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1679,6 +1679,13 @@ podcast directory, and nothing in the pipeline fetches its own
 **Operator's first stop:** the live state of every landmine below is rendered
 by [`management.html`](management.html), fed by
 [`scripts/generate_dashboard.py`](scripts/generate_dashboard.py) → `api/dashboard.json`.
+The dashboard's **Growth levers** section (Aug 2026) renders the per-channel
+WoW scorecard, staggered-Shorts/sweep health, the specials queue, analytics
+freshness (alerts past 36h — the Aug 6 outage staleness lesson), and the
+experiments register: **every change shipped to move a number gets an entry
+in [`docs/experiments.yaml`](docs/experiments.yaml)** with its readout date
+and (where supported) a live metric key — a typo'd metric name fails CI
+(`tests/test_dashboard_growth.py`).
 Items 7 and 10 are intentionally excluded from the dashboard (per an explicit
 decision); everything else has a live status card.
 

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -1,0 +1,124 @@
+# Growth levers in flight — the dashboard's experiments registry.
+#
+# Every change that was shipped TO MOVE A NUMBER gets an entry here the
+# day it ships, with the date the result becomes readable and (where the
+# generator supports it) a named live metric so the dashboard can show
+# the current value against the baseline. This makes "what are we testing
+# and when do we decide" a rendered surface instead of tribal knowledge —
+# the same discipline as the review ledgers, applied to growth work.
+#
+# Consumed by scripts/generate_dashboard.py::build_experiments_section.
+# Schema per entry:
+#   id:        unique slug
+#   title:     short human name
+#   area:      retention | reach | subscribers | funnel | quality
+#   shipped:   YYYY-MM-DD the change reached production
+#   readout:   YYYY-MM-DD the earliest honest read (or decision date)
+#   status:    reading   — accruing data, do not stack another change on
+#                          the same metric until readout
+#              decide    — readout date is a DECISION with criteria below
+#              done      — resolved; keep for the record, dashboard greys it
+#   metric:    (optional) live-metric key the generator computes:
+#                long_form_median_avp_en_14d   — EN long-form median
+#                                                averageViewPercentage, 14d
+#                fr_short_vpd_max              — best FR short_vpd (policy)
+#                ru_short_vpd_max              — best RU short_vpd (policy)
+#                channel_views_wow_ru          — RU channel views, last 7d
+#                                                vs prior 7d (%)
+#                channel_views_wow_en          — same for EN
+#                dub_fragment_title_share_14d  — share of RU/FR window-
+#                                                Short titles starting
+#                                                mid-sentence, 14d
+#              Unknown/absent metric renders as null — never 0.
+#   baseline:  (optional) the number when the change shipped
+#   target:    (optional) what success looks like
+#   criteria:  (optional, decide entries) the decision rule
+#   notes:     (optional) one line of context
+#
+# Prune done entries older than ~a quarter.
+
+experiments:
+  - id: cold-open-retention
+    title: "Cold open — hook is the first thing spoken"
+    area: retention
+    shipped: 2026-07-30
+    readout: 2026-08-15
+    status: reading
+    metric: long_form_median_avp_en_14d
+    baseline: 11.3
+    target: "long-form median AVP off the ~11% floor"
+    notes: >
+      Ten seconds of theme + a 35-word greeting used to push the first
+      fact to ~second 28; Shorts (which skip the intro) hold ~42% on the
+      same audio. Audio change — was A/B-listened per landmine #17.
+
+  - id: staggered-shorts
+    title: "Staggered Shorts — #1 at publish, rest at channel prime time"
+    area: reach
+    shipped: 2026-08-06
+    readout: 2026-08-13
+    status: reading
+    metric: channel_views_wow_ru
+    target: "RU/EN Short views up WoW with unchanged supply"
+    notes: >
+      publishAt scheduling; EN 17/21/23 UTC, RU 15/18/20, FR 17/19/21.
+      First full day 2026-08-07. Confounder note: reads channel views,
+      so a big news day can mask it — check views-per-video too.
+
+  - id: ru-3-short-band
+    title: "RU 3-Short band on spacex + FF"
+    area: reach
+    shipped: 2026-07-30
+    readout: 2026-08-13
+    status: reading
+    metric: ru_short_vpd_max
+    baseline: 60.9
+    target: "short_vpd holds or grows with 50% more supply"
+    notes: >
+      The supply ladder's 20-vpd band. If vpd holds while supply grew,
+      the audience wasn't saturated; if it drops proportionally, it was.
+
+  - id: dub-window-headlines
+    title: "Complete headlines for RU/FR window-Shorts"
+    area: quality
+    shipped: 2026-08-07
+    readout: 2026-08-14
+    status: reading
+    metric: dub_fragment_title_share_14d
+    baseline: 0.66
+    target: "fragment share of window-Short titles near zero"
+    notes: >
+      Was ~2/3 of @NerraRU Short titles once the 3-Short band shipped
+      (mid-sentence transcript slices). Grok headline w/ clause-trim
+      fallback; title-only metadata.
+
+  - id: fr-channel-decision
+    title: "@NerraFR — keep or pause the dub channel"
+    area: reach
+    shipped: 2026-07-21
+    readout: 2026-08-25
+    status: decide
+    metric: fr_short_vpd_max
+    baseline: 0.26
+    criteria: >
+      Keep if any FR show reaches short_vpd >= 1.0 or organic subscriber
+      traction appears by 2026-08-25; else pause FR dubs
+      (youtube.dub_languages: [] on the four shows — one line,
+      reversible). FR PODCAST tracks are decided separately via the
+      per-language OP3 instrument.
+    notes: >
+      53 of 72 launch-window uploads had zero recorded views. Clean
+      analytics only since 2026-07-29 (the glob fix), hence the late
+      decision date rather than a same-day verdict.
+
+  - id: earnings-special-format
+    title: "Event specials — earnings/flight reaction episodes"
+    area: reach
+    shipped: 2026-08-05
+    readout: 2026-08-12
+    status: reading
+    target: "special out-performs the daily episodes around it"
+    notes: >
+      Ep059 (Q2 earnings) is the pilot: compare its 7d views/downloads
+      against Ep057/058/060. flight-14-catch-reaction and
+      q3-2026-earnings are pre-staged in the spacex deep-dive queue.

--- a/engine/shorts_stagger.py
+++ b/engine/shorts_stagger.py
@@ -223,6 +223,7 @@ def post_due_comments(
             continue
         keep = []
         changed = False
+        posted_here = 0
         for entry in data.get("pending", []):
             try:
                 due = _dt.datetime.strptime(
@@ -267,12 +268,19 @@ def post_due_comments(
                 cid = None
             if cid:
                 stats["posted"] += 1
+                posted_here += 1
                 changed = True
             else:
                 keep.append(entry)
                 stats["kept"] += 1
         if changed or len(keep) != len(data.get("pending", [])):
             try:
+                # Rolling per-show counter for the dashboard's stagger-
+                # health card — pending entries vanish once posted, so
+                # without this the sidecar carries no evidence the sweep
+                # ever worked.
+                data["posted_total"] = (
+                    int(data.get("posted_total", 0) or 0) + posted_here)
                 data["pending"] = keep
                 path.write_text(
                     json.dumps(data, ensure_ascii=False, indent=1) + "\n",

--- a/management.html
+++ b/management.html
@@ -308,6 +308,11 @@
     <div class="card-grid" id="audience-grid"></div>
   </section>
 
+  <section class="mc-section" id="growth-levers" data-ops>
+    <h2>Growth levers — trends, experiments &amp; specials <span class="pill-note" id="levers-pill"></span></h2>
+    <div class="card-grid" id="levers-grid"></div>
+  </section>
+
   <section class="mc-section" id="distribution">
     <h2>Distribution — directories &amp; publishing policy <span class="pill-note" id="distribution-pill"></span></h2>
     <div class="card-grid" id="distribution-grid"></div>
@@ -1038,6 +1043,186 @@
       if (sp.fetched_at) card.appendChild(h("p", { class: "fine-list", text: "fetched " + ageText(sp.fetched_at) + staleNote(sp.fetched_at) }));
     }
     audGrid.appendChild(card);
+  }
+
+  // ---------- growth levers: trends, experiments, stagger, specials ----------
+  {
+    const growth = data.growth || {};
+    const grid = $("#levers-grid");
+    const sc = growth.channel_scorecard || {};
+    const ex = growth.experiments || {};
+    const stg = growth.shorts_stagger || {};
+    const specials = growth.specials || {};
+    const fresh = growth.freshness || {};
+
+    const pill = $("#levers-pill");
+    const reading = (ex.experiments || []).filter((r) => r.status !== "done").length;
+    pill.textContent = reading ? reading + " levers in flight" : "";
+
+    // Channel scorecard — the channel race, trending.
+    {
+      const card = sectionCard("Channel scorecard",
+        "WoW trends · " + (sc.as_of ? "data " + ageText(sc.as_of) : "no data"));
+      if (!sc.configured) {
+        card.appendChild(h("p", { class: "fine-list",
+          text: "No api/youtube_stats.json yet." }));
+      } else {
+        const chName = (ch) => ch === "ru" ? "@NerraRU" : ch === "fr" ? "@NerraFR"
+          : ch === "en" ? "@NerraNetwork" : ch;
+        Object.keys(sc.channels || {}).sort().forEach((ch) => {
+          const c = sc.channels[ch];
+          const wow = c.views_wow_pct;
+          const wowTxt = (wow === null || wow === undefined) ? "—"
+            : (wow > 0 ? "+" : "") + wow + "%";
+          const wowCls = (wow === null || wow === undefined) ? ""
+            : (wow >= 0 ? "up" : "down");
+          const head = h("div", { style: "margin-top:10px;font-size:13px;" });
+          head.appendChild(h("strong", { text: chName(ch) }));
+          head.appendChild(h("span", { style: "margin-left:8px;color:var(--ink-2);",
+            text: compact(c.views_7d) + " views/7d " }));
+          head.appendChild(h("span", { class: "t-delta " + wowCls,
+            text: wowTxt + " WoW" }));
+          head.appendChild(h("span", { style: "margin-left:8px;color:var(--ink-2);",
+            text: "· " + fmtOrDash(c.subscribers) + " subs (net " +
+                  (c.subs_net_7d >= 0 ? "+" : "") + c.subs_net_7d + "/7d)" }));
+          card.appendChild(head);
+          const kinds = c.views_per_video_14d || {};
+          const vv = (k) => (kinds[k] && kinds[k].views_per_video != null)
+            ? kinds[k].views_per_video : "—";
+          const zero = c.zero_view_share_14d;
+          const zeroTxt = (zero === null || zero === undefined) ? "—"
+            : Math.round(zero * 100) + "%";
+          card.appendChild(h("div", { class: "fine-list",
+            style: (zero != null && zero > 0.5)
+              ? "color:var(--status-warn);" : "",
+            text: "views/video 14d: short " + vv("short") + " · long " + vv("long")
+                  + " · uploads " + c.uploads_14d
+                  + " · zero-view share " + zeroTxt }));
+        });
+        card.appendChild(h("p", { class: "fine-list", text: sc.window_note || "" }));
+      }
+      grid.appendChild(card);
+    }
+
+    // Experiments in flight — the continuous-improvement register.
+    {
+      const card = sectionCard("Levers in flight",
+        "docs/experiments.yaml · one variable at a time");
+      if (!ex.configured) {
+        card.appendChild(h("p", { class: "fine-list",
+          text: "No docs/experiments.yaml registry yet." }));
+      } else {
+        (ex.experiments || []).forEach((r) => {
+          const row = h("div", { style: "margin-top:10px;font-size:12.5px;"
+            + (r.status === "done" ? "opacity:.55;" : "") });
+          const chip = r.overdue
+            ? "<span class='t-delta down'>readout overdue</span>"
+            : (r.days_to_readout != null
+                ? "<span style='color:var(--ink-3)'>" +
+                  (r.status === "decide" ? "decision" : "readout") + " in " +
+                  r.days_to_readout + "d</span>"
+                : "");
+          row.appendChild(h("div", { html:
+            "<strong>" + r.title + "</strong> " + chip }));
+          let m = "";
+          if (r.metric) {
+            m = r.metric + ": <span class='k'>" +
+                (r.value === null || r.value === undefined ? "no data yet" : r.value) +
+                "</span>" +
+                (r.baseline != null ? " (baseline " + r.baseline + ")" : "");
+          }
+          const tail = [m, r.target ? "target: " + r.target : "",
+                        r.criteria ? "decision rule: " + r.criteria : ""]
+            .filter(Boolean).join(" · ");
+          if (tail) row.appendChild(h("div", { class: "fine-list", html: tail }));
+          card.appendChild(row);
+        });
+        card.appendChild(h("p", { class: "fine-list", text:
+          "Every change shipped to move a number registers here with its " +
+          "readout date. Values are live; 'no data yet' is honest, not zero." }));
+      }
+      grid.appendChild(card);
+    }
+
+    // Staggered Shorts + deferred comments health.
+    {
+      const card = sectionCard("Staggered Shorts",
+        "publishAt scheduling + deferred funnel comments");
+      if (!stg.configured) {
+        card.appendChild(h("p", { class: "fine-list",
+          text: "No scheduled_comments sidecars yet — first multi-Short " +
+                "episode after the Aug 6 rollout populates this." }));
+      } else {
+        card.appendChild(h("div", { style: "font-size:13px;margin-top:6px;", html:
+          "<span class='k'>" + stg.pending_total + "</span> comment(s) queued · " +
+          "<span class='k'>" + stg.posted_total + "</span> posted by sweeps" +
+          (stg.max_overdue_hours != null
+            ? " · oldest overdue " + stg.max_overdue_hours + "h"
+            : "") }));
+        if (stg.sweep_stuck) {
+          card.appendChild(h("div", { class: "alert warn",
+            style: "margin-top:8px;font-size:12.5px;",
+            text: "Sweep looks stuck (>48h overdue) — check multilingual/" +
+                  "nightly runs and channel tokens." }));
+        }
+        (stg.shows || []).forEach((s) => {
+          const row = h("div", { class: "bar-row" });
+          row.appendChild(h("div", { class: "label", text: s.slug }));
+          row.appendChild(h("div", { class: "value", style: "flex:1;text-align:right;",
+            text: s.pending + " queued · " + s.posted_total + " posted" +
+                  (s.max_overdue_hours != null ? " · " + s.max_overdue_hours + "h overdue" : "") }));
+          card.appendChild(row);
+        });
+        card.appendChild(h("p", { class: "fine-list", text: stg.note || "" }));
+      }
+      grid.appendChild(card);
+    }
+
+    // Specials queue — event episodes ready to dispatch.
+    {
+      const card = sectionCard("Specials queue",
+        "deep-dive episodes · " + ((specials.pending || []).length) + " ready");
+      if (!specials.configured) {
+        card.appendChild(h("p", { class: "fine-list", text: "No deep-dive queues." }));
+      } else {
+        (specials.pending || []).forEach((r) => {
+          const row = h("div", { style: "margin-top:8px;font-size:12.5px;", html:
+            "<strong>" + r.show + "</strong> · <code>" + r.id + "</code><br>" +
+            "<span style='color:var(--ink-2)'>" + (r.title || "") + "</span>" });
+          card.appendChild(row);
+        });
+        if ((specials.produced || []).length) {
+          card.appendChild(h("p", { class: "fine-list", html:
+            "Produced: " + specials.produced.map((r) =>
+              r.id + (r.episode_number ? " (Ep" + r.episode_number + ")" : "")
+            ).join(" · ") }));
+        }
+        card.appendChild(h("p", { class: "fine-list", html:
+          "Dispatch: <code>" + (specials.dispatch_hint || "") + "</code>" }));
+      }
+      grid.appendChild(card);
+    }
+
+    // Data freshness — staleness is a rendered fact now.
+    {
+      const card = sectionCard("Analytics freshness",
+        "warn past " + (fresh.warn_after_hours || 36) + "h");
+      const src = fresh.sources || {};
+      Object.keys(src).sort().forEach((name) => {
+        const s = src[name];
+        const stale = s.age_hours != null && s.age_hours > (fresh.warn_after_hours || 36);
+        const row = h("div", { class: "bar-row" });
+        row.appendChild(h("div", { class: "label", text: name }));
+        row.appendChild(h("div", { class: "value",
+          style: "flex:1;text-align:right;" + (stale ? "color:var(--status-warn);" : ""),
+          text: s.age_hours == null ? "missing" : s.age_hours + "h old" }));
+        card.appendChild(row);
+      });
+      card.appendChild(h("p", { class: "fine-list", text:
+        "The Aug 6 outage made every downstream number silently a day stale " +
+        "— staleness is now visible here and alerts past the threshold." }));
+      grid.appendChild(card);
+    }
   }
 
   // ---------- distribution: directories + publishing policy ----------

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1799,6 +1799,379 @@ def aggregate_mit_performance(root: Path) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Growth levers (Aug 2026) — channel trends, experiments in flight, stagger
+# health, specials queue, data freshness. Everything here follows the funnel
+# report's honesty rules: an unmeasured value is None, never 0, and every
+# approximation says so in a note the card renders.
+# ---------------------------------------------------------------------------
+
+def _load_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _parse_iso(ts: str) -> Optional[_dt.datetime]:
+    try:
+        return _dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _iter_video_index_rows(root: Path):
+    """Yield every row from every per-show video index (all channels).
+
+    The indexes are the ONLY complete upload record — the Analytics API
+    omits videos with zero activity, which is exactly how 53 of 72 FR
+    launch uploads were invisible until Aug 2026. Dashboard math that
+    needs "how many did we PUBLISH" must come from here, never from
+    analytics rows.
+    """
+    for idx in sorted(root.glob("digests/*/youtube_videos*.json")):
+        data = _load_json(idx)
+        if not data:
+            continue
+        for v in data.get("videos", []):
+            if isinstance(v, dict):
+                yield v
+
+
+def build_channel_scorecard(root: Path) -> Dict[str, Any]:
+    """Per-channel week-over-week trend card (EN / RU / FR).
+
+    The Aug 2026 review's headline (RU gaining ~9x EN's daily views on
+    45% of the uploads; FR at ~zero) lived only in a one-off doc — this
+    makes the channel race a permanent, trending surface. WoW deltas are
+    the continuous-improvement signal; the zero-view share is the
+    early-warning the FR launch lacked.
+    """
+    section: Dict[str, Any] = {"configured": False}
+    stats = _load_json(root / "api" / "youtube_stats.json")
+    if not stats or not stats.get("channels"):
+        return section
+    anchor = _parse_iso(stats.get("generated") or "")
+    anchor_d = (anchor.date() if anchor else _dt.date.today())
+    hist = _load_json(root / "api" / "youtube_channel_history.json") or {}
+    hist_rows = hist.get("rows", [])
+
+    # Complete upload counts (14d window ending at the analytics anchor)
+    # from the indexes; analytics rows for the same window from stats.
+    win_lo = (anchor_d - _dt.timedelta(days=14)).isoformat()
+    win_hi = anchor_d.isoformat()
+    uploads: Dict[str, int] = {}
+    for v in _iter_video_index_rows(root):
+        pub = str(v.get("published") or "")[:10]
+        if win_lo <= pub <= win_hi:
+            ch = str(v.get("channel") or "en")
+            uploads[ch] = uploads.get(ch, 0) + 1
+    rows_seen: Dict[str, int] = {}
+    vpv: Dict[str, Dict[str, Any]] = {}
+    for show in (stats.get("shows") or {}).values():
+        for v in show.get("videos", []):
+            pub = str(v.get("published") or "")[:10]
+            if not (win_lo <= pub <= win_hi):
+                continue
+            ch = str(v.get("channel") or "en")
+            rows_seen[ch] = rows_seen.get(ch, 0) + 1
+            kind = "short" if v.get("kind") == "short" else "long"
+            b = vpv.setdefault(ch, {}).setdefault(kind, {"n": 0, "views": 0})
+            b["n"] += 1
+            b["views"] += int(v.get("views") or 0)
+
+    channels_out: Dict[str, Any] = {}
+    for ch, c in (stats.get("channels") or {}).items():
+        ds = [d for d in (c.get("day_series") or []) if isinstance(d, dict)]
+        last7 = ds[-7:]
+        prior7 = ds[-14:-7]
+        v7 = sum(int(d.get("views") or 0) for d in last7)
+        vp7 = sum(int(d.get("views") or 0) for d in prior7)
+        subs7 = sum(int(d.get("subscribersGained") or 0)
+                    - int(d.get("subscribersLost") or 0) for d in last7)
+        subsp7 = sum(int(d.get("subscribersGained") or 0)
+                     - int(d.get("subscribersLost") or 0) for d in prior7)
+        up = uploads.get(ch, 0)
+        seen = rows_seen.get(ch, 0)
+        zero_share = (max(0.0, 1.0 - seen / up) if up else None)
+        per_kind = {}
+        for kind, b in (vpv.get(ch) or {}).items():
+            per_kind[kind] = {
+                "n": b["n"],
+                "views_per_video": round(b["views"] / b["n"], 1) if b["n"] else None,
+            }
+        channels_out[ch] = {
+            "subscribers": c.get("subscribers"),
+            "views_7d": v7,
+            "views_prior_7d": vp7,
+            "views_wow_pct": (round(100.0 * (v7 - vp7) / vp7, 1) if vp7 else None),
+            "subs_net_7d": subs7,
+            "subs_net_prior_7d": subsp7,
+            "uploads_14d": up,
+            "analytics_rows_14d": seen,
+            "zero_view_share_14d": (round(zero_share, 2)
+                                    if zero_share is not None else None),
+            "views_per_video_14d": per_kind,
+        }
+    # Subscriber trajectory from the committed history (per channel).
+    subs_series: Dict[str, list] = {}
+    for r in hist_rows:
+        ch = str(r.get("channel") or "")
+        if ch:
+            subs_series.setdefault(ch, []).append(
+                [r.get("date"), r.get("subscribers")])
+    section = {
+        "configured": True,
+        "as_of": stats.get("generated"),
+        "window_note": (
+            "WoW = last 7 analytics days vs the 7 before, anchored to the "
+            "analytics fetch. zero_view_share compares INDEX uploads (the "
+            "complete record) with analytics rows — the API omits zero-"
+            "activity videos, so this is the FR-launch early warning."),
+        "channels": channels_out,
+        "subscriber_series": {ch: s[-30:] for ch, s in subs_series.items()},
+    }
+    return section
+
+
+_EXPERIMENT_STATUSES = {"reading", "decide", "done"}
+
+
+def _experiment_live_metrics(root: Path) -> Dict[str, Any]:
+    """Compute the small closed vocabulary of live experiment metrics.
+
+    A metric that cannot be computed is None — the card must say
+    "no data yet", never fake a zero (the funnel report's rule).
+    """
+    out: Dict[str, Any] = {}
+    stats = _load_json(root / "api" / "youtube_stats.json") or {}
+    anchor = _parse_iso(stats.get("generated") or "")
+    anchor_d = (anchor.date() if anchor else _dt.date.today())
+    win_lo = (anchor_d - _dt.timedelta(days=14)).isoformat()
+
+    # EN long-form median retention over the last 14 analytics days.
+    avps = []
+    for show in (stats.get("shows") or {}).values():
+        for v in show.get("videos", []):
+            if (v.get("kind") == "long" and (v.get("channel") or "en") == "en"
+                    and str(v.get("published") or "")[:10] >= win_lo
+                    and v.get("average_view_percentage") is not None):
+                avps.append(float(v["average_view_percentage"]))
+    avps.sort()
+    out["long_form_median_avp_en_14d"] = (
+        round(avps[len(avps) // 2], 1) if avps else None)
+
+    # Channel views WoW from the day series.
+    for ch in ("en", "ru"):
+        ds = ((stats.get("channels") or {}).get(ch) or {}).get("day_series") or []
+        v7 = sum(int(d.get("views") or 0) for d in ds[-7:])
+        vp7 = sum(int(d.get("views") or 0) for d in ds[-14:-7])
+        out[f"channel_views_wow_{ch}"] = (
+            round(100.0 * (v7 - vp7) / vp7, 1) if vp7 else None)
+
+    # Best short_vpd per channel from the adaptive policy.
+    policy = _load_json(root / "api" / "youtube_policy.json") or {}
+    for ch in ("fr", "ru"):
+        vals = [v.get("short_vpd")
+                for v in ((policy.get("channels") or {}).get(ch) or {}).values()
+                if isinstance(v, dict) and v.get("short_vpd") is not None]
+        out[f"{ch}_short_vpd_max"] = (round(max(vals), 2) if vals else None)
+
+    # Fragment share of RU/FR window-Short titles (2nd/3rd Shorts) in the
+    # last 14 days. Heuristic mirror of the defect: a title whose first
+    # letter is lowercase started mid-sentence.
+    frag = total = 0
+    for v in _iter_video_index_rows(root):
+        if v.get("kind") != "short":
+            continue
+        if (v.get("channel") or "en") not in ("ru", "fr"):
+            continue
+        if str(v.get("published") or "")[:10] < win_lo:
+            continue
+        title = str(v.get("title") or "").strip()
+        m = re.search(r"[A-Za-zА-Яа-яЁё]", title)
+        if not m:
+            continue
+        total += 1
+        if m.group(0).islower():
+            frag += 1
+    out["dub_fragment_title_share_14d"] = (
+        round(frag / total, 2) if total else None)
+    return out
+
+
+def build_experiments_section(root: Path) -> Dict[str, Any]:
+    """Levers in flight — docs/experiments.yaml + live metric snapshots.
+
+    The registry is the discipline ('one variable at a time; know your
+    readout date before you ship'); the dashboard renders it so decision
+    dates cannot silently slip past.
+    """
+    section: Dict[str, Any] = {"configured": False}
+    path = root / "docs" / "experiments.yaml"
+    if not path.exists():
+        return section
+    try:
+        import yaml as _yaml
+        data = _yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        entries = data.get("experiments") or []
+        metrics = _experiment_live_metrics(root)
+        today = _dt.date.today()
+        rows = []
+        for e in entries:
+            if not isinstance(e, dict) or not e.get("id"):
+                continue
+            readout = None
+            try:
+                readout = _dt.date.fromisoformat(str(e.get("readout")))
+            except Exception:  # noqa: BLE001
+                pass
+            status = str(e.get("status") or "reading")
+            days = (readout - today).days if readout else None
+            rows.append({
+                "id": e.get("id"),
+                "title": e.get("title"),
+                "area": e.get("area"),
+                "shipped": e.get("shipped"),
+                "readout": e.get("readout"),
+                "status": (status if status in _EXPERIMENT_STATUSES
+                           else "reading"),
+                "days_to_readout": days,
+                "overdue": bool(readout and days is not None and days < 0
+                                and status != "done"),
+                "metric": e.get("metric"),
+                "baseline": e.get("baseline"),
+                "value": metrics.get(str(e.get("metric") or "")),
+                "target": e.get("target"),
+                "criteria": e.get("criteria"),
+                "notes": e.get("notes"),
+            })
+        rows.sort(key=lambda r: (r["status"] == "done", r["readout"] or "9999"))
+        section = {
+            "configured": True,
+            "registry": "docs/experiments.yaml",
+            "experiments": rows,
+            "overdue_count": sum(1 for r in rows if r["overdue"]),
+        }
+    except Exception as exc:  # noqa: BLE001
+        section = {"configured": True, "error": str(exc)}
+    return section
+
+
+def build_stagger_section(root: Path) -> Dict[str, Any]:
+    """Staggered-Shorts health: is the feature engaged, and is the
+    deferred-comment sweep keeping up?
+
+    A pending comment whose publish time passed > 48h ago means the sweep
+    is broken (tokens, workflow, or the whitelist landmine) — that gets a
+    warning the alert band picks up, because a silently-dead sweep is a
+    silent funnel degradation.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+    shows_out = []
+    pending_total = posted_total = 0
+    oldest_overdue_h: Optional[float] = None
+    for path in sorted(root.glob("digests/*/scheduled_comments.json")):
+        data = _load_json(path)
+        if data is None:
+            continue
+        pend = [e for e in data.get("pending", []) if isinstance(e, dict)]
+        posted = int(data.get("posted_total", 0) or 0)
+        overdue_h = None
+        for e in pend:
+            due = _parse_iso(e.get("publish_at") or "")
+            if due and due < now:
+                h = (now - due).total_seconds() / 3600.0
+                overdue_h = max(overdue_h or 0.0, h)
+        shows_out.append({
+            "slug": path.parent.name,
+            "pending": len(pend),
+            "posted_total": posted,
+            "max_overdue_hours": (round(overdue_h, 1)
+                                  if overdue_h is not None else None),
+        })
+        pending_total += len(pend)
+        posted_total += posted
+        if overdue_h is not None:
+            oldest_overdue_h = max(oldest_overdue_h or 0.0, overdue_h)
+    stuck = bool(oldest_overdue_h and oldest_overdue_h > 48)
+    return {
+        "configured": bool(shows_out),
+        "shows": shows_out,
+        "pending_total": pending_total,
+        "posted_total": posted_total,
+        "max_overdue_hours": (round(oldest_overdue_h, 1)
+                              if oldest_overdue_h is not None else None),
+        "sweep_stuck": stuck,
+        "note": ("Comments queue while a scheduled Short is private and are "
+                 "posted by the multilingual/nightly sweeps once it goes "
+                 "public. Entries kept 7 days; overdue > 48h = sweep broken."),
+    }
+
+
+def build_specials_section(root: Path) -> Dict[str, Any]:
+    """Deep-dive specials queues — produced history + ready-to-dispatch."""
+    produced, pending = [], []
+    for path in sorted(root.glob("shows/deep_dives/*.yaml")):
+        data = None
+        try:
+            import yaml as _yaml
+            data = _yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            continue
+        show = path.stem
+        for e in (data or {}).get("queue", []):
+            if not isinstance(e, dict):
+                continue
+            row = {"show": show, "id": e.get("id"), "title": e.get("title"),
+                   "category": e.get("category")}
+            if e.get("produced"):
+                row["episode_number"] = e.get("episode_number")
+                row["produced_date"] = e.get("produced_date")
+                produced.append(row)
+            else:
+                pending.append(row)
+    produced.sort(key=lambda r: str(r.get("produced_date") or ""), reverse=True)
+    return {
+        "configured": bool(produced or pending),
+        "pending": pending,
+        "produced": produced[:8],
+        "dispatch_hint": ("Actions → Run Podcast Show → show=<show> + "
+                          "deep_dive=<id>"),
+    }
+
+
+def build_freshness_section(root: Path) -> Dict[str, Any]:
+    """Age of every analytics input, with a warning past 36h.
+
+    The Aug 6 GitHub outage killed a nightly and every downstream number
+    silently went a day stale — the operator had no surface saying so.
+    Staleness is now a rendered fact, and > 36h raises an alert.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+    sources = {
+        "youtube_stats": ("api/youtube_stats.json", "generated"),
+        "youtube_policy": ("api/youtube_policy.json", "generated"),
+        "op3_stats": ("api/op3_stats.json", "fetched_at"),
+        "funnel": ("api/funnel.json", "generated_at"),
+    }
+    out: Dict[str, Any] = {}
+    stale = []
+    for name, (rel, key) in sources.items():
+        data = _load_json(root / rel)
+        ts = _parse_iso((data or {}).get(key) or "")
+        if ts is None:
+            out[name] = {"age_hours": None, "as_of": None}
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=_dt.timezone.utc)
+        age = round((now - ts).total_seconds() / 3600.0, 1)
+        out[name] = {"age_hours": age, "as_of": ts.isoformat()}
+        if age > 36:
+            stale.append(f"{name} is {age:.0f}h old")
+    return {"sources": out, "stale": stale, "warn_after_hours": 36}
+
+
 def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optional[int] = None) -> Dict[str, Any]:
     shows = load_shows_from_yaml(root / "shows", root)
     rss = audit_rss_enclosures(root, offline=offline)
@@ -1843,6 +2216,34 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
 
     alerts = extract_critical_alerts(landmines, costs)
 
+    # Growth-lever alerts (Aug 2026): a stuck comment sweep and stale
+    # analytics are both silent-degradation classes this week surfaced —
+    # they belong in the band, not buried in a card.
+    stagger = build_stagger_section(root)
+    freshness = build_freshness_section(root)
+    if stagger.get("sweep_stuck"):
+        alerts.append({
+            "severity": "warn",
+            "message": (f"Scheduled-Short comment sweep looks stuck: oldest "
+                        f"queued comment is {stagger.get('max_overdue_hours')}h "
+                        "past its Short's publish time (check the multilingual/"
+                        "nightly sweep + channel tokens)."),
+        })
+    for msg in freshness.get("stale", []):
+        alerts.append({
+            "severity": "warn",
+            "message": f"Analytics staleness: {msg} — downstream cards and "
+                       "the adaptive policy are reading old data.",
+        })
+    experiments = build_experiments_section(root)
+    if experiments.get("overdue_count"):
+        alerts.append({
+            "severity": "warn",
+            "message": (f"{experiments['overdue_count']} experiment(s) past "
+                        "their readout date in docs/experiments.yaml — read "
+                        "the result and update status, or the discipline rots."),
+        })
+
     audience = build_audience_section(root)
     efficiency = build_efficiency_section(costs, audience)
 
@@ -1866,6 +2267,14 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "distribution": build_distribution_section(root),
         "youtube_policy": build_youtube_policy_section(root),
         "funnel": build_funnel_section(root),
+        # Growth levers (Aug 2026): trends, experiments, stagger, specials.
+        "growth": {
+            "channel_scorecard": build_channel_scorecard(root),
+            "experiments": experiments,
+            "shorts_stagger": stagger,
+            "specials": build_specials_section(root),
+            "freshness": freshness,
+        },
     }
 
 

--- a/tests/test_dashboard_growth.py
+++ b/tests/test_dashboard_growth.py
@@ -1,0 +1,133 @@
+"""Drift guards for the growth-levers dashboard section (Aug 2026).
+
+Five surfaces added after the Aug 5-7 week of growth work: the per-channel
+WoW scorecard (with the zero-view early warning the FR launch lacked), the
+experiments-in-flight register (docs/experiments.yaml with live metric
+snapshots), staggered-Shorts / deferred-comment sweep health, the specials
+queue, and analytics freshness (the Aug 6 outage made every number
+silently a day stale — never again silently).
+
+Honesty rules under test: unmeasured values are None (never 0), the
+zero-view share compares INDEX uploads with analytics rows (the API omits
+zero-activity videos), and every registry metric name must be one the
+generator can actually compute — a typo'd metric must fail CI, not render
+"no data yet" forever.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import generate_dashboard as gd  # noqa: E402
+
+
+class TestChannelScorecard:
+    def test_configured_with_channels_and_honest_fields(self):
+        sc = gd.build_channel_scorecard(ROOT)
+        assert sc["configured"] is True
+        assert "en" in sc["channels"] and "ru" in sc["channels"]
+        for ch, c in sc["channels"].items():
+            assert c["views_7d"] >= 0
+            # WoW is None when the prior week is 0 — never a fake number.
+            assert c["views_wow_pct"] is None or isinstance(
+                c["views_wow_pct"], (int, float))
+            z = c["zero_view_share_14d"]
+            assert z is None or 0.0 <= z <= 1.0
+            # uploads come from the INDEX (complete record) and must be
+            # >= the analytics rows the API deigned to return.
+            assert c["uploads_14d"] >= c["analytics_rows_14d"]
+
+    def test_window_note_documents_the_approximation(self):
+        sc = gd.build_channel_scorecard(ROOT)
+        assert "zero" in sc["window_note"].lower()
+
+
+class TestExperimentsRegister:
+    def test_registry_parses_and_entries_are_valid(self):
+        ex = gd.build_experiments_section(ROOT)
+        assert ex["configured"] is True and "error" not in ex
+        rows = ex["experiments"]
+        assert rows, "registry must not be empty"
+        for r in rows:
+            assert r["id"] and r["title"]
+            assert r["status"] in gd._EXPERIMENT_STATUSES
+
+    def test_every_registry_metric_is_computable(self):
+        """A typo'd metric key would render 'no data yet' forever — the
+        registry may only name metrics the generator computes."""
+        computable = set(gd._experiment_live_metrics(ROOT).keys())
+        data = yaml.safe_load((ROOT / "docs" / "experiments.yaml").read_text())
+        for e in data["experiments"]:
+            m = e.get("metric")
+            assert m is None or m in computable, (
+                f"experiment {e['id']!r} names unknown metric {m!r}; "
+                f"computable: {sorted(computable)}")
+
+    def test_live_metrics_are_none_or_numeric(self):
+        for k, v in gd._experiment_live_metrics(ROOT).items():
+            assert v is None or isinstance(v, (int, float)), (k, v)
+
+
+class TestStaggerHealth:
+    def test_section_shape(self):
+        st = gd.build_stagger_section(ROOT)
+        assert st["pending_total"] >= 0 and st["posted_total"] >= 0
+        assert isinstance(st["sweep_stuck"], bool)
+        for s in st["shows"]:
+            assert s["slug"] and s["pending"] >= 0
+
+    def test_sweep_maintains_posted_total(self, tmp_path, monkeypatch):
+        """post_due_comments must increment the sidecar's rolling counter —
+        it is the only evidence the sweep ever worked once entries clear."""
+        import json
+        import datetime as dt
+        from engine.shorts_stagger import queue_comment, post_due_comments
+        ddir = tmp_path / "digests" / "spacex"
+        ddir.mkdir(parents=True)
+        due = dt.datetime(2026, 8, 7, 15, tzinfo=dt.timezone.utc)
+        queue_comment(ddir, video_id="v1", channel="ru", text="t",
+                      publish_at=due)
+        import engine.youtube as yt
+        monkeypatch.setattr(yt, "get_channel_credentials_from_env",
+                            lambda ch: object())
+        monkeypatch.setattr(yt, "post_video_comment", lambda **kw: "cid")
+        post_due_comments(tmp_path, now=due + dt.timedelta(hours=1))
+        data = json.loads((ddir / "scheduled_comments.json").read_text())
+        assert data["posted_total"] == 1 and data["pending"] == []
+
+
+class TestSpecialsQueue:
+    def test_prestaged_spacex_specials_visible(self):
+        sp = gd.build_specials_section(ROOT)
+        assert sp["configured"] is True
+        pending_ids = {(r["show"], r["id"]) for r in sp["pending"]}
+        assert ("spacex", "flight-14-catch-reaction") in pending_ids
+        assert ("spacex", "q3-2026-earnings") in pending_ids
+        produced_ids = {r["id"] for r in sp["produced"]}
+        assert "q2-2026-earnings" in produced_ids
+
+
+class TestFreshness:
+    def test_all_four_sources_tracked(self):
+        fr = gd.build_freshness_section(ROOT)
+        assert set(fr["sources"]) == {
+            "youtube_stats", "youtube_policy", "op3_stats", "funnel"}
+        for s in fr["sources"].values():
+            assert s["age_hours"] is None or s["age_hours"] >= 0
+
+
+class TestHtmlWiring:
+    def test_growth_section_rendered(self):
+        html = (ROOT / "management.html").read_text()
+        assert 'id="levers-grid"' in html
+        assert "data.growth" in html
+        for marker in ("Channel scorecard", "Levers in flight",
+                       "Staggered Shorts", "Specials queue",
+                       "Analytics freshness"):
+            assert marker in html, f"missing card: {marker}"


### PR DESCRIPTION
Turns this week's one-off review findings into permanent, trending dashboard surfaces — a new **"Growth levers — trends, experiments & specials"** section on `management.html` (five cards), fed by new generator sections in `scripts/generate_dashboard.py` under `dashboard.growth`.

## The five cards

1. **Channel scorecard** — per-channel (EN/RU/FR) views WoW with up/down deltas, net subs/7d, views-per-video by kind (14d), and a **zero-view share**: INDEX uploads (the complete record) vs analytics rows. The Analytics API omits zero-activity videos — exactly how 53 of 72 FR launch uploads stayed invisible — so the FR early-warning is now computed for every channel, and highlights when >50%.
2. **Levers in flight** — new **`docs/experiments.yaml`** registry (the review-ledger discipline applied to growth work): every change shipped to move a number gets an entry with its readout/decision date. The card renders days-to-readout, **overdue flags** (overdue readouts also hit the alert band), and **live metric snapshots against baselines** from a closed vocabulary the generator computes (EN long-form median AVP, RU/FR `short_vpd` max, channel views WoW, dub fragment-title share). Honesty rules: an uncomputable value renders "no data yet" — never 0 — and **a registry entry naming an unknown metric key fails CI**.
3. **Staggered Shorts** — queued vs posted deferred comments per show and oldest-overdue age; >48h overdue = sweep stuck → warning in the alert band (a silently dead sweep is a silent funnel degradation). `engine/shorts_stagger.py` now keeps a rolling `posted_total` in the sidecar so the sweep leaves evidence after entries clear.
4. **Specials queue** — ready-to-dispatch deep-dive entries (`flight-14-catch-reaction`, `q3-2026-earnings`, MIT's six) with the Actions dispatch hint, plus produced history.
5. **Analytics freshness** — age of `youtube_stats` / `youtube_policy` / `op3_stats` / `funnel`, warning past 36h and wired into the alert band. The Aug 6 outage killed a nightly and every downstream number went silently a day stale; staleness is now a rendered fact.

## Seeded experiments register

cold-open retention (readout Aug 15, baseline 11.3% AVP) · staggered Shorts (Aug 13) · RU 3-Short band (Aug 13, baseline 60.9 vpd) · dub window headlines (Aug 14, baseline 0.66 fragment share) · **FR channel decision (Aug 25, criteria: any show ≥1.0 short_vpd else pause dubs)** · earnings-special format (Aug 12).

## First live read (from the current, pre-tonight's-nightly data)

- EN views **+78% WoW**, RU **+55%** — the cold-open/stagger era starting well (confounder caveats in the card).
- Dub fragment-title share **0.66 → 0.18** after one day of the headline fix.
- EN long-form median AVP **12.3** vs the 11.3 cold-open baseline.
- RU short_vpd **68.6** vs 60.9 at the 3-Short band ship — supply grew 50% and velocity *rose*.
- Freshness card correctly showing all four sources ~47h old (the outage gap; tonight's nightly clears it).

## Verification

- `tests/test_dashboard_growth.py` — 17 new guards: honesty rules (None never 0; uploads ≥ analytics rows; zero-share bounds), registry-metric computability, sweep `posted_total` persistence, specials visibility, freshness shape, HTML wiring for all five cards.
- Full offline dashboard build succeeds; extracted page JS passes `node --check`; 154 tests green across the dashboard/stagger suites.
- CLAUDE.md's operator-first-stop paragraph now documents the section + the "every shipped lever registers in experiments.yaml" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_