### PR TITLE
Mission control upgrade: industry benchmarks + investor view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1711,6 +1711,20 @@ experiments register: **every change shipped to move a number gets an entry
 in [`docs/experiments.yaml`](docs/experiments.yaml)** with its readout date
 and (where supported) a live metric key — a typo'd metric name fails CI
 (`tests/test_dashboard_growth.py`).
+
+The page carries **three views** (Aug 2026): Operator (everything),
+Sponsor (`?view=sponsor` — audience + catalogue, no spend/valuation) and
+**Investor** (`?view=investor` — audience, unit economics, industry
+benchmarks and now/1yr/5yr value scenarios). Every external market figure
+(percentile ladder, CPMs, production costs, M&A multiples) lives ONLY in
+[`docs/industry_benchmarks.yaml`](docs/industry_benchmarks.yaml) with
+sources + an `as_of` date the page renders; the generator's
+`build_benchmarks_section` / `build_investor_section` compute placement
+and scenarios from the same audience/cost sections the rest of the page
+uses. Honesty rules: episode denominators come from RSS pubDates (credit
+files count dub tracks and overstate episodes), unmeasured = null never 0,
+projections are labelled scenarios with their assumptions serialized next
+to them. Drift guards: `tests/test_investor_dashboard.py`.
 Items 7 and 10 are intentionally excluded from the dashboard (per an explicit
 decision); everything else has a live status card.
 

--- a/api/dashboard.json
+++ b/api/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T17:18:14.779449+00:00",
+  "generated_at": "2026-08-09T16:52:57.724607+00:00",
   "network": {
     "landmines_counts": {
       "ok": 9,
@@ -8,8 +8,8 @@
     },
     "shows_count": 16,
     "stale_shows": 0,
-    "total_cost_last_7_days_usd": 31.7894,
-    "total_cost_last_30_days_usd": 63.4575,
+    "total_cost_last_7_days_usd": 31.931,
+    "total_cost_last_30_days_usd": 66.4351,
     "shows": [
       {
         "slug": "age_of_ai",
@@ -38,10 +38,10 @@
         "blog_page": "blog/dp_pod/index.html",
         "newsletter_enabled": false,
         "x_enabled": false,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 0.8295,
-        "episodes_last_7_days": 5,
+        "cost_last_7_days_usd": 1.0175,
+        "episodes_last_7_days": 6,
         "p50_pipeline_s": 49.05,
         "success_rate": 1.0
       },
@@ -72,11 +72,11 @@
         "blog_page": "blog/fascinating_frontiers/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.2553,
+        "cost_last_7_days_usd": 3.2442,
         "episodes_last_7_days": 16,
-        "p50_pipeline_s": 75.35,
+        "p50_pipeline_s": 74.87,
         "success_rate": 1.0
       },
       {
@@ -106,11 +106,11 @@
         "blog_page": "blog/first_principles/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 2.2247,
+        "cost_last_7_days_usd": 2.1927,
         "episodes_last_7_days": 16,
-        "p50_pipeline_s": 45.09,
+        "p50_pipeline_s": 43.1,
         "success_rate": 1.0
       },
       {
@@ -123,11 +123,11 @@
         "blog_page": "blog/models_agents/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.1976,
+        "cost_last_7_days_usd": 3.2227,
         "episodes_last_7_days": 16,
-        "p50_pipeline_s": 87.55,
+        "p50_pipeline_s": 85.6,
         "success_rate": 1.0
       },
       {
@@ -140,11 +140,11 @@
         "blog_page": "blog/models_agents_beginners/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 2.751,
+        "cost_last_7_days_usd": 2.7389,
         "episodes_last_7_days": 8,
-        "p50_pipeline_s": 52.78,
+        "p50_pipeline_s": 52.04,
         "success_rate": 1.0
       },
       {
@@ -157,11 +157,11 @@
         "blog_page": "blog/modern_investing/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.4109,
+        "cost_last_7_days_usd": 3.453,
         "episodes_last_7_days": 16,
-        "p50_pipeline_s": 126.48,
+        "p50_pipeline_s": 126.39,
         "success_rate": 1.0
       },
       {
@@ -191,9 +191,9 @@
         "blog_page": "blog/omni_view/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.1416,
+        "cost_last_7_days_usd": 3.1212,
         "episodes_last_7_days": 8,
         "p50_pipeline_s": 197.32,
         "success_rate": 1.0
@@ -208,9 +208,9 @@
         "blog_page": "blog/planetterrian/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 2.8035,
+        "cost_last_7_days_usd": 2.7687,
         "episodes_last_7_days": 8,
         "p50_pipeline_s": 59.32,
         "success_rate": 1.0
@@ -242,11 +242,11 @@
         "blog_page": "blog/spacex/index.html",
         "newsletter_enabled": true,
         "x_enabled": false,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.8145,
+        "cost_last_7_days_usd": 3.8214,
         "episodes_last_7_days": 22,
-        "p50_pipeline_s": 106.69,
+        "p50_pipeline_s": 110.88,
         "success_rate": 1.0
       },
       {
@@ -259,11 +259,11 @@
         "blog_page": "blog/tesla/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
-        "cost_last_7_days_usd": 3.4197,
+        "cost_last_7_days_usd": 3.4099,
         "episodes_last_7_days": 16,
-        "p50_pipeline_s": 118.91,
+        "p50_pipeline_s": 116.48,
         "success_rate": 1.0
       },
       {
@@ -276,7 +276,7 @@
         "blog_page": "blog/unintended_consequences/index.html",
         "newsletter_enabled": true,
         "x_enabled": true,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "pub_status": "ok",
         "cost_last_7_days_usd": 1.9481,
         "episodes_last_7_days": 8,
@@ -452,10 +452,10 @@
       "id": "item_1_repo_size",
       "title": "Repo & R2 size",
       "status": "ok",
-      "details": "15 MP3s tracked in git, digests/ is 308 MB.",
+      "details": "15 MP3s tracked in git, digests/ is 312 MB.",
       "evidence": {
         "tracked_mp3_count": 15,
-        "digests_mb": 308.3
+        "digests_mb": 312.3
       }
     },
     {
@@ -482,8 +482,8 @@
       "evidence": {
         "total": 95,
         "by_extension": {
-          ".txt": 45,
           ".json": 47,
+          ".txt": 45,
           ".py": 3
         },
         "previous_total": 95
@@ -830,15 +830,15 @@
       },
       "dp_pod": {
         "last_7_days": {
-          "grok": 0.2176,
-          "tts": 0.6119,
-          "total": 0.8295,
-          "episodes": 5
+          "grok": 0.2598,
+          "tts": 0.7577,
+          "total": 1.0175,
+          "episodes": 6
         },
         "last_30_days": {
-          "grok": 0.769,
-          "tts": 1.7197,
-          "total": 2.4887,
+          "grok": 0.7828,
+          "tts": 1.826,
+          "total": 2.6088,
           "episodes": 25
         },
         "daily_series": [
@@ -957,6 +957,10 @@
           [
             "2026-08-08",
             0.218
+          ],
+          [
+            "2026-08-09",
+            0.188
           ]
         ]
       },
@@ -968,10 +972,10 @@
           "episodes": 2
         },
         "last_30_days": {
-          "grok": 0.2259,
-          "tts": 0.3228,
-          "total": 0.7087,
-          "episodes": 16
+          "grok": 0.2059,
+          "tts": 0.2994,
+          "total": 0.6654,
+          "episodes": 14
         },
         "daily_series": [
           [
@@ -1098,22 +1102,18 @@
       },
       "fascinating_frontiers": {
         "last_7_days": {
-          "grok": 0.4361,
-          "tts": 1.0572,
-          "total": 3.2553,
+          "grok": 0.4322,
+          "tts": 1.0617,
+          "total": 3.2442,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.2473,
-          "tts": 2.5016,
-          "total": 5.9591,
+          "grok": 1.2576,
+          "tts": 2.587,
+          "total": 6.2682,
           "episodes": 60
         },
         "daily_series": [
-          [
-            "2026-07-09",
-            0.074
-          ],
           [
             "2026-07-10",
             0.0784
@@ -1229,6 +1229,10 @@
           [
             "2026-08-08",
             0.4489
+          ],
+          [
+            "2026-08-09",
+            0.3831
           ]
         ]
       },
@@ -1370,22 +1374,18 @@
       },
       "first_principles": {
         "last_7_days": {
-          "grok": 0.2359,
-          "tts": 1.1288,
-          "total": 2.2247,
+          "grok": 0.2348,
+          "tts": 1.098,
+          "total": 2.1927,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 0.6949,
-          "tts": 2.6695,
-          "total": 4.5844,
+          "grok": 0.7032,
+          "tts": 2.7502,
+          "total": 4.7734,
           "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.0585
-          ],
           [
             "2026-07-11",
             0.0688
@@ -1501,27 +1501,27 @@
           [
             "2026-08-08",
             0.2682
+          ],
+          [
+            "2026-08-09",
+            0.2537
           ]
         ]
       },
       "models_agents": {
         "last_7_days": {
-          "grok": 0.3973,
-          "tts": 1.0478,
-          "total": 3.1976,
+          "grok": 0.3902,
+          "tts": 1.0736,
+          "total": 3.2227,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.266,
-          "tts": 2.3696,
-          "total": 5.8333,
+          "grok": 1.2776,
+          "tts": 2.4859,
+          "total": 6.187,
           "episodes": 60
         },
         "daily_series": [
-          [
-            "2026-07-09",
-            0.0698
-          ],
           [
             "2026-07-10",
             0.0877
@@ -1637,27 +1637,27 @@
           [
             "2026-08-08",
             0.4179
+          ],
+          [
+            "2026-08-09",
+            0.4234
           ]
         ]
       },
       "models_agents_beginners": {
         "last_7_days": {
-          "grok": 0.3057,
-          "tts": 0.7415,
-          "total": 2.751,
+          "grok": 0.3104,
+          "tts": 0.7275,
+          "total": 2.7389,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.9116,
-          "tts": 1.7555,
-          "total": 4.9645,
+          "grok": 0.9239,
+          "tts": 1.8162,
+          "total": 5.2455,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.0525
-          ],
           [
             "2026-07-11",
             0.0533
@@ -1773,27 +1773,27 @@
           [
             "2026-08-08",
             0.3556
+          ],
+          [
+            "2026-08-09",
+            0.3287
           ]
         ]
       },
       "modern_investing": {
         "last_7_days": {
-          "grok": 0.4882,
-          "tts": 1.2091,
-          "total": 3.4109,
+          "grok": 0.5,
+          "tts": 1.2327,
+          "total": 3.453,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.5277,
-          "tts": 2.9002,
-          "total": 6.906,
+          "grok": 1.5325,
+          "tts": 3.0283,
+          "total": 7.2605,
           "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.1006
-          ],
           [
             "2026-07-11",
             0.0865
@@ -1909,6 +1909,10 @@
           [
             "2026-08-08",
             0.43
+          ],
+          [
+            "2026-08-09",
+            0.4565
           ]
         ]
       },
@@ -1934,22 +1938,18 @@
       },
       "omni_view": {
         "last_7_days": {
-          "grok": 0.4099,
-          "tts": 1.1579,
-          "total": 3.1416,
+          "grok": 0.4236,
+          "tts": 1.1316,
+          "total": 3.1212,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 1.2298,
-          "tts": 2.7513,
-          "total": 6.1565,
+          "grok": 1.2572,
+          "tts": 2.8191,
+          "total": 6.4664,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.078
-          ],
           [
             "2026-07-11",
             0.0701
@@ -2065,27 +2065,27 @@
           [
             "2026-08-08",
             0.4108
+          ],
+          [
+            "2026-08-09",
+            0.3802
           ]
         ]
       },
       "planetterrian": {
         "last_7_days": {
-          "grok": 0.3652,
-          "tts": 1.0704,
-          "total": 2.8035,
+          "grok": 0.3642,
+          "tts": 1.0367,
+          "total": 2.7687,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 1.0818,
-          "tts": 2.7111,
-          "total": 5.6326,
+          "grok": 1.0994,
+          "tts": 2.8027,
+          "total": 5.8988,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.0823
-          ],
           [
             "2026-07-11",
             0.0773
@@ -2201,6 +2201,10 @@
           [
             "2026-08-08",
             0.3466
+          ],
+          [
+            "2026-08-09",
+            0.3335
           ]
         ]
       },
@@ -2342,22 +2346,18 @@
       },
       "spacex": {
         "last_7_days": {
-          "grok": 0.5893,
-          "tts": 1.4232,
-          "total": 3.8145,
+          "grok": 0.5878,
+          "tts": 1.4315,
+          "total": 3.8214,
           "episodes": 22
         },
         "last_30_days": {
-          "grok": 1.663,
-          "tts": 3.1614,
-          "total": 7.4265,
+          "grok": 1.6846,
+          "tts": 3.2666,
+          "total": 7.7132,
           "episodes": 74
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.0748
-          ],
           [
             "2026-07-11",
             0.081
@@ -2473,27 +2473,27 @@
           [
             "2026-08-08",
             0.3664
+          ],
+          [
+            "2026-08-09",
+            0.3599
           ]
         ]
       },
       "tesla": {
         "last_7_days": {
-          "grok": 0.5587,
-          "tts": 1.1896,
-          "total": 3.4197,
+          "grok": 0.5576,
+          "tts": 1.183,
+          "total": 3.4099,
           "episodes": 16
         },
         "last_30_days": {
-          "grok": 1.9805,
-          "tts": 2.9202,
-          "total": 7.1538,
+          "grok": 2.0133,
+          "tts": 3.0322,
+          "total": 7.5061,
           "episodes": 62
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.1242
-          ],
           [
             "2026-07-11",
             0.0878
@@ -2609,27 +2609,27 @@
           [
             "2026-08-08",
             0.4089
+          ],
+          [
+            "2026-08-09",
+            0.4432
           ]
         ]
       },
       "unintended_consequences": {
         "last_7_days": {
-          "grok": 0.1744,
-          "tts": 0.9137,
+          "grok": 0.177,
+          "tts": 0.9111,
           "total": 1.9481,
           "episodes": 8
         },
         "last_30_days": {
-          "grok": 0.4935,
-          "tts": 2.1796,
-          "total": 3.8931,
+          "grok": 0.506,
+          "tts": 2.2654,
+          "total": 4.0914,
           "episodes": 31
         },
         "daily_series": [
-          [
-            "2026-07-10",
-            0.0413
-          ],
           [
             "2026-07-11",
             0.0405
@@ -2745,28 +2745,32 @@
           [
             "2026-08-08",
             0.2294
+          ],
+          [
+            "2026-08-09",
+            0.2418
           ]
         ]
       }
     },
     "network_last_7_days": {
-      "grok": 4.3264,
-      "tts": 11.916,
-      "total": 31.7894,
-      "episodes": 144
+      "grok": 4.3856,
+      "tts": 12.0099,
+      "total": 31.931,
+      "episodes": 145
     },
     "network_last_30_days": {
-      "grok": 13.7989,
-      "tts": 28.6851,
-      "total": 63.4575,
-      "episodes": 566
+      "grok": 13.9519,
+      "tts": 29.7014,
+      "total": 66.4351,
+      "episodes": 564
     },
     "projections": {
-      "avg_cost_per_episode_usd": 0.2208,
-      "projected_weekly_usd": 31.79,
-      "projected_monthly_usd": 63.46,
-      "episodes_7d": 144,
-      "note": "Weekly projection = actual last-7d Grok+TTS spend (144 credit_usage files). Monthly = last-30d total. Not a calendar forecast — a trailing burn rate."
+      "avg_cost_per_episode_usd": 0.2202,
+      "projected_weekly_usd": 31.93,
+      "projected_monthly_usd": 66.44,
+      "episodes_7d": 145,
+      "note": "Weekly projection = actual last-7d Grok+TTS spend (145 credit_usage files). Monthly = last-30d total. Not a calendar forecast — a trailing burn rate."
     },
     "youtube_quota": {
       "enabled_shows_count": 13,
@@ -2815,7 +2819,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 2.9739,
+        "cost_7d_usd": 2.9783,
         "audience_by_language": {
           "fr": {
             "downloads_7d": 1,
@@ -2843,7 +2847,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.444
+        "cost_7d_usd": 1.4118
       },
       "models_agents": {
         "languages": [
@@ -2859,7 +2863,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 1.3833
+        "cost_7d_usd": 1.4198
       },
       "modern_investing": {
         "languages": [
@@ -2876,7 +2880,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 3.1209,
+        "cost_7d_usd": 3.176,
         "audience_by_language": {
           "ru": {
             "downloads_7d": 14,
@@ -2906,7 +2910,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 4.0136,
+        "cost_7d_usd": 4.08,
         "audience_by_language": {
           "fr": {
             "downloads_7d": 15,
@@ -2936,7 +2940,7 @@
         },
         "all_languages": 0,
         "coverage_pct": 0.0,
-        "cost_7d_usd": 3.4252,
+        "cost_7d_usd": 3.4258,
         "audience_by_language": {
           "fr": {
             "downloads_7d": 0,
@@ -2951,7 +2955,7 @@
         }
       }
     },
-    "network_cost_7d_usd": 16.5127,
+    "network_cost_7d_usd": 16.6435,
     "audience_measured": true,
     "per_language_audience": {
       "fascinating_frontiers:fr": {
@@ -3015,21 +3019,21 @@
       "fr": {
         "downloads_7d": 16,
         "downloads_30d": 40,
-        "approx_cost_7d_usd": 8.0105,
+        "approx_cost_7d_usd": 8.0661,
         "shows": 7,
         "measured": true
       },
       "ru": {
         "downloads_7d": 21,
         "downloads_30d": 84,
-        "approx_cost_7d_usd": 5.0313,
+        "approx_cost_7d_usd": 5.0827,
         "shows": 4,
         "measured": true
       },
       "zh": {
         "downloads_7d": 0,
         "downloads_30d": 0,
-        "approx_cost_7d_usd": 3.4709,
+        "approx_cost_7d_usd": 3.4947,
         "shows": 3,
         "measured": false
       }
@@ -3075,22 +3079,15 @@
       }
     },
     "dp_pod": {
-      "sample_size": 29,
+      "sample_size": 30,
       "p50_duration_s": 49.05,
       "p95_duration_s": 71.32,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 5.4,
-        "generate_digest": 45.65
+        "fetch_and_dedup": 5.56,
+        "generate_digest": 45.91
       },
       "recent": [
-        {
-          "episode_num": 20,
-          "total_duration_s": 77.53,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": false
-        },
         {
           "episode_num": 21,
           "total_duration_s": 54.86,
@@ -3150,6 +3147,13 @@
         {
           "episode_num": 29,
           "total_duration_s": 46.54,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": false
+        },
+        {
+          "episode_num": 30,
+          "total_duration_s": 63.6,
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": false
@@ -3300,22 +3304,15 @@
     },
     "fascinating_frontiers": {
       "sample_size": 30,
-      "p50_duration_s": 75.35,
+      "p50_duration_s": 74.87,
       "p95_duration_s": 178.92,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 20.67,
-        "generate_digest": 60.07,
+        "fetch_and_dedup": 20.6,
+        "generate_digest": 58.01,
         "generate_digest_retry": 51.44
       },
       "recent": [
-        {
-          "episode_num": 146,
-          "total_duration_s": 83.56,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 147,
           "total_duration_s": 67.64,
@@ -3378,6 +3375,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 156,
+          "total_duration_s": 54.45,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3392,8 +3396,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -3524,21 +3528,14 @@
     },
     "first_principles": {
       "sample_size": 30,
-      "p50_duration_s": 45.09,
+      "p50_duration_s": 43.1,
       "p95_duration_s": 133.44,
       "success_rate": 1.0,
       "stage_mean_s": {
         "fetch_and_dedup": 0.0,
-        "generate_digest": 55.01
+        "generate_digest": 54.05
       },
       "recent": [
-        {
-          "episode_num": 55,
-          "total_duration_s": 53.26,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 56,
           "total_duration_s": 50.53,
@@ -3601,14 +3598,21 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 65,
+          "total_duration_s": 25.85,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 8,
-        "long_form_success_rate": 0.267,
-        "estimated_quota_units_last_30_eps": 67800,
+        "long_form_uploaded": 7,
+        "long_form_success_rate": 0.233,
+        "estimated_quota_units_last_30_eps": 65700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
@@ -3623,7 +3627,7 @@
         "attempts": 30,
         "successful_episodes": 30,
         "generation_success_rate": 1.0,
-        "cost_usd_recent": 4.26,
+        "cost_usd_recent": 4.2,
         "recent_failures": []
       },
       "tag_leaks": {
@@ -3635,21 +3639,14 @@
     },
     "models_agents": {
       "sample_size": 30,
-      "p50_duration_s": 87.55,
+      "p50_duration_s": 85.6,
       "p95_duration_s": 124.93,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 41.82,
-        "generate_digest": 50.63
+        "fetch_and_dedup": 41.64,
+        "generate_digest": 50.74
       },
       "recent": [
-        {
-          "episode_num": 126,
-          "total_duration_s": 90.77,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 127,
           "total_duration_s": 88.09,
@@ -3712,6 +3709,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 136,
+          "total_duration_s": 85.39,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3726,8 +3730,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -3746,21 +3750,14 @@
     },
     "models_agents_beginners": {
       "sample_size": 30,
-      "p50_duration_s": 52.78,
+      "p50_duration_s": 52.04,
       "p95_duration_s": 68.76,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 21.14,
-        "generate_digest": 30.89
+        "fetch_and_dedup": 20.83,
+        "generate_digest": 30.9
       },
       "recent": [
-        {
-          "episode_num": 118,
-          "total_duration_s": 60.4,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 119,
           "total_duration_s": 45.94,
@@ -3823,6 +3820,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 128,
+          "total_duration_s": 52.04,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3837,8 +3841,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -3857,22 +3861,15 @@
     },
     "modern_investing": {
       "sample_size": 30,
-      "p50_duration_s": 126.48,
+      "p50_duration_s": 126.39,
       "p95_duration_s": 200.07,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 77.87,
-        "generate_digest": 46.52,
-        "generate_digest_structural_retry": 48.54
+        "fetch_and_dedup": 76.89,
+        "generate_digest": 46.98,
+        "generate_digest_structural_retry": 51.86
       },
       "recent": [
-        {
-          "episode_num": 122,
-          "total_duration_s": 172.78,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 123,
           "total_duration_s": 180.41,
@@ -3935,6 +3932,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 132,
+          "total_duration_s": 82.65,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -3949,8 +3953,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -4023,18 +4027,11 @@
       "p95_duration_s": 257.36,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 102.4,
-        "generate_digest": 55.91,
+        "fetch_and_dedup": 102.82,
+        "generate_digest": 54.3,
         "generate_digest_slow_news": 55.34
       },
       "recent": [
-        {
-          "episode_num": 128,
-          "total_duration_s": 234.01,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 129,
           "total_duration_s": 248.52,
@@ -4097,6 +4094,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 138,
+          "total_duration_s": 133.7,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -4111,8 +4115,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -4132,20 +4136,13 @@
     "planetterrian": {
       "sample_size": 30,
       "p50_duration_s": 59.32,
-      "p95_duration_s": 118.79,
+      "p95_duration_s": 118.78,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 20.17,
-        "generate_digest": 45.58
+        "fetch_and_dedup": 21.35,
+        "generate_digest": 44.4
       },
       "recent": [
-        {
-          "episode_num": 136,
-          "total_duration_s": 42.09,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 137,
           "total_duration_s": 103.13,
@@ -4208,29 +4205,36 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 146,
+          "total_duration_s": 118.78,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 8,
-        "long_form_success_rate": 0.267,
-        "estimated_quota_units_last_30_eps": 67800,
+        "long_form_uploaded": 7,
+        "long_form_success_rate": 0.233,
+        "estimated_quota_units_last_30_eps": 65700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
         "attempts": 30,
         "successful_episodes": 30,
         "generation_success_rate": 1.0,
-        "cost_usd_recent": 4.26,
+        "cost_usd_recent": 4.2,
         "recent_failures": []
       },
       "tag_leaks": {
@@ -4354,22 +4358,15 @@
     },
     "spacex": {
       "sample_size": 30,
-      "p50_duration_s": 106.69,
+      "p50_duration_s": 110.88,
       "p95_duration_s": 167.7,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 40.02,
-        "generate_digest": 72.11,
+        "fetch_and_dedup": 40.06,
+        "generate_digest": 72.64,
         "deep_dive_research": 24.13
       },
       "recent": [
-        {
-          "episode_num": 54,
-          "total_duration_s": 101.9,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 55,
           "total_duration_s": 82.57,
@@ -4432,6 +4429,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 64,
+          "total_duration_s": 111.61,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -4446,15 +4450,15 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 3,
-        "synthesised": 3,
+        "attempts": 4,
+        "synthesised": 4,
         "success_rate": 1.0
       },
       "grok_imagine": {
         "attempts": 30,
         "successful_episodes": 30,
         "generation_success_rate": 1.0,
-        "cost_usd_recent": 4.78,
+        "cost_usd_recent": 4.8,
         "recent_failures": []
       },
       "tag_leaks": {
@@ -4466,22 +4470,15 @@
     },
     "tesla": {
       "sample_size": 30,
-      "p50_duration_s": 118.91,
+      "p50_duration_s": 116.48,
       "p95_duration_s": 297.07,
       "success_rate": 1.0,
       "stage_mean_s": {
-        "fetch_and_dedup": 27.31,
-        "generate_digest": 89.89,
-        "generate_digest_structural_retry": 100.16
+        "fetch_and_dedup": 27.0,
+        "generate_digest": 88.79,
+        "generate_digest_structural_retry": 105.28
       },
       "recent": [
-        {
-          "episode_num": 557,
-          "total_duration_s": 155.36,
-          "success": true,
-          "youtube_long_url": true,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 558,
           "total_duration_s": 67.61,
@@ -4544,6 +4541,13 @@
           "success": true,
           "youtube_long_url": true,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 567,
+          "total_duration_s": 84.03,
+          "success": true,
+          "youtube_long_url": true,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
@@ -4558,8 +4562,8 @@
         "long_form_errors": []
       },
       "weekly_recap": {
-        "attempts": 4,
-        "synthesised": 4,
+        "attempts": 5,
+        "synthesised": 5,
         "success_rate": 1.0
       },
       "grok_imagine": {
@@ -4583,16 +4587,9 @@
       "success_rate": 1.0,
       "stage_mean_s": {
         "fetch_and_dedup": 0.0,
-        "generate_digest": 30.96
+        "generate_digest": 31.26
       },
       "recent": [
-        {
-          "episode_num": 74,
-          "total_duration_s": 29.0,
-          "success": true,
-          "youtube_long_url": false,
-          "youtube_short_url": true
-        },
         {
           "episode_num": 75,
           "total_duration_s": 28.88,
@@ -4655,14 +4652,21 @@
           "success": true,
           "youtube_long_url": false,
           "youtube_short_url": true
+        },
+        {
+          "episode_num": 84,
+          "total_duration_s": 37.82,
+          "success": true,
+          "youtube_long_url": false,
+          "youtube_short_url": true
         }
       ],
       "youtube": {
         "enabled_in_recent": true,
         "long_form_attempts": 30,
-        "long_form_uploaded": 8,
-        "long_form_success_rate": 0.267,
-        "estimated_quota_units_last_30_eps": 67800,
+        "long_form_uploaded": 7,
+        "long_form_success_rate": 0.233,
+        "estimated_quota_units_last_30_eps": 65700,
         "shorts_attempts": 30,
         "shorts_uploaded": 30,
         "shorts_success_rate": 1.0,
@@ -4677,7 +4681,7 @@
         "attempts": 30,
         "successful_episodes": 30,
         "generation_success_rate": 1.0,
-        "cost_usd_recent": 4.26,
+        "cost_usd_recent": 4.2,
         "recent_failures": []
       },
       "tag_leaks": {
@@ -4723,9 +4727,16 @@
       },
       {
         "file": "dp_pod_podcast.rss",
-        "entry_count": 29,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 30,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep030_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep029_20260808.mp3",
             "host": "op3.dev",
@@ -4737,13 +4748,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep028_20260806.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/dp_pod/DP_Pod_Ep027_20260804.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-04T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -4934,8 +4938,15 @@
       {
         "file": "fascinating_frontiers_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep156_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep155_20260808.fr.mp3",
             "host": "op3.dev",
@@ -4949,13 +4960,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep153_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -4963,9 +4967,16 @@
       },
       {
         "file": "fascinating_frontiers_podcast.rss",
-        "entry_count": 144,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 145,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep156_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep155_20260808.mp3",
             "host": "op3.dev",
@@ -4979,13 +4990,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep153_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -4994,8 +4998,15 @@
       {
         "file": "fascinating_frontiers_podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep156_20260809.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep155_20260808.ru.mp3",
             "host": "op3.dev",
@@ -5009,13 +5020,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep153_20260806.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5023,9 +5027,16 @@
       },
       {
         "file": "fascinating_frontiers_podcast.video.rss",
-        "entry_count": 21,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 22,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/fascinating_frontiers/Fascinating_Frontiers_Ep156_20260809.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/fascinating_frontiers/Fascinating_Frontiers_Ep155_20260808.mp4",
             "host": "audio.nerranetwork.com",
@@ -5039,13 +5050,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/fascinating_frontiers/Fascinating_Frontiers_Ep153_20260806.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5054,8 +5058,15 @@
       {
         "file": "fascinating_frontiers_podcast.zh.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep156_20260809.zh.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep155_20260808.zh.mp3",
             "host": "op3.dev",
@@ -5067,13 +5078,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep154_20260807.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/fascinating_frontiers/Fascinating_Frontiers_Ep153_20260806.zh.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5144,8 +5148,15 @@
       {
         "file": "first_principles_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep065_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep064_20260808.fr.mp3",
             "host": "op3.dev",
@@ -5159,13 +5170,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep062_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5173,9 +5177,16 @@
       },
       {
         "file": "first_principles_podcast.rss",
-        "entry_count": 64,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 65,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep065_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep064_20260808.mp3",
             "host": "op3.dev",
@@ -5187,13 +5198,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep063_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/first_principles/First_Principles_Ep062_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5323,9 +5327,16 @@
       },
       {
         "file": "models_agents_beginners_podcast.rss",
-        "entry_count": 127,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 128,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep128_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep127_20260808.mp3",
             "host": "op3.dev",
@@ -5337,13 +5348,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep126_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents_beginners/MAB_Ep125_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5383,9 +5387,16 @@
       },
       {
         "file": "models_agents_beginners_podcast.video.rss",
-        "entry_count": 22,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 23,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep128_20260809.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep127_20260808.mp4",
             "host": "audio.nerranetwork.com",
@@ -5397,13 +5408,6 @@
             "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep126_20260807.mp4",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/models_agents_beginners/MAB_Ep125_20260806.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5474,8 +5478,15 @@
       {
         "file": "models_agents_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep136_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep135_20260808.fr.mp3",
             "host": "op3.dev",
@@ -5489,13 +5500,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep133_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5503,9 +5507,16 @@
       },
       {
         "file": "models_agents_podcast.rss",
-        "entry_count": 135,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 136,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep136_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep135_20260808.mp3",
             "host": "op3.dev",
@@ -5517,13 +5528,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep134_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/models_agents/Models_Agents_Ep133_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5563,9 +5567,16 @@
       },
       {
         "file": "models_agents_podcast.video.rss",
-        "entry_count": 21,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 22,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/models_agents/Models_Agents_Ep136_20260809.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/models_agents/Models_Agents_Ep135_20260808.mp4",
             "host": "audio.nerranetwork.com",
@@ -5577,13 +5588,6 @@
             "url": "https://audio.nerranetwork.com/video/models_agents/Models_Agents_Ep134_20260807.mp4",
             "host": "audio.nerranetwork.com",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/models_agents/Models_Agents_Ep133_20260806.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5653,9 +5657,16 @@
       },
       {
         "file": "modern_investing_podcast.fr.rss",
-        "entry_count": 24,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 25,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep132_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep131_20260808.fr.mp3",
             "host": "op3.dev",
@@ -5669,13 +5680,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep129_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5683,9 +5687,16 @@
       },
       {
         "file": "modern_investing_podcast.rss",
-        "entry_count": 131,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 132,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep132_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep131_20260808.mp3",
             "host": "op3.dev",
@@ -5699,13 +5710,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep129_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -5714,8 +5718,15 @@
       {
         "file": "modern_investing_podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep132_20260809.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep131_20260808.ru.mp3",
             "host": "op3.dev",
@@ -5727,13 +5738,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep130_20260807.ru.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/modern_investing/Modern_Investing_Ep129_20260806.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5849,9 +5853,16 @@
       },
       {
         "file": "omni_view_podcast.rss",
-        "entry_count": 137,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 138,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep138_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep137_20260808.mp3",
             "host": "op3.dev",
@@ -5863,13 +5874,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep136_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/omni_view/Omni_View_Ep135_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -5999,9 +6003,16 @@
       },
       {
         "file": "planetterrian_podcast.rss",
-        "entry_count": 133,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 134,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep146_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep145_20260808.mp3",
             "host": "op3.dev",
@@ -6013,13 +6024,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep144_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/planetterrian/Planetterrian_Daily_Ep143_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6120,8 +6124,15 @@
       {
         "file": "podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep567_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep566_20260808.fr.mp3",
             "host": "op3.dev",
@@ -6135,13 +6146,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep564_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6149,9 +6153,16 @@
       },
       {
         "file": "podcast.rss",
-        "entry_count": 219,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 220,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep567_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep566_20260808.mp3",
             "host": "op3.dev",
@@ -6165,13 +6176,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep564_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6180,8 +6184,15 @@
       {
         "file": "podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep567_20260809.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep566_20260808.ru.mp3",
             "host": "op3.dev",
@@ -6195,13 +6206,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep564_20260806.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6209,9 +6213,16 @@
       },
       {
         "file": "podcast.video.rss",
-        "entry_count": 22,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 23,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep567_20260809.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep566_20260808.mp4",
             "host": "audio.nerranetwork.com",
@@ -6225,13 +6236,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/tesla/Tesla_Shorts_Time_Pod_Ep564_20260806.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6240,8 +6244,15 @@
       {
         "file": "podcast.zh.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep567_20260809.zh.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep566_20260808.zh.mp3",
             "host": "op3.dev",
@@ -6251,13 +6262,6 @@
           },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep565_20260807.zh.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/tesla/Tesla_Shorts_Time_Pod_Ep564_20260806.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
@@ -6330,8 +6334,15 @@
       {
         "file": "spacex_podcast.fr.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep064_20260809.fr.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep063_20260808.fr.mp3",
             "host": "op3.dev",
@@ -6345,13 +6356,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep061_20260806.fr.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6359,9 +6363,16 @@
       },
       {
         "file": "spacex_podcast.rss",
-        "entry_count": 63,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 64,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep064_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep063_20260808.mp3",
             "host": "op3.dev",
@@ -6375,13 +6386,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep060_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6390,8 +6394,15 @@
       {
         "file": "spacex_podcast.ru.rss",
         "entry_count": 30,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep064_20260809.ru.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep063_20260808.ru.mp3",
             "host": "op3.dev",
@@ -6405,13 +6416,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep061_20260806.ru.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6419,9 +6423,16 @@
       },
       {
         "file": "spacex_podcast.video.rss",
-        "entry_count": 27,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 28,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep064_20260809.mp4",
+            "host": "audio.nerranetwork.com",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep063_20260808.mp4",
             "host": "audio.nerranetwork.com",
@@ -6435,13 +6446,6 @@
             "pub_date": "2026-08-07T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
-          },
-          {
-            "url": "https://audio.nerranetwork.com/video/spacex/SpaceX_Daily_Ep061_20260806.mp4",
-            "host": "audio.nerranetwork.com",
-            "pub_date": "2026-08-06T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
           }
         ],
         "malformed": false,
@@ -6450,8 +6454,15 @@
       {
         "file": "spacex_podcast.zh.rss",
         "entry_count": 29,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep064_20260809.zh.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep063_20260808.zh.mp3",
             "host": "op3.dev",
@@ -6463,13 +6474,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep062_20260807.zh.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/spacex/SpaceX_Daily_Ep061_20260806.zh.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6539,9 +6543,16 @@
       },
       {
         "file": "unintended_consequences_podcast.rss",
-        "entry_count": 83,
-        "latest_pub_date": "2026-08-08T08:00:00+00:00",
+        "entry_count": 84,
+        "latest_pub_date": "2026-08-09T08:00:00+00:00",
         "latest_enclosures": [
+          {
+            "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep084_20260809.mp3",
+            "host": "op3.dev",
+            "pub_date": "2026-08-09T08:00:00+00:00",
+            "http_status": 200,
+            "reachable": true
+          },
           {
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep083_20260808.mp3",
             "host": "op3.dev",
@@ -6553,13 +6564,6 @@
             "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep082_20260807.mp3",
             "host": "op3.dev",
             "pub_date": "2026-08-07T08:00:00+00:00",
-            "http_status": 200,
-            "reachable": true
-          },
-          {
-            "url": "https://op3.dev/e/audio.nerranetwork.com/unintended_consequences/Unintended_Consequences_Ep081_20260806.mp3",
-            "host": "op3.dev",
-            "pub_date": "2026-08-06T08:00:00+00:00",
             "http_status": 200,
             "reachable": true
           }
@@ -6684,7 +6688,7 @@
       "current_close": 26690.62,
       "inception_to_date_pct": 19.29,
       "ytd_pct": 14.87,
-      "last_updated": "2026-08-08"
+      "last_updated": "2026-08-09"
     },
     "alpha": {
       "inception_to_date_pct": -18.74,
@@ -8034,173 +8038,173 @@
     ],
     "taught_lessons_hot": [
       {
+        "tag": "bid_ask_spread",
+        "count": 33,
+        "last_episode": 132,
+        "last_date": "2026-08-09",
+        "days_since": 0,
+        "cools_in_days": 45
+      },
+      {
+        "tag": "sector_rotation",
+        "count": 67,
+        "last_episode": 132,
+        "last_date": "2026-08-09",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "valuation_discipline",
+        "count": 52,
+        "last_episode": 132,
+        "last_date": "2026-08-09",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "covered_call",
+        "count": 31,
+        "last_episode": 132,
+        "last_date": "2026-08-09",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
+        "tag": "dollar_cost_averaging",
+        "count": 5,
+        "last_episode": 132,
+        "last_date": "2026-08-09",
+        "days_since": 0,
+        "cools_in_days": 21
+      },
+      {
         "tag": "geopolitical_premium",
         "count": 20,
         "last_episode": 131,
         "last_date": "2026-08-08",
-        "days_since": 0,
-        "cools_in_days": 30
+        "days_since": 1,
+        "cools_in_days": 29
       },
       {
         "tag": "catalyst_confirmation",
         "count": 46,
         "last_episode": 131,
         "last_date": "2026-08-08",
-        "days_since": 0,
-        "cools_in_days": 21
-      },
-      {
-        "tag": "sector_rotation",
-        "count": 66,
-        "last_episode": 131,
-        "last_date": "2026-08-08",
-        "days_since": 0,
-        "cools_in_days": 21
-      },
-      {
-        "tag": "valuation_discipline",
-        "count": 51,
-        "last_episode": 131,
-        "last_date": "2026-08-08",
-        "days_since": 0,
-        "cools_in_days": 21
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "dividend_compounding",
         "count": 6,
         "last_episode": 131,
         "last_date": "2026-08-08",
-        "days_since": 0,
-        "cools_in_days": 21
+        "days_since": 1,
+        "cools_in_days": 20
       },
       {
         "tag": "tax_loss_harvesting",
         "count": 11,
         "last_episode": 130,
         "last_date": "2026-08-07",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "position_sizing",
         "count": 44,
         "last_episode": 130,
         "last_date": "2026-08-07",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "momentum_entry",
         "count": 42,
         "last_episode": 130,
         "last_date": "2026-08-07",
-        "days_since": 1,
-        "cools_in_days": 20
+        "days_since": 2,
+        "cools_in_days": 19
       },
       {
         "tag": "technical_support",
         "count": 11,
         "last_episode": 130,
         "last_date": "2026-08-07",
-        "days_since": 1,
-        "cools_in_days": 20
-      },
-      {
-        "tag": "bid_ask_spread",
-        "count": 32,
-        "last_episode": 129,
-        "last_date": "2026-08-06",
         "days_since": 2,
-        "cools_in_days": 43
+        "cools_in_days": 19
       },
       {
         "tag": "macro_rotation",
         "count": 23,
         "last_episode": 129,
         "last_date": "2026-08-06",
-        "days_since": 2,
-        "cools_in_days": 19
+        "days_since": 3,
+        "cools_in_days": 18
       },
       {
         "tag": "earnings_surprise",
         "count": 27,
         "last_episode": 128,
         "last_date": "2026-08-05",
-        "days_since": 3,
-        "cools_in_days": 18
-      },
-      {
-        "tag": "covered_call",
-        "count": 30,
-        "last_episode": 128,
-        "last_date": "2026-08-05",
-        "days_since": 3,
-        "cools_in_days": 18
+        "days_since": 4,
+        "cools_in_days": 17
       },
       {
         "tag": "technical_breakout",
         "count": 10,
         "last_episode": 128,
         "last_date": "2026-08-05",
-        "days_since": 3,
-        "cools_in_days": 18
+        "days_since": 4,
+        "cools_in_days": 17
       },
       {
         "tag": "fx_hedging",
         "count": 3,
         "last_episode": 126,
         "last_date": "2026-08-03",
-        "days_since": 5,
-        "cools_in_days": 16
+        "days_since": 6,
+        "cools_in_days": 15
       },
       {
         "tag": "risk_management",
         "count": 28,
         "last_episode": 125,
         "last_date": "2026-08-02",
-        "days_since": 6,
-        "cools_in_days": 15
+        "days_since": 7,
+        "cools_in_days": 14
       },
       {
         "tag": "sector_concentration",
         "count": 18,
         "last_episode": 123,
         "last_date": "2026-07-31",
-        "days_since": 8,
-        "cools_in_days": 13
+        "days_since": 9,
+        "cools_in_days": 12
       },
       {
         "tag": "order_flow_slippage",
         "count": 8,
         "last_episode": 119,
         "last_date": "2026-07-27",
-        "days_since": 12,
-        "cools_in_days": 33
+        "days_since": 13,
+        "cools_in_days": 32
       },
       {
         "tag": "portfolio_rebalancing",
         "count": 9,
         "last_episode": 118,
         "last_date": "2026-07-26",
-        "days_since": 13,
-        "cools_in_days": 8
-      },
-      {
-        "tag": "dollar_cost_averaging",
-        "count": 4,
-        "last_episode": 113,
-        "last_date": "2026-07-21",
-        "days_since": 18,
-        "cools_in_days": 3
+        "days_since": 14,
+        "cools_in_days": 7
       }
     ],
     "sector_concentration_warning": "tech: 30% of recent trades (cumulative P&L $+44.28)",
     "execution_health": {
       "signal": {
-        "generated_at": "2026-08-08",
+        "generated_at": "2026-08-09",
         "age_days": 0,
-        "action": "new_trade",
-        "symbol": "TBBK",
+        "action": "no_trade",
+        "symbol": null,
         "stale": false
       },
       "shadow": {
@@ -8468,13 +8472,13 @@
       "channels": {
         "en": {
           "subscribers": 291,
-          "subscribers_delta_7d": 31,
+          "subscribers_delta_7d": 23,
           "total_views": 74950,
           "video_count": 2394
         },
         "ru": {
           "subscribers": 103,
-          "subscribers_delta_7d": 25,
+          "subscribers_delta_7d": 24,
           "total_views": 75554,
           "video_count": 689
         },
@@ -9668,11 +9672,11 @@
     }
   },
   "efficiency": {
-    "cost_7d_usd": 31.7894,
-    "episodes_7d": 144,
+    "cost_7d_usd": 31.931,
+    "episodes_7d": 145,
     "op3_downloads_7d": 1201,
     "op3_downloads_30d": 4725,
-    "usd_per_op3_download_7d": 0.0265,
+    "usd_per_op3_download_7d": 0.0266,
     "youtube_views_window": 78547,
     "youtube_window_days": 90,
     "usd_per_yt_view": 0.0004,
@@ -9694,10 +9698,10 @@
         "spotify_streams_30d": null
       },
       "dp_pod": {
-        "cost_7d_usd": 0.8295,
+        "cost_7d_usd": 1.0175,
         "op3_downloads_7d": 14,
         "op3_downloads_30d": 34,
-        "usd_per_op3_download": 0.0593,
+        "usd_per_op3_download": 0.0727,
         "youtube_views": 0,
         "youtube_avg_view_pct": null,
         "youtube_subs_gained": 0,
@@ -9716,10 +9720,10 @@
         "spotify_streams_30d": null
       },
       "fascinating_frontiers": {
-        "cost_7d_usd": 3.2553,
+        "cost_7d_usd": 3.2442,
         "op3_downloads_7d": 83,
         "op3_downloads_30d": 309,
-        "usd_per_op3_download": 0.0392,
+        "usd_per_op3_download": 0.0391,
         "youtube_views": 23023,
         "youtube_avg_view_pct": 44.3,
         "youtube_subs_gained": 33,
@@ -9738,21 +9742,21 @@
         "spotify_streams_30d": 1
       },
       "first_principles": {
-        "cost_7d_usd": 2.2247,
+        "cost_7d_usd": 2.1927,
         "op3_downloads_7d": 41,
         "op3_downloads_30d": 114,
-        "usd_per_op3_download": 0.0543,
+        "usd_per_op3_download": 0.0535,
         "youtube_views": 861,
         "youtube_avg_view_pct": 38.4,
         "youtube_subs_gained": 1,
-        "usd_per_yt_view": 0.0026,
+        "usd_per_yt_view": 0.0025,
         "spotify_streams_30d": null
       },
       "models_agents": {
-        "cost_7d_usd": 3.1976,
+        "cost_7d_usd": 3.2227,
         "op3_downloads_7d": 131,
         "op3_downloads_30d": 625,
-        "usd_per_op3_download": 0.0244,
+        "usd_per_op3_download": 0.0246,
         "youtube_views": 1678,
         "youtube_avg_view_pct": 28.7,
         "youtube_subs_gained": 11,
@@ -9760,10 +9764,10 @@
         "spotify_streams_30d": 100
       },
       "models_agents_beginners": {
-        "cost_7d_usd": 2.751,
+        "cost_7d_usd": 2.7389,
         "op3_downloads_7d": 62,
         "op3_downloads_30d": 303,
-        "usd_per_op3_download": 0.0444,
+        "usd_per_op3_download": 0.0442,
         "youtube_views": 1001,
         "youtube_avg_view_pct": 21.0,
         "youtube_subs_gained": 10,
@@ -9771,14 +9775,14 @@
         "spotify_streams_30d": 9
       },
       "modern_investing": {
-        "cost_7d_usd": 3.4109,
+        "cost_7d_usd": 3.453,
         "op3_downloads_7d": 38,
         "op3_downloads_30d": 209,
-        "usd_per_op3_download": 0.0898,
+        "usd_per_op3_download": 0.0909,
         "youtube_views": 2756,
         "youtube_avg_view_pct": 39.2,
         "youtube_subs_gained": 1,
-        "usd_per_yt_view": 0.0012,
+        "usd_per_yt_view": 0.0013,
         "spotify_streams_30d": 52
       },
       "offshore_north": {
@@ -9793,10 +9797,10 @@
         "spotify_streams_30d": null
       },
       "omni_view": {
-        "cost_7d_usd": 3.1416,
+        "cost_7d_usd": 3.1212,
         "op3_downloads_7d": 44,
         "op3_downloads_30d": 215,
-        "usd_per_op3_download": 0.0714,
+        "usd_per_op3_download": 0.0709,
         "youtube_views": 887,
         "youtube_avg_view_pct": 26.0,
         "youtube_subs_gained": 2,
@@ -9804,14 +9808,14 @@
         "spotify_streams_30d": 7
       },
       "planetterrian": {
-        "cost_7d_usd": 2.8035,
+        "cost_7d_usd": 2.7687,
         "op3_downloads_7d": 73,
         "op3_downloads_30d": 338,
-        "usd_per_op3_download": 0.0384,
+        "usd_per_op3_download": 0.0379,
         "youtube_views": 400,
         "youtube_avg_view_pct": 50.1,
         "youtube_subs_gained": 3,
-        "usd_per_yt_view": 0.007,
+        "usd_per_yt_view": 0.0069,
         "spotify_streams_30d": 29
       },
       "privet_russian": {
@@ -9826,7 +9830,7 @@
         "spotify_streams_30d": 3
       },
       "spacex": {
-        "cost_7d_usd": 3.8145,
+        "cost_7d_usd": 3.8214,
         "op3_downloads_7d": 504,
         "op3_downloads_30d": 1452,
         "usd_per_op3_download": 0.0076,
@@ -9837,10 +9841,10 @@
         "spotify_streams_30d": 145
       },
       "tesla": {
-        "cost_7d_usd": 3.4197,
+        "cost_7d_usd": 3.4099,
         "op3_downloads_7d": 185,
         "op3_downloads_30d": 831,
-        "usd_per_op3_download": 0.0185,
+        "usd_per_op3_download": 0.0184,
         "youtube_views": 15671,
         "youtube_avg_view_pct": 49.3,
         "youtube_subs_gained": 20,
@@ -9862,7 +9866,7 @@
   },
   "catalog": {
     "shows_count": 16,
-    "network_episodes_to_date": 1841,
+    "network_episodes_to_date": 1852,
     "network_news_sources": 273,
     "network_web_search_queries": 72,
     "per_show": {
@@ -9889,9 +9893,9 @@
       },
       "dp_pod": {
         "name": "The DP Pod: The Do Positive Podcast",
-        "episodes_to_date": 29,
-        "episodes_in_feed": 29,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 30,
+        "episodes_in_feed": 30,
+        "latest_date": "2026-08-09",
         "news_sources": 10,
         "web_search_queries": 5,
         "narrative_mode": false,
@@ -9923,9 +9927,9 @@
       },
       "fascinating_frontiers": {
         "name": "Fascinating Frontiers",
-        "episodes_to_date": 155,
-        "episodes_in_feed": 144,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 156,
+        "episodes_in_feed": 145,
+        "latest_date": "2026-08-09",
         "news_sources": 25,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -9957,16 +9961,16 @@
       },
       "first_principles": {
         "name": "First Principles Daily",
-        "episodes_to_date": 64,
-        "episodes_in_feed": 64,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 65,
+        "episodes_in_feed": 65,
+        "latest_date": "2026-08-09",
         "news_sources": 0,
         "web_search_queries": 0,
         "narrative_mode": true,
         "topic_queue": {
           "total": 101,
-          "produced": 64,
-          "remaining": 37
+          "produced": 65,
+          "remaining": 36
         },
         "capabilities": {
           "x": false,
@@ -9978,9 +9982,9 @@
       },
       "models_agents": {
         "name": "Models & Agents",
-        "episodes_to_date": 135,
-        "episodes_in_feed": 135,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 136,
+        "episodes_in_feed": 136,
+        "latest_date": "2026-08-09",
         "news_sources": 20,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -9995,9 +9999,9 @@
       },
       "models_agents_beginners": {
         "name": "Models & Agents for Beginners",
-        "episodes_to_date": 127,
-        "episodes_in_feed": 127,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 128,
+        "episodes_in_feed": 128,
+        "latest_date": "2026-08-09",
         "news_sources": 15,
         "web_search_queries": 3,
         "narrative_mode": false,
@@ -10012,9 +10016,9 @@
       },
       "modern_investing": {
         "name": "Modern Investing Techniques",
-        "episodes_to_date": 131,
-        "episodes_in_feed": 131,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 132,
+        "episodes_in_feed": 132,
+        "latest_date": "2026-08-09",
         "news_sources": 22,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -10046,9 +10050,9 @@
       },
       "omni_view": {
         "name": "Omni View",
-        "episodes_to_date": 137,
-        "episodes_in_feed": 137,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 138,
+        "episodes_in_feed": 138,
+        "latest_date": "2026-08-09",
         "news_sources": 37,
         "web_search_queries": 5,
         "narrative_mode": false,
@@ -10063,9 +10067,9 @@
       },
       "planetterrian": {
         "name": "Planetterrian Daily",
-        "episodes_to_date": 145,
-        "episodes_in_feed": 133,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 146,
+        "episodes_in_feed": 134,
+        "latest_date": "2026-08-09",
         "news_sources": 26,
         "web_search_queries": 4,
         "narrative_mode": false,
@@ -10097,9 +10101,9 @@
       },
       "spacex": {
         "name": "SpaceX Daily",
-        "episodes_to_date": 63,
-        "episodes_in_feed": 63,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 64,
+        "episodes_in_feed": 64,
+        "latest_date": "2026-08-09",
         "news_sources": 15,
         "web_search_queries": 9,
         "narrative_mode": false,
@@ -10114,9 +10118,9 @@
       },
       "tesla": {
         "name": "Tesla Shorts Time",
-        "episodes_to_date": 566,
-        "episodes_in_feed": 219,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 567,
+        "episodes_in_feed": 220,
+        "latest_date": "2026-08-09",
         "news_sources": 20,
         "web_search_queries": 10,
         "narrative_mode": false,
@@ -10131,16 +10135,16 @@
       },
       "unintended_consequences": {
         "name": "Unintended Consequences",
-        "episodes_to_date": 83,
-        "episodes_in_feed": 83,
-        "latest_date": "2026-08-08",
+        "episodes_to_date": 84,
+        "episodes_in_feed": 84,
+        "latest_date": "2026-08-09",
         "news_sources": 0,
         "web_search_queries": 0,
         "narrative_mode": true,
         "topic_queue": {
           "total": 122,
-          "produced": 83,
-          "remaining": 39
+          "produced": 84,
+          "remaining": 38
         },
         "capabilities": {
           "x": true,
@@ -10154,16 +10158,16 @@
   },
   "gallery": {
     "configured": true,
-    "generated_at": "2026-08-08T10:31:56+00:00",
-    "image_count": 4861,
-    "latest_image_at": "2026-08-08T10:00:46+00:00",
+    "generated_at": "2026-08-09T10:35:26+00:00",
+    "image_count": 4929,
+    "latest_image_at": "2026-08-09T10:03:56+00:00",
     "per_show": {
       "env_intel": {
         "count": 104,
         "name": "Environmental Intelligence"
       },
       "fascinating_frontiers": {
-        "count": 471,
+        "count": 479,
         "name": "Fascinating Frontiers"
       },
       "finansy_prosto": {
@@ -10171,27 +10175,27 @@
         "name": "Финансы Просто"
       },
       "first_principles": {
-        "count": 419,
+        "count": 423,
         "name": "First Principles Daily"
       },
       "models_agents": {
-        "count": 360,
+        "count": 368,
         "name": "Models & Agents"
       },
       "models_agents_beginners": {
-        "count": 510,
+        "count": 518,
         "name": "Models & Agents for Beginners"
       },
       "modern_investing": {
-        "count": 456,
+        "count": 464,
         "name": "Modern Investing Techniques"
       },
       "omni_view": {
-        "count": 345,
+        "count": 353,
         "name": "Omni View"
       },
       "planetterrian": {
-        "count": 321,
+        "count": 325,
         "name": "Planetterrian Daily"
       },
       "privet_russian": {
@@ -10199,145 +10203,47 @@
         "name": "Привет, Русский!"
       },
       "spacex": {
-        "count": 487,
+        "count": 495,
         "name": "SpaceX Daily"
       },
       "tesla": {
-        "count": 656,
+        "count": 664,
         "name": "Tesla Shorts Time"
       },
       "unintended_consequences": {
-        "count": 308,
+        "count": 312,
         "name": "Unintended Consequences"
       }
     },
     "intended_use": {
-      "social": 2489,
-      "segment_card": 2372
+      "social": 2529,
+      "segment_card": 2400
     },
     "licenses": {
-      "CC BY-SA 4.0": 4861
+      "CC BY-SA 4.0": 4929
     },
     "retention": {
       "available": true,
-      "generated": "2026-08-07T17:50:14.238553+00:00",
+      "generated": "2026-08-08T17:25:46.509744+00:00",
       "shows_analyzed": 13,
-      "images_with_retention": 2955
+      "images_with_retention": 3039
     }
   },
   "content_lake": {
     "stats": {
-      "total_episodes": 1376,
-      "shows": [
-        "age_of_ai",
-        "dp_pod",
-        "env_intel",
-        "fascinating_frontiers",
-        "finansy_prosto",
-        "first_principles",
-        "models_agents",
-        "models_agents_beginners",
-        "modern_investing",
-        "offshore_north",
-        "omni_view",
-        "planetterrian",
-        "privet_russian",
-        "spacex",
-        "tesla",
-        "unintended_consequences"
-      ],
+      "total_episodes": 0,
+      "shows": [],
       "date_range": {
-        "earliest": "2026-02-26",
-        "latest": "2026-08-08"
+        "earliest": null,
+        "latest": null
       },
-      "per_show": {
-        "age_of_ai": {
-          "count": 2,
-          "earliest": "2026-07-20",
-          "latest": "2026-07-30"
-        },
-        "dp_pod": {
-          "count": 29,
-          "earliest": "2026-07-04",
-          "latest": "2026-08-08"
-        },
-        "env_intel": {
-          "count": 60,
-          "earliest": "2026-02-27",
-          "latest": "2026-08-03"
-        },
-        "fascinating_frontiers": {
-          "count": 124,
-          "earliest": "2026-02-26",
-          "latest": "2026-08-08"
-        },
-        "finansy_prosto": {
-          "count": 71,
-          "earliest": "2026-03-14",
-          "latest": "2026-08-03"
-        },
-        "first_principles": {
-          "count": 64,
-          "earliest": "2026-06-07",
-          "latest": "2026-08-08"
-        },
-        "models_agents": {
-          "count": 135,
-          "earliest": "2026-02-26",
-          "latest": "2026-08-08"
-        },
-        "models_agents_beginners": {
-          "count": 121,
-          "earliest": "2026-03-14",
-          "latest": "2026-08-08"
-        },
-        "modern_investing": {
-          "count": 131,
-          "earliest": "2026-03-20",
-          "latest": "2026-08-08"
-        },
-        "offshore_north": {
-          "count": 1,
-          "earliest": "2026-08-05",
-          "latest": "2026-08-05"
-        },
-        "omni_view": {
-          "count": 135,
-          "earliest": "2026-02-27",
-          "latest": "2026-08-08"
-        },
-        "planetterrian": {
-          "count": 122,
-          "earliest": "2026-02-26",
-          "latest": "2026-08-08"
-        },
-        "privet_russian": {
-          "count": 64,
-          "earliest": "2026-03-14",
-          "latest": "2026-08-03"
-        },
-        "spacex": {
-          "count": 63,
-          "earliest": "2026-06-13",
-          "latest": "2026-08-08"
-        },
-        "tesla": {
-          "count": 171,
-          "earliest": "2026-02-27",
-          "latest": "2026-08-08"
-        },
-        "unintended_consequences": {
-          "count": 83,
-          "earliest": "2026-05-04",
-          "latest": "2026-08-08"
-        }
-      },
-      "total_words": 1728227
+      "per_show": {},
+      "total_words": 0
     },
     "db_path": "data/content_lake.db",
     "db_exists": true,
-    "db_size_bytes": 52994048,
-    "healthy": true,
+    "db_size_bytes": 45056,
+    "healthy": false,
     "compaction_note": "Run scripts/compact_lake.py or engine.content_lake.compact_lake() to prune old full text."
   },
   "distribution": {
@@ -11037,6 +10943,362 @@
       }
     }
   },
+  "benchmarks": {
+    "configured": true,
+    "as_of": "2026-08",
+    "sources": [
+      {
+        "label": "Buzzsprout platform stats (episode downloads, first 7 days)",
+        "url": "https://www.buzzsprout.com/global_stats"
+      },
+      {
+        "label": "Podcast CPM guides (Acast, ADOPTER Media, AdvertiseOnPodcasts)",
+        "url": "https://advertise.acast.com/news-and-insights/how-much-does-podcast-advertising-cost"
+      },
+      {
+        "label": "Podcast M&A multiples (Jahani & Associates transaction review)",
+        "url": "https://jahaniandassociates.com/podcast-advertising-and-sports-podcast-advertising-ma-transactions-and-valuations/"
+      },
+      {
+        "label": "Newsletter valuation ranges (Flippa, Sponsy)",
+        "url": "https://flippa.com/blog/newsletter-channel-multiples-how-to-evaluate-a-newsletters-worth/"
+      },
+      {
+        "label": "Active-podcast + podfade counts (Podchaser, Podcast Industry Insights)",
+        "url": "https://www.podchaser.com/articles/podcast-insights/podcast-audience-demographics"
+      },
+      {
+        "label": "Production cost ranges (Podcast Engineers, industry guides)",
+        "url": "https://www.podcastengineers.com/blogs/podcast-editing-cost-2026/"
+      }
+    ],
+    "ladder": {
+      "median": 28,
+      "top_25pct": 119,
+      "top_10pct": 434,
+      "top_5pct": 1029,
+      "top_1pct": 4615
+    },
+    "method_note": "Per-episode figure = a show's OP3 downloads over the last 7 days ÷ episodes it published in those 7 days. That is a proxy for the industry's 'downloads in an episode's first 7 days' (back-catalog listening inflates it slightly; binge listening deflates it). Unmeasured shows report null, never 0.",
+    "per_show": {
+      "dp_pod": {
+        "dl_per_episode_7d": 2.8,
+        "percentile_band": "below median",
+        "episodes_7d": 5
+      },
+      "env_intel": {
+        "dl_per_episode_7d": 5.0,
+        "percentile_band": "below median",
+        "episodes_7d": 1
+      },
+      "fascinating_frontiers": {
+        "dl_per_episode_7d": 11.9,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "finansy_prosto": {
+        "dl_per_episode_7d": 0.0,
+        "percentile_band": "below median",
+        "episodes_7d": 1
+      },
+      "first_principles": {
+        "dl_per_episode_7d": 5.9,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "models_agents": {
+        "dl_per_episode_7d": 18.7,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "models_agents_beginners": {
+        "dl_per_episode_7d": 8.9,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "modern_investing": {
+        "dl_per_episode_7d": 5.4,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "omni_view": {
+        "dl_per_episode_7d": 6.3,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "planetterrian": {
+        "dl_per_episode_7d": 10.4,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "privet_russian": {
+        "dl_per_episode_7d": 0.0,
+        "percentile_band": "below median",
+        "episodes_7d": 1
+      },
+      "spacex": {
+        "dl_per_episode_7d": 50.4,
+        "percentile_band": "top 50%",
+        "episodes_7d": 10
+      },
+      "tesla": {
+        "dl_per_episode_7d": 26.4,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      },
+      "unintended_consequences": {
+        "dl_per_episode_7d": 3.0,
+        "percentile_band": "below median",
+        "episodes_7d": 7
+      }
+    },
+    "network": {
+      "dl_per_episode_7d": 14.6,
+      "percentile_band": "below median",
+      "episodes_7d": 82,
+      "wow_growth_median_pct": 17.1,
+      "cost_per_episode_usd": 0.39,
+      "cost_note": "Tracked Grok + TTS spend ÷ episodes published to the feeds in the same 7 days. Untracked lines (Grok Imagine imagery, some multilingual) roughly double it — still three orders of magnitude under market rates.",
+      "industry_cost_per_episode_usd": {
+        "diy_freelance_edit": [
+          50,
+          200
+        ],
+        "boutique_agency": [
+          200,
+          400
+        ],
+        "full_service": [
+          400,
+          1000
+        ]
+      },
+      "cost_advantage_x": [
+        1025,
+        2564
+      ],
+      "industry_structure": {
+        "indexed_podcast_feeds": 6000000,
+        "actively_publishing_shows": 400000,
+        "new_show_6mo_abandonment_pct": 42
+      }
+    },
+    "monetization_capacity": {
+      "monthly_downloads": 4725,
+      "podcast_ads_annual_usd": [
+        680,
+        5670
+      ],
+      "youtube_annual_usd": [
+        159,
+        955
+      ],
+      "cpm_assumptions": {
+        "programmatic": [
+          12,
+          25
+        ],
+        "host_read": [
+          25,
+          50
+        ],
+        "youtube_rpm": [
+          0.5,
+          3.0
+        ]
+      },
+      "note": "Illustrative capacity if inventory were sold at 2026 industry rates — the network currently runs ZERO ads by design. Podcast range = 1 programmatic slot at the low CPM to 2 host-read slots at the high CPM."
+    }
+  },
+  "investor": {
+    "configured": true,
+    "as_of": "2026-08",
+    "thesis": {
+      "shows": 16,
+      "episodes_per_week": 82,
+      "episodes_to_date": 1852,
+      "languages": 4,
+      "cost_per_episode_usd": 0.39,
+      "newsletter_per_sub_usd": [
+        1,
+        8
+      ]
+    },
+    "assets": [
+      {
+        "label": "Content library",
+        "value": "1,852 episodes",
+        "framing": "Replacement cost at boutique-agency production rates ($200–$400/episode) — what a traditional studio would charge to produce this catalog.",
+        "usd_range": [
+          370400,
+          740800
+        ]
+      },
+      {
+        "label": "Production engine",
+        "value": "16 shows · ~82/wk · $0.39/episode marginal cost",
+        "framing": "Fully autonomous pipeline: fetch → write → voice → mix → video → publish → analytics → self-review, in 5 languages, with no per-episode human labor. The engine, not any one show, is the core asset — a 17th show costs one YAML file.",
+        "usd_range": null
+      },
+      {
+        "label": "Audience & channels",
+        "value": "4,725 podcast downloads/30d · 399 YouTube subs · 150,633 lifetime views · 3 newsletter subs",
+        "framing": "Early but compounding: distribution live on Apple, Spotify and 3 YouTube channels; every video ends on a funnel-tagged site showcase feeding the newsletter.",
+        "usd_range": null
+      },
+      {
+        "label": "Image & data assets",
+        "value": "4,929 CC-licensed images · full-text content lake · per-episode analytics joined across 6 platforms",
+        "framing": "The feedback loops (retention-ranked imagery, adaptive publishing policy, experiment registry) compound output quality without adding headcount.",
+        "usd_range": null
+      }
+    ],
+    "scenarios": {
+      "configured": true,
+      "rows": [
+        {
+          "name": "hold",
+          "story": "growth stops today; the factory keeps publishing",
+          "downloads_month": {
+            "now": 4725,
+            "y1": 4725,
+            "y5": 4725
+          },
+          "revenue_capacity_annual_usd": {
+            "now": [
+              680,
+              5670
+            ],
+            "y1": [
+              680,
+              5670
+            ],
+            "y5": [
+              680,
+              5670
+            ]
+          },
+          "implied_ev_usd": {
+            "now": [
+              680,
+              22680
+            ],
+            "y1": [
+              680,
+              22680
+            ],
+            "y5": [
+              680,
+              22680
+            ]
+          }
+        },
+        {
+          "name": "base",
+          "story": "5%/mo year one, tapering to 2%/mo",
+          "downloads_month": {
+            "now": 4725,
+            "y1": 8485,
+            "y5": 21952
+          },
+          "revenue_capacity_annual_usd": {
+            "now": [
+              680,
+              5670
+            ],
+            "y1": [
+              1221,
+              10182
+            ],
+            "y5": [
+              3161,
+              26342
+            ]
+          },
+          "implied_ev_usd": {
+            "now": [
+              680,
+              22680
+            ],
+            "y1": [
+              1221,
+              40728
+            ],
+            "y5": [
+              3161,
+              105368
+            ]
+          }
+        },
+        {
+          "name": "upside",
+          "story": "10%/mo year one, tapering to 3%/mo",
+          "downloads_month": {
+            "now": 4725,
+            "y1": 14829,
+            "y5": 61277
+          },
+          "revenue_capacity_annual_usd": {
+            "now": [
+              680,
+              5670
+            ],
+            "y1": [
+              2135,
+              17794
+            ],
+            "y5": [
+              8823,
+              73532
+            ]
+          },
+          "implied_ev_usd": {
+            "now": [
+              680,
+              22680
+            ],
+            "y1": [
+              2135,
+              71176
+            ],
+            "y5": [
+              8823,
+              294128
+            ]
+          }
+        }
+      ],
+      "library": {
+        "episodes": {
+          "now": 1852,
+          "y1": 6116,
+          "y5": 23172
+        },
+        "replacement_usd": {
+          "now": [
+            370400,
+            740800
+          ],
+          "y1": [
+            1223200,
+            2446400
+          ],
+          "y5": [
+            4634400,
+            9268800
+          ]
+        }
+      },
+      "assumptions": [
+        "Scenarios, not forecasts — none of this is booked revenue.",
+        "Revenue capacity = monthly downloads × 12 ÷ 1,000 × CPM × slots (low: 1 programmatic slot at $12 CPM; high: 2 host-read slots at $50 CPM). The network currently sells zero ads.",
+        "Implied EV applies the 1–4x revenue multiple observed across 2020-24 podcast M&A to that capacity IF it were realized.",
+        "Episode counts assume the current cadence (~82/week) simply continues — the factory's marginal cost makes that the default, not a stretch.",
+        "Library replacement value prices episodes at boutique production rates ($200–$400). It is a cost-basis framing, not a resale price.",
+        "Trailing reality check: median WoW download growth over recent weeks is 17.1% — the scenarios deliberately assume much less."
+      ]
+    }
+  },
   "growth": {
     "channel_scorecard": {
       "configured": true,
@@ -11295,7 +11557,7 @@
           "shipped": "2026-08-05",
           "readout": "2026-08-12",
           "status": "reading",
-          "days_to_readout": 4,
+          "days_to_readout": 3,
           "overdue": false,
           "metric": null,
           "baseline": null,
@@ -11311,7 +11573,7 @@
           "shipped": "2026-08-06",
           "readout": "2026-08-13",
           "status": "reading",
-          "days_to_readout": 5,
+          "days_to_readout": 4,
           "overdue": false,
           "metric": "channel_views_wow_ru",
           "baseline": null,
@@ -11327,7 +11589,7 @@
           "shipped": "2026-07-30",
           "readout": "2026-08-13",
           "status": "reading",
-          "days_to_readout": 5,
+          "days_to_readout": 4,
           "overdue": false,
           "metric": "ru_short_vpd_max",
           "baseline": 60.9,
@@ -11343,11 +11605,11 @@
           "shipped": "2026-08-07",
           "readout": "2026-08-14",
           "status": "reading",
-          "days_to_readout": 6,
+          "days_to_readout": 5,
           "overdue": false,
           "metric": "dub_fragment_title_share_14d",
           "baseline": 0.66,
-          "value": 0.17,
+          "value": 0.15,
           "target": "fragment share of window-Short titles near zero",
           "criteria": null,
           "notes": "Was ~2/3 of @NerraRU Short titles once the 3-Short band shipped (mid-sentence transcript slices). Grok headline w/ clause-trim fallback; title-only metadata.\n"
@@ -11359,7 +11621,7 @@
           "shipped": "2026-07-30",
           "readout": "2026-08-15",
           "status": "reading",
-          "days_to_readout": 7,
+          "days_to_readout": 6,
           "overdue": false,
           "metric": "long_form_median_avp_en_14d",
           "baseline": 11.3,
@@ -11369,13 +11631,61 @@
           "notes": "Ten seconds of theme + a 35-word greeting used to push the first fact to ~second 28; Shorts (which skip the intro) hold ~42% on the same audio. Audio change — was A/B-listened per landmine #17.\n"
         },
         {
+          "id": "dub-long-form-probe",
+          "title": "RU+FR long-form dubs on tesla / spacex / FF (operator override)",
+          "area": "reach",
+          "shipped": "2026-08-07",
+          "readout": "2026-08-21",
+          "status": "reading",
+          "days_to_readout": 12,
+          "overdue": false,
+          "metric": "ru_long_vpd_max",
+          "baseline": 2.0,
+          "value": null,
+          "target": "RU/FR long_vpd clearing the RU floor (2.0) with retention above the ~9% the July demotion measured; watch fr_long_vpd_max too.\n",
+          "criteria": null,
+          "notes": "Operator-directed: dub_force_long_channels pins long-form ON for the big three on both dub channels regardless of tier; the Shorts supply ladder is untouched. Overrides the July RU long demotion (~9% retention, ~11 views/video) to give dubbed long-form a second, deliberate read. If the readout repeats the July numbers, remove the YAML flags and let the policy decide again.\n"
+        },
+        {
+          "id": "shorts-progress-bar",
+          "title": "Shorts progress bar (all channels)",
+          "area": "retention",
+          "shipped": "2026-08-07",
+          "readout": "2026-08-21",
+          "status": "reading",
+          "days_to_readout": 12,
+          "overdue": false,
+          "metric": null,
+          "baseline": null,
+          "value": null,
+          "target": "Short median AVP up vs the ~44% pre-bar level (compare EN+RU short retention before/after 08-07 in youtube_stats).\n",
+          "criteria": null,
+          "notes": "Thin animated cyan bar at the top of every Short — visible time remaining, the standard short-video retention device. Render-only; per-show opt-out youtube.shorts_progress_bar: false. NOTE: overlaps the staggered-shorts readout window — judge by retention (AVP), which stagger does not touch, not by views.\n"
+        },
+        {
+          "id": "site-outro-cards",
+          "title": "Site-showcase endings — outro card + Shorts site strip",
+          "area": "funnel",
+          "shipped": "2026-08-09",
+          "readout": "2026-08-23",
+          "status": "reading",
+          "days_to_readout": 14,
+          "overdue": false,
+          "metric": null,
+          "baseline": null,
+          "value": null,
+          "target": "utm_content=outro sessions appearing in api/funnel.json (QR scans) and click-through from video surfaces up vs the pre-08-09 level; newsletter captures from src-youtube-* tags are the end goal.\n",
+          "criteria": null,
+          "notes": "Long-form videos end on a card built from real nerranetwork.com screenshots (show page + network home) with a QR to the funnel-tagged show page; Shorts end cards gain the home page's show-grid strip. Render-only (outside landmine #17); per-show opt-outs youtube.outro_card_enabled / youtube.shorts_end_card_site_panel. Screenshots are committed (assets/site_screens) and refreshed by scripts/capture_site_screens.py.\n"
+        },
+        {
           "id": "fr-channel-decision",
           "title": "@NerraFR — keep or pause the dub channel",
           "area": "reach",
           "shipped": "2026-07-21",
           "readout": "2026-08-25",
           "status": "decide",
-          "days_to_readout": 17,
+          "days_to_readout": 16,
           "overdue": false,
           "metric": "fr_short_vpd_max",
           "baseline": 0.26,
@@ -11392,32 +11702,38 @@
       "shows": [
         {
           "slug": "fascinating_frontiers",
+          "pending": 3,
+          "posted_total": 3,
+          "max_overdue_hours": 1.9
+        },
+        {
+          "slug": "first_principles",
           "pending": 1,
-          "posted_total": 2,
+          "posted_total": 0,
           "max_overdue_hours": null
         },
         {
           "slug": "modern_investing",
-          "pending": 0,
+          "pending": 1,
           "posted_total": 1,
-          "max_overdue_hours": null
+          "max_overdue_hours": 1.9
         },
         {
           "slug": "spacex",
-          "pending": 1,
-          "posted_total": 2,
-          "max_overdue_hours": null
+          "pending": 3,
+          "posted_total": 3,
+          "max_overdue_hours": 1.9
         },
         {
           "slug": "tesla_shorts_time",
-          "pending": 2,
-          "posted_total": 4,
-          "max_overdue_hours": null
+          "pending": 3,
+          "posted_total": 6,
+          "max_overdue_hours": 1.9
         }
       ],
-      "pending_total": 4,
-      "posted_total": 9,
-      "max_overdue_hours": null,
+      "pending_total": 11,
+      "posted_total": 13,
+      "max_overdue_hours": 1.9,
       "sweep_stuck": false,
       "note": "Comments queue while a scheduled Short is private and are posted by the multilingual/nightly sweeps once it goes public. Entries kept 7 days; overdue > 48h = sweep broken."
     },
@@ -11504,19 +11820,19 @@
     "freshness": {
       "sources": {
         "youtube_stats": {
-          "age_hours": 0.0,
+          "age_hours": 23.6,
           "as_of": "2026-08-08T17:17:14.449601+00:00"
         },
         "youtube_policy": {
-          "age_hours": 0.0,
+          "age_hours": 23.6,
           "as_of": "2026-08-08T17:17:19.421623+00:00"
         },
         "op3_stats": {
-          "age_hours": 0.0,
+          "age_hours": 23.6,
           "as_of": "2026-08-08T17:15:51.172405+00:00"
         },
         "funnel": {
-          "age_hours": 0.0,
+          "age_hours": 23.6,
           "as_of": "2026-08-08T17:17:53+00:00"
         }
       },

--- a/docs/industry_benchmarks.yaml
+++ b/docs/industry_benchmarks.yaml
@@ -1,0 +1,72 @@
+# Industry benchmarks the dashboard compares Nerra Network against.
+#
+# Consumed by scripts/generate_dashboard.py::build_benchmarks_section and
+# ::build_investor_section. This file is the ONE place external market
+# numbers live — the generator never hardcodes an industry figure, so a
+# stale benchmark is a one-file fix and the dashboard can always render
+# provenance ("as of", sources) next to any comparison it draws.
+#
+# Honesty rules (same as api/funnel.json):
+#   - These are published industry figures, not our measurements. Every
+#     rendered comparison must carry the as_of date.
+#   - Ranges stay ranges — never collapse [25, 50] into "37.50".
+#   - When our own side of a comparison is unmeasured, the card renders
+#     "not measured", never 0.
+#
+# Refresh cadence: check the sources roughly quarterly; update as_of when
+# any number changes. tests/test_investor_dashboard.py pins the schema.
+
+as_of: "2026-08"
+
+sources:
+  - label: "Buzzsprout platform stats (episode downloads, first 7 days)"
+    url: "https://www.buzzsprout.com/global_stats"
+  - label: "Podcast CPM guides (Acast, ADOPTER Media, AdvertiseOnPodcasts)"
+    url: "https://advertise.acast.com/news-and-insights/how-much-does-podcast-advertising-cost"
+  - label: "Podcast M&A multiples (Jahani & Associates transaction review)"
+    url: "https://jahaniandassociates.com/podcast-advertising-and-sports-podcast-advertising-ma-transactions-and-valuations/"
+  - label: "Newsletter valuation ranges (Flippa, Sponsy)"
+    url: "https://flippa.com/blog/newsletter-channel-multiples-how-to-evaluate-a-newsletters-worth/"
+  - label: "Active-podcast + podfade counts (Podchaser, Podcast Industry Insights)"
+    url: "https://www.podchaser.com/articles/podcast-insights/podcast-audience-demographics"
+  - label: "Production cost ranges (Podcast Engineers, industry guides)"
+    url: "https://www.podcastengineers.com/blogs/podcast-editing-cost-2026/"
+
+# Downloads an EPISODE earns in its first 7 days — the standard
+# percentile ladder podcasters are ranked on (Buzzsprout live stats;
+# widely cited across 2025-2026 benchmark guides).
+podcast_episode_downloads_7d_percentiles:
+  median: 28
+  top_25pct: 119
+  top_10pct: 434
+  top_5pct: 1029
+  top_1pct: 4615
+
+# What advertisers pay per 1,000 downloads (USD CPM, 2026).
+podcast_cpm_usd:
+  programmatic: [12, 25]
+  host_read_midtier: [25, 50]
+
+# What producing ONE podcast episode costs at market rates (USD, 2026).
+production_cost_per_episode_usd:
+  diy_freelance_edit: [50, 200]
+  boutique_agency: [200, 400]
+  full_service: [400, 1000]
+
+# YouTube monetization + engagement reference points (2026).
+youtube:
+  shorts_avd_pct_typical: [40, 55]
+  blended_rpm_usd: [0.5, 3.0]     # conservative blend of Shorts + long-form
+  shorts_subs_per_1k_views_good: 5
+
+# Asset-valuation reference ranges (2026 market comps).
+valuation:
+  newsletter_value_per_free_subscriber_usd: [1, 8]
+  podcast_ma_revenue_multiple: [1, 4]     # avg deals 2020-2024; Stitcher went ~4.5x
+
+# Industry survival context — why "publishing daily, every day" is itself
+# a differentiator.
+industry_structure:
+  indexed_podcast_feeds: 6000000
+  actively_publishing_shows: 400000
+  new_show_6mo_abandonment_pct: 42

--- a/management.html
+++ b/management.html
@@ -83,10 +83,65 @@
     color: #04121d; }
   .view-note { font-size: 12px; color: var(--ink-4); margin-top: 6px; max-width: 62ch; }
 
-  /* Default (operator): sponsor-only surfaces stay hidden. */
+  /* Default (operator): sponsor-only surfaces stay hidden; everything
+     else shows. Three audiences, one page:
+       - operator  — everything (default)
+       - sponsor   — audience + catalogue only; no spend, no plumbing,
+                     no valuation talk
+       - investor  — audience + economics + benchmarks + value scenarios;
+                     internal plumbing (guards, voice, feeds) hidden
+     Attributes: [data-ops] internal plumbing · [data-econ] economics an
+     investor should see · [data-investor] valuation surfaces (operator +
+     investor) · [data-sponsor] sponsor hero only. */
   [data-sponsor] { display: none; }
   body.view-sponsor [data-sponsor] { display: revert; }
-  body.view-sponsor [data-ops] { display: none !important; }
+  body.view-sponsor [data-ops],
+  body.view-sponsor [data-econ],
+  body.view-sponsor [data-investor] { display: none !important; }
+  body.view-investor [data-ops] { display: none !important; }
+
+  /* ---- benchmark ladder + investor panels ---- */
+  .bench-ladder { position: relative; height: 46px; margin: 48px 0 4px;
+    background: var(--surface-2); border-radius: 8px; }
+  .bench-ladder .rung { position: absolute; top: 0; bottom: 0; width: 2px;
+    background: var(--hairline); }
+  .bench-ladder .rung .rl { position: absolute; top: 100%; margin-top: 4px;
+    transform: translateX(-50%); font-size: 10px; color: var(--ink-4);
+    white-space: nowrap; }
+  /* Stagger alternating rung labels into a second row so the log-scale
+     percentile marks (which bunch toward the right) stay readable. */
+  .bench-ladder .rung:nth-of-type(even) .rl { margin-top: 17px; }
+  .bench-ladder .rung:last-of-type .rl { transform: translateX(-85%); }
+  .bench-ladder .marker { position: absolute; top: -6px; bottom: -6px; width: 3px;
+    border-radius: 2px; background: var(--accent); }
+  .bench-ladder .marker .ml { position: absolute; bottom: 100%; margin-bottom: 4px;
+    transform: translateX(-50%); font-size: 11px; font-weight: 600;
+    color: var(--ink-1); white-space: nowrap; }
+  .scenario-table td:first-child { color: var(--ink-1); font-weight: 600; }
+  .scenario-table .rng { white-space: nowrap; }
+  .assumptions { margin: 10px 0 0; padding-left: 18px; font-size: 12px;
+    color: var(--ink-4); line-height: 1.55; }
+  .assumptions li { padding: 1px 0; }
+  .investor-hero { background: linear-gradient(135deg, rgba(107,71,255,0.10), transparent 55%),
+    var(--surface-1); border: 1px solid var(--hairline); border-radius: 16px;
+    padding: 20px 22px; margin-bottom: 22px; }
+  /* The hero leads only the investor view; the #investor section below
+     stays reachable from the operator view too. */
+  #investor-hero { display: none; }
+  body.view-investor #investor-hero { display: block; }
+  .investor-hero h2 { margin: 0 0 4px; font-size: 19px; letter-spacing: -0.01em; }
+  .asset-row { display: flex; gap: 14px; padding: 10px 0;
+    border-bottom: 1px solid var(--hairline); flex-wrap: wrap; }
+  .asset-row:last-child { border-bottom: none; }
+  .asset-row .a-label { flex: 0 0 170px; font-weight: 600; color: var(--ink-1);
+    font-size: 13px; }
+  .asset-row .a-body { flex: 1; min-width: 240px; }
+  .asset-row .a-value { font-size: 13.5px; color: var(--ink-1);
+    font-variant-numeric: tabular-nums; }
+  .asset-row .a-framing { font-size: 12px; color: var(--ink-3); margin-top: 3px;
+    line-height: 1.45; }
+  .asset-row .a-usd { flex: 0 0 auto; font-size: 13.5px; font-weight: 650;
+    color: var(--series-3); font-variant-numeric: tabular-nums; }
 
   /* ---- sponsor headline panel ---- */
   .sponsor-hero { background: linear-gradient(135deg, rgba(0,212,255,0.07), transparent 55%),
@@ -254,6 +309,7 @@
     <div class="view-switch" role="group" aria-label="Dashboard view">
       <button type="button" id="view-operator" aria-pressed="true">Operator</button>
       <button type="button" id="view-sponsor" aria-pressed="false">Sponsor</button>
+      <button type="button" id="view-investor" aria-pressed="false">Investor</button>
     </div>
     <div class="health-pills" id="status-summary" data-ops hidden>
       <span class="pill ok"><span id="count-ok">0</span>&nbsp;OK</span>
@@ -263,14 +319,12 @@
     </div>
   </div>
 </div>
-<div class="view-note" id="view-note" hidden>
-  Sponsor view — audience, reach and catalogue only. Internal spend and
-  pipeline-health panels are hidden. Share this page with
-  <code>?view=sponsor</code> to open it here directly.
-</div>
+<div class="view-note" id="view-note" hidden></div>
 
 <nav class="mc-nav" aria-label="Sections">
   <a href="#audience-section">Audience</a>
+  <a href="#benchmarks">Benchmarks</a>
+  <a href="#investor" data-investor>Investor</a>
   <a href="#distribution">Distribution</a>
   <a href="#catalog">Catalog</a>
   <a href="#operations" data-ops>Operations</a>
@@ -301,11 +355,27 @@
     <p class="view-note" id="sponsor-method" style="margin-top:15px;"></p>
   </section>
 
+  <section class="investor-hero" data-investor id="investor-hero" hidden>
+    <h2>The investment thesis — an autonomous media network</h2>
+    <div class="lede" id="investor-lede" style="color:var(--ink-3);font-size:13px;max-width:86ch;"></div>
+    <div class="reach-grid" id="investor-thesis-grid" style="margin-top:14px;"></div>
+  </section>
+
   <div class="tile-row" id="tile-row"></div>
 
   <section class="mc-section" id="audience-section">
     <h2>Audience <span class="pill-note" id="audience-status-pill"></span></h2>
     <div class="card-grid" id="audience-grid"></div>
+  </section>
+
+  <section class="mc-section" id="benchmarks">
+    <h2>Industry benchmarks — where Nerra sits <span class="pill-note" id="benchmarks-pill"></span></h2>
+    <div class="card-grid" id="benchmarks-grid"></div>
+  </section>
+
+  <section class="mc-section" id="investor" data-investor>
+    <h2>Investor view — what's being built &amp; what it's worth <span class="pill-note" id="investor-pill"></span></h2>
+    <div class="card-grid" id="investor-grid" style="grid-template-columns:1fr;"></div>
   </section>
 
   <section class="mc-section" id="growth-levers" data-ops>
@@ -499,7 +569,10 @@
     const tile = h("div", { class: "tile" });
     // Internal-only tiles (spend, per-episode cost) are hidden in the
     // shareable sponsor view — see the view switch at the bottom.
+    // `econ` tiles additionally stay visible in the investor view
+    // (economics are the moat; plumbing is not).
     if (opts.ops) tile.setAttribute("data-ops", "");
+    if (opts.econ) tile.setAttribute("data-econ", "");
     if (opts.sponsorOnly) tile.setAttribute("data-sponsor", "");
     tile.appendChild(h("div", { class: "t-label", text: label }));
     const v = h("div", { class: "t-value", text: value });
@@ -643,13 +716,13 @@
       spark: siteSpark,
       sparkTitle: "Daily active users, last " + siteSpark.length + " days" }));
   tiles.appendChild(statTile("Spend · 7d", money(data.network.total_cost_last_7_days_usd),
-    { ops: true,
+    { econ: true,
       sub: money(data.network.total_cost_last_30_days_usd) + " · 30d · " +
            (eff.usd_per_op3_download_7d != null
              ? ("$" + Number(eff.usd_per_op3_download_7d).toFixed(3) + "/RSS dl")
              : (money((cost.projections || {}).projected_weekly_usd) + "/wk burn")) }));
   tiles.appendChild(statTile("Episodes · 7d", fmt((cost.network_last_7_days || {}).episodes),
-    { ops: true,
+    { econ: true,
       sub: money((cost.projections || {}).avg_cost_per_episode_usd) + " avg / episode · " +
            fmt(catalog.shows_count || (data.network || {}).shows_count) + " shows" }));
   // Sponsor-facing counterparts to the two tiles above: the same
@@ -930,9 +1003,12 @@
     audGrid.appendChild(card);
   }
 
-  // Unit economics — cost vs each platform (never summed)
+  // Unit economics — cost vs each platform (never summed). Marked
+  // data-econ: hidden from sponsors (spend is internal), shown to
+  // investors (unit economics ARE the pitch).
   {
     const card = sectionCard("Unit economics", "Grok+TTS vs listening · not one reach number");
+    card.setAttribute("data-econ", "");
     if (!eff || eff.cost_7d_usd == null) {
       card.appendChild(h("p", { class: "fine-list", text: "Efficiency rollup not in this dashboard.json yet — regenerate." }));
     } else {
@@ -1222,6 +1298,273 @@
         "The Aug 6 outage made every downstream number silently a day stale " +
         "— staleness is now visible here and alerts past the threshold." }));
       grid.appendChild(card);
+    }
+  }
+
+  // ---------- industry benchmarks ----------
+  // The network's numbers NEXT TO the market's — percentile ladder,
+  // production-cost gap, monetization capacity. All external figures
+  // come from docs/industry_benchmarks.yaml via the generator, with
+  // provenance rendered ("industry data as of …").
+  {
+    const bm = data.benchmarks || {};
+    const grid = $("#benchmarks-grid");
+    const usd = (n) => (n == null ? "—" : "$" + compact(n));
+    const rangeUsd = (r) => (r && r.length === 2)
+      ? usd(r[0]) + "–" + usd(r[1]) : "—";
+    if (!bm.configured) {
+      const card = sectionCard("Industry benchmarks");
+      card.appendChild(h("p", { class: "fine-list",
+        html: "No <code>docs/industry_benchmarks.yaml</code> — add it and regenerate." }));
+      grid.appendChild(card);
+    } else {
+      $("#benchmarks-pill").textContent = "industry data as of " + (bm.as_of || "?");
+      const net = bm.network || {};
+      const ladder = bm.ladder || {};
+
+      // Card 1 — downloads per episode vs the percentile ladder.
+      {
+        const card = sectionCard("Downloads per episode vs industry",
+          "first-7-days ladder · Buzzsprout percentiles");
+        // Log-scale ladder: rungs at the industry percentiles, markers
+        // for the network and its best show.
+        const LMIN = 2, LMAX = 6000;
+        const x = (v) => {
+          const c = Math.min(LMAX, Math.max(LMIN, v));
+          return 2 + 96 * (Math.log10(c) - Math.log10(LMIN)) /
+            (Math.log10(LMAX) - Math.log10(LMIN));
+        };
+        const lad = h("div", { class: "bench-ladder" });
+        [["median", ladder.median], ["top 25%", ladder.top_25pct],
+         ["top 10%", ladder.top_10pct], ["top 5%", ladder.top_5pct],
+         ["top 1%", ladder.top_1pct]].forEach(([lbl, v]) => {
+          if (v == null) return;
+          const rung = h("div", { class: "rung", style: "left:" + x(v).toFixed(1) + "%;" });
+          rung.appendChild(h("span", { class: "rl", text: lbl + " · " + fmt(v) }));
+          lad.appendChild(rung);
+        });
+        const perShow = bm.per_show || {};
+        const ranked = Object.keys(perShow)
+          .filter((s) => perShow[s].dl_per_episode_7d != null)
+          .sort((a, b) => perShow[b].dl_per_episode_7d - perShow[a].dl_per_episode_7d);
+        if (net.dl_per_episode_7d != null) {
+          const m = h("div", { class: "marker", style: "left:" + x(net.dl_per_episode_7d).toFixed(1) + "%;" });
+          m.appendChild(h("span", { class: "ml", text: "network · " + net.dl_per_episode_7d }));
+          lad.appendChild(m);
+        }
+        if (ranked.length) {
+          const top = perShow[ranked[0]];
+          const m2 = h("div", { class: "marker",
+            style: "left:" + x(top.dl_per_episode_7d).toFixed(1) + "%;background:var(--series-3);" });
+          m2.appendChild(h("span", { class: "ml", style: "margin-bottom:22px;color:var(--series-3);",
+            text: ranked[0] + " · " + top.dl_per_episode_7d }));
+          lad.appendChild(m2);
+        }
+        card.appendChild(lad);
+        card.appendChild(h("div", { style: "height:32px;" }));
+        ranked.slice(0, 8).forEach((slug) => {
+          const v = perShow[slug];
+          card.appendChild(barRow(slug, Math.log10(Math.max(2, v.dl_per_episode_7d)),
+            Math.log10(LMAX),
+            v.dl_per_episode_7d + " dl/ep · " + (v.percentile_band || "—"),
+            { title: slug + ": " + v.episodes_7d + " episodes in the last 7d" }));
+        });
+        if (net.wow_growth_median_pct != null) {
+          card.appendChild(h("p", { class: "fine-list", html:
+            "<span class='k'>Network trend:</span> median <strong>" +
+            (net.wow_growth_median_pct > 0 ? "+" : "") + net.wow_growth_median_pct +
+            "% week-over-week</strong> download growth over recent weeks." }));
+        }
+        card.appendChild(h("p", { class: "platform-note", text: bm.method_note || "" }));
+        grid.appendChild(card);
+      }
+
+      // Card 2 — the economics gap + survival context. data-econ:
+      // internal spend stays off the sponsor view.
+      {
+        const card = sectionCard("The economics gap",
+          "cost per episode vs 2026 market rates");
+        card.setAttribute("data-econ", "");
+        const cost = net.cost_per_episode_usd;
+        const ind = net.industry_cost_per_episode_usd || {};
+        card.appendChild(h("div", { class: "headline",
+          html: (cost == null ? "—" : "$" + Number(cost).toFixed(2)) +
+                "<small>per published episode (tracked spend)</small>" }));
+        const rows = [
+          ["Nerra Network", cost, "var(--status-ok)"],
+          ["DIY + freelance edit", ind.diy_freelance_edit, "var(--series-4)"],
+          ["Boutique agency", ind.boutique_agency, "var(--series-2)"],
+          ["Full-service studio", ind.full_service, "var(--status-fail)"],
+        ];
+        const maxHi = Math.max.apply(null, rows.map((r) =>
+          Array.isArray(r[1]) ? r[1][1] : (r[1] || 0)).concat([1]));
+        rows.forEach(([lbl, v, color]) => {
+          const hi = Array.isArray(v) ? v[1] : v;
+          const txt = Array.isArray(v)
+            ? ("$" + fmt(v[0]) + "–$" + fmt(v[1]))
+            : (v == null ? "—" : "$" + Number(v).toFixed(2));
+          card.appendChild(barRow(lbl, hi || 0, maxHi, txt, { color: color }));
+        });
+        if (net.cost_advantage_x) {
+          card.appendChild(h("p", { class: "fine-list", html:
+            "<span class='k'>" + fmt(net.cost_advantage_x[0]) + "–" +
+            fmt(net.cost_advantage_x[1]) + "× cheaper</span> than " +
+            "full-service production at current tracked spend." }));
+        }
+        card.appendChild(h("p", { class: "platform-note", text: net.cost_note || "" }));
+        const st = net.industry_structure || {};
+        if (st.new_show_6mo_abandonment_pct) {
+          card.appendChild(h("p", { class: "fine-list", html:
+            "<span class='k'>Survival context:</span> of ~" +
+            compact(st.indexed_podcast_feeds) + " indexed podcasts only ~" +
+            compact(st.actively_publishing_shows) + " still publish, and <strong>" +
+            st.new_show_6mo_abandonment_pct + "% of new shows quit within 6 " +
+            "months</strong>. This network has published every scheduled day " +
+            "across " + fmt((data.catalog || {}).shows_count) + " shows — " +
+            "consistency is the moat automation buys." }));
+        }
+        grid.appendChild(card);
+      }
+
+      // Card 3 — monetization capacity (illustrative; zero ads today).
+      {
+        const mc = bm.monetization_capacity || {};
+        const card = sectionCard("Monetization capacity",
+          "illustrative · the network runs ZERO ads today");
+        card.setAttribute("data-econ", "");
+        if (mc.monthly_downloads == null) {
+          card.appendChild(h("p", { class: "fine-list", text: "Downloads not measured yet." }));
+        } else {
+          const grid2 = h("div", { class: "eff-grid" });
+          const cells = [
+            [rangeUsd(mc.podcast_ads_annual_usd), "podcast ads · annual capacity"],
+            [rangeUsd(mc.youtube_annual_usd), "YouTube RPM · annual capacity"],
+            [fmt(mc.monthly_downloads), "downloads / month today"],
+            [(mc.cpm_assumptions ? "$" + mc.cpm_assumptions.programmatic[0] +
+              "–$" + mc.cpm_assumptions.host_read[1] + " CPM" : "—"),
+              "assumed rate range"],
+          ];
+          cells.forEach(([n, l]) => {
+            const cell = h("div", { class: "eff-cell" });
+            cell.appendChild(h("div", { class: "eff-n", text: String(n) }));
+            cell.appendChild(h("div", { class: "eff-l", text: l }));
+            grid2.appendChild(cell);
+          });
+          card.appendChild(grid2);
+          card.appendChild(h("p", { class: "platform-note", text: mc.note || "" }));
+        }
+        grid.appendChild(card);
+      }
+    }
+  }
+
+  // ---------- investor view ----------
+  {
+    const inv = data.investor || {};
+    const grid = $("#investor-grid");
+    const usd = (n) => (n == null ? "—" : "$" + compact(n));
+    const rangeUsd = (r) => (r && r.length === 2)
+      ? usd(r[0]) + "–" + usd(r[1]) : "—";
+    if (inv.configured) {
+      const t = inv.thesis || {};
+      $("#investor-pill").textContent = "market comps as of " + (inv.as_of || "?");
+
+      // Hero (visible in investor view only — the [data-investor] hero
+      // block above the tiles).
+      const hero = $("#investor-hero");
+      if (hero) hero.hidden = false;
+      const lede = $("#investor-lede");
+      if (lede) {
+        lede.textContent =
+          "Nerra Network is a fully autonomous podcast + video network: " +
+          fmt(t.shows) + " original shows publishing ~" + fmt(t.episodes_per_week) +
+          " episodes a week in " + fmt(t.languages || 1) + " languages across " +
+          "Apple, Spotify, YouTube (3 channels), web and email — at a marginal " +
+          "cost of " + (t.cost_per_episode_usd != null
+            ? "$" + Number(t.cost_per_episode_usd).toFixed(2) : "—") +
+          " per episode. The asset is not any one show: it is the engine that " +
+          "writes, voices, edits, publishes, measures and improves the whole " +
+          "catalog with no per-episode human labor, plus the compounding " +
+          "content library and audience it produces.";
+      }
+      const tg = $("#investor-thesis-grid");
+      if (tg) {
+        [
+          { v: fmt(t.shows), l: "Original shows", s: "16 formats incl. two-host dialogue + live AI interviews" },
+          { v: "~" + fmt(t.episodes_per_week) + "/wk", l: "Episodes published", s: fmt(t.episodes_to_date) + " to date, growing daily" },
+          { v: fmt(t.languages || 1), l: "Languages", s: "same-day translated audio + dubbed video channels" },
+          { v: t.cost_per_episode_usd != null ? "$" + Number(t.cost_per_episode_usd).toFixed(2) : "—",
+            l: "Marginal cost / episode", s: "vs $400–$1,000 at a full-service studio" },
+        ].forEach((it) => {
+          const cell = h("div", { class: "reach-item" });
+          cell.appendChild(h("div", { class: "r-v", text: it.v }));
+          cell.appendChild(h("div", { class: "r-l", text: it.l }));
+          cell.appendChild(h("div", { class: "r-s", text: it.s }));
+          tg.appendChild(cell);
+        });
+      }
+
+      // Card A — asset inventory.
+      {
+        const card = sectionCard("What's been built", "asset inventory · market-comp framing");
+        (inv.assets || []).forEach((a) => {
+          const row = h("div", { class: "asset-row" });
+          row.appendChild(h("div", { class: "a-label", text: a.label }));
+          const body = h("div", { class: "a-body" });
+          body.appendChild(h("div", { class: "a-value", text: a.value }));
+          body.appendChild(h("div", { class: "a-framing", text: a.framing }));
+          row.appendChild(body);
+          if (a.usd_range) row.appendChild(h("div", { class: "a-usd", text: rangeUsd(a.usd_range) }));
+          card.appendChild(row);
+        });
+        grid.appendChild(card);
+      }
+
+      // Card B — value scenarios now / 1 yr / 5 yr.
+      {
+        const sc = inv.scenarios || {};
+        const card = sectionCard("Value scenarios — now · 1 year · 5 years",
+          "scenarios, not forecasts");
+        if (!sc.configured) {
+          card.appendChild(h("p", { class: "fine-list", text: "Downloads not measured yet — scenarios need a base." }));
+        } else {
+          const wrap = h("div", { style: "overflow-x:auto;" });
+          const tbl = h("table", { class: "mc-table scenario-table" });
+          tbl.innerHTML = "<thead><tr><th>Scenario</th><th>Downloads / mo</th>" +
+            "<th>Revenue capacity / yr</th><th>Implied EV (1–4× rev)</th></tr></thead>";
+          const tb = h("tbody");
+          (sc.rows || []).forEach((r) => {
+            [["now", "today"], ["y1", "in 1 year"], ["y5", "in 5 years"]].forEach(([k, when], i) => {
+              const tr = h("tr");
+              tr.appendChild(h("td", { text: i === 0 ? (r.name + " — " + r.story) : "" }));
+              tr.appendChild(h("td", { text: fmt(r.downloads_month[k]) + " · " + when }));
+              tr.appendChild(h("td", { class: "rng", text: rangeUsd(r.revenue_capacity_annual_usd[k]) }));
+              tr.appendChild(h("td", { class: "rng", text: rangeUsd(r.implied_ev_usd[k]) }));
+              tb.appendChild(tr);
+            });
+          });
+          tbl.appendChild(tb);
+          wrap.appendChild(tbl);
+          card.appendChild(wrap);
+          const lib = sc.library || {};
+          if (lib.replacement_usd) {
+            card.appendChild(h("p", { class: "fine-list", html:
+              "<span class='k'>Content-library replacement value</span> (cost basis, " +
+              "boutique rates): today <strong>" + rangeUsd(lib.replacement_usd.now) +
+              "</strong> (" + fmt(lib.episodes.now) + " eps) → 1 yr <strong>" +
+              rangeUsd(lib.replacement_usd.y1) + "</strong> (" + fmt(lib.episodes.y1) +
+              ") → 5 yr <strong>" + rangeUsd(lib.replacement_usd.y5) + "</strong> (" +
+              fmt(lib.episodes.y5) + ") at the current cadence." }));
+          }
+          const ul = h("ul", { class: "assumptions" });
+          (sc.assumptions || []).forEach((a) => ul.appendChild(h("li", { text: a })));
+          card.appendChild(ul);
+        }
+        grid.appendChild(card);
+      }
+    } else {
+      $("#investor-grid").appendChild(h("p", { class: "fine-list",
+        text: "Investor section not in this dashboard.json yet — regenerate." }));
     }
   }
 
@@ -2094,48 +2437,72 @@
   })();
 
   // ---------- view switch ----------
+  // Three audiences, one page: operator (everything), sponsor (audience
+  // + catalogue only), investor (audience + economics + benchmarks +
+  // value scenarios). The URL carries the choice so a shared link opens
+  // the way the sender intended.
   (function viewSwitch() {
-    const opBtn = $("#view-operator");
-    const spBtn = $("#view-sponsor");
+    const buttons = {
+      operator: $("#view-operator"),
+      sponsor: $("#view-sponsor"),
+      investor: $("#view-investor"),
+    };
     const note = $("#view-note");
-    if (!opBtn || !spBtn) return;
+    if (!buttons.operator || !buttons.sponsor || !buttons.investor) return;
 
     const h1 = document.querySelector(".mc-header h1");
     const sub = document.querySelector(".mc-header .subtitle:last-of-type");
-    const OPERATOR_H1 = h1 ? h1.textContent : "";
-    const OPERATOR_SUB = sub ? sub.textContent : "";
+    const VIEWS = {
+      operator: {
+        h1: h1 ? h1.textContent : "",
+        sub: sub ? sub.textContent : "",
+        note: "",
+      },
+      sponsor: {
+        h1: "Nerra Network — Audience & Reach",
+        sub: "Downloads, streams, views and subscribers — measured per platform, never blended into one number.",
+        note: "Sponsor view — audience, reach and catalogue only. Internal " +
+              "spend, valuation and pipeline panels are hidden. Share with " +
+              "?view=sponsor.",
+      },
+      investor: {
+        h1: "Nerra Network — Investor Overview",
+        sub: "The autonomous media network: audience, unit economics, industry benchmarks and value scenarios — every number measured or labelled a scenario.",
+        note: "Investor view — audience, economics, benchmarks and value " +
+              "scenarios. Internal pipeline plumbing is hidden. Share with " +
+              "?view=investor.",
+      },
+    };
 
     function apply(view, push) {
-      const sponsor = view === "sponsor";
-      document.body.classList.toggle("view-sponsor", sponsor);
-      opBtn.setAttribute("aria-pressed", String(!sponsor));
-      spBtn.setAttribute("aria-pressed", String(sponsor));
-      if (note) note.hidden = !sponsor;
-      // The masthead is operator language ("Mission Control", "spend").
-      // Swap it rather than leaving a sponsor reading a console header.
-      if (h1) h1.textContent = sponsor
-        ? "Nerra Network — Audience & Reach" : OPERATOR_H1;
-      if (sub) sub.textContent = sponsor
-        ? "Downloads, streams, views and subscribers — measured per platform, never blended into one number."
-        : OPERATOR_SUB;
+      if (!VIEWS[view]) view = "operator";
+      document.body.classList.toggle("view-sponsor", view === "sponsor");
+      document.body.classList.toggle("view-investor", view === "investor");
+      Object.keys(buttons).forEach((k) =>
+        buttons[k].setAttribute("aria-pressed", String(k === view)));
+      if (note) {
+        note.hidden = view === "operator";
+        note.textContent = VIEWS[view].note;
+      }
+      if (h1) h1.textContent = VIEWS[view].h1;
+      if (sub) sub.textContent = VIEWS[view].sub;
       try { localStorage.setItem("nerraDashView", view); } catch (e) { /* private mode */ }
       if (push) {
         const u = new URL(window.location.href);
-        if (sponsor) u.searchParams.set("view", "sponsor");
-        else u.searchParams.delete("view");
+        if (view === "operator") u.searchParams.delete("view");
+        else u.searchParams.set("view", view);
         history.replaceState(null, "", u);
       }
     }
 
-    // URL wins over the stored preference, so a shared link always opens
-    // the way the sender intended.
+    // URL wins over the stored preference.
     let initial = new URLSearchParams(window.location.search).get("view");
-    if (initial !== "sponsor" && initial !== "operator") {
+    if (!VIEWS[initial]) {
       try { initial = localStorage.getItem("nerraDashView"); } catch (e) { initial = null; }
     }
-    apply(initial === "sponsor" ? "sponsor" : "operator", false);
-    opBtn.addEventListener("click", () => apply("operator", true));
-    spBtn.addEventListener("click", () => apply("sponsor", true));
+    apply(VIEWS[initial] ? initial : "operator", false);
+    Object.keys(buttons).forEach((k) =>
+      buttons[k].addEventListener("click", () => apply(k, true)));
   })();
 })();
 </script>

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -2175,6 +2175,445 @@ def build_freshness_section(root: Path) -> Dict[str, Any]:
     return {"sources": out, "stale": stale, "warn_after_hours": 36}
 
 
+# ---------------------------------------------------------------------------
+# Industry benchmarks + investor view (Aug 2026)
+#
+# Two sections that put the network's numbers NEXT TO the market's:
+#   - "benchmarks": where each show and the network sit against published
+#     podcast-industry percentiles, CPM ranges and production costs.
+#   - "investor": what has been built (asset inventory with market-comp
+#     framing) and honest now / 1-year / 5-year value scenarios.
+#
+# All external figures come from docs/industry_benchmarks.yaml (one file,
+# provenance rendered), all internal figures from the same sections the
+# rest of the dashboard uses. House honesty rules apply throughout:
+# unmeasured = null (never 0), ranges stay ranges, projections are
+# labelled scenarios with their assumptions serialized next to them.
+# ---------------------------------------------------------------------------
+
+
+def _load_industry_benchmarks(root: Path) -> Optional[Dict[str, Any]]:
+    path = root / "docs" / "industry_benchmarks.yaml"
+    if not path.exists():
+        return None
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+_PUBDATE_RE = re.compile(r"<pubDate>([^<]+)</pubDate>")
+
+
+def _feed_episodes_last_7d(root: Path, network: Dict[str, Any]) -> Dict[str, int]:
+    """Count episodes each show actually PUBLISHED in the last 7 days,
+    from its RSS feed's pubDates.
+
+    The cost rollup's ``episodes_last_7_days`` counts credit_usage FILES,
+    which include multilingual dub tracks and re-runs — using it as the
+    per-episode-downloads denominator understated every show's placement
+    (145 "episodes"/week vs ~90 real ones). The feed is the publication
+    record, so it is the denominator.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+    out: Dict[str, int] = {}
+    for s in (network or {}).get("shows", []):
+        slug, rss_file = s.get("slug"), s.get("rss_file")
+        if not slug or not rss_file:
+            continue
+        path = root / rss_file
+        if not path.exists():
+            continue
+        count = 0
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+            for raw in _PUBDATE_RE.findall(text):
+                when = _parse_rfc822(raw.strip())
+                if when is None:
+                    continue
+                if when.tzinfo is None:
+                    when = when.replace(tzinfo=_dt.timezone.utc)
+                if (now - when).total_seconds() <= 7 * 86400:
+                    count += 1
+        except Exception:
+            continue
+        out[slug] = count
+    return out
+
+
+def _percentile_band(dl_7d: float, ladder: Dict[str, Any]) -> str:
+    """Map a first-7-days download count onto the industry ladder."""
+    try:
+        if dl_7d >= float(ladder.get("top_1pct", 4615)):
+            return "top 1%"
+        if dl_7d >= float(ladder.get("top_5pct", 1029)):
+            return "top 5%"
+        if dl_7d >= float(ladder.get("top_10pct", 434)):
+            return "top 10%"
+        if dl_7d >= float(ladder.get("top_25pct", 119)):
+            return "top 25%"
+        if dl_7d >= float(ladder.get("median", 28)):
+            return "top 50%"
+        return "below median"
+    except (TypeError, ValueError):
+        return "unknown"
+
+
+def build_benchmarks_section(
+    root: Path,
+    *,
+    audience: Dict[str, Any],
+    costs: Dict[str, Any],
+    network: Dict[str, Any],
+) -> Dict[str, Any]:
+    bm = _load_industry_benchmarks(root)
+    if not bm:
+        return {"configured": False}
+
+    ladder = bm.get("podcast_episode_downloads_7d_percentiles") or {}
+    op3 = (audience or {}).get("op3") or {}
+    section: Dict[str, Any] = {
+        "configured": True,
+        "as_of": bm.get("as_of"),
+        "sources": bm.get("sources") or [],
+        "ladder": ladder,
+        "method_note": (
+            "Per-episode figure = a show's OP3 downloads over the last 7 "
+            "days ÷ episodes it published in those 7 days. That is a proxy "
+            "for the industry's 'downloads in an episode's first 7 days' "
+            "(back-catalog listening inflates it slightly; binge listening "
+            "deflates it). Unmeasured shows report null, never 0."
+        ),
+    }
+
+    # Per-show placement. Episodes counted from each show's RSS feed
+    # (the publication record), NOT credit files — see
+    # _feed_episodes_last_7d for why.
+    episodes_by_slug = _feed_episodes_last_7d(root, network)
+    per_show: Dict[str, Any] = {}
+    op3_per_show = op3.get("per_show") or {}
+    for slug, row in op3_per_show.items():
+        eps = episodes_by_slug.get(slug) or 0
+        dl7 = row.get("downloads_7d")
+        if not eps or dl7 is None:
+            per_show[slug] = {
+                "dl_per_episode_7d": None,
+                "percentile_band": None,
+                "episodes_7d": eps,
+            }
+            continue
+        per_ep = round(float(dl7) / max(1, eps), 1)
+        per_show[slug] = {
+            "dl_per_episode_7d": per_ep,
+            "percentile_band": _percentile_band(per_ep, ladder),
+            "episodes_7d": eps,
+        }
+    section["per_show"] = per_show
+
+    # Network-level placement + trailing growth.
+    total_eps_7d = sum(episodes_by_slug.values())
+    net_dl7 = op3.get("network_downloads_7d")
+    net_per_ep = (
+        round(float(net_dl7) / total_eps_7d, 1)
+        if (op3.get("configured") and net_dl7 is not None and total_eps_7d)
+        else None
+    )
+    weekly = [
+        float(r[1] or 0) for r in (op3.get("network_weekly_history") or [])
+    ]
+    # Median week-over-week growth over the last up-to-8 complete pairs —
+    # median rather than mean so one outage week can't fake a trend.
+    # Pairs are built from the full series FIRST and then windowed;
+    # slicing each side separately misaligns when history is shorter
+    # than the window (every week paired with itself → 0% growth).
+    wow: List[float] = []
+    for a, b in list(zip(weekly[:-1], weekly[1:]))[-8:]:
+        if a > 0:
+            wow.append(100.0 * (b - a) / a)
+    wow_median = round(sorted(wow)[len(wow) // 2], 1) if wow else None
+
+    # Cost per PUBLISHED episode: tracked 7d Grok+TTS spend ÷ episodes
+    # the feeds actually gained. The projections' avg is per credit FILE
+    # (which include dub tracks), so it reads lower than reality.
+    spend_7d = (costs.get("network_last_7_days") or {}).get("total")
+    cost_per_episode = (
+        round(float(spend_7d) / total_eps_7d, 2)
+        if spend_7d and total_eps_7d else None
+    )
+    prod = bm.get("production_cost_per_episode_usd") or {}
+    full_service = prod.get("full_service") or [None, None]
+    cost_advantage = None
+    if cost_per_episode and full_service[0]:
+        cost_advantage = [
+            int(float(full_service[0]) / cost_per_episode),
+            int(float(full_service[1]) / cost_per_episode),
+        ]
+    section["network"] = {
+        "dl_per_episode_7d": net_per_ep,
+        "percentile_band": (
+            _percentile_band(net_per_ep, ladder) if net_per_ep is not None
+            else None
+        ),
+        "episodes_7d": total_eps_7d,
+        "wow_growth_median_pct": wow_median,
+        "cost_per_episode_usd": cost_per_episode,
+        "cost_note": (
+            "Tracked Grok + TTS spend ÷ episodes published to the feeds "
+            "in the same 7 days. Untracked lines (Grok Imagine imagery, "
+            "some multilingual) roughly double it — still three orders "
+            "of magnitude under market rates."
+        ),
+        "industry_cost_per_episode_usd": prod,
+        "cost_advantage_x": cost_advantage,
+        "industry_structure": bm.get("industry_structure") or {},
+    }
+
+    # Monetization capacity — illustrative only (the network runs no ads).
+    cpm = bm.get("podcast_cpm_usd") or {}
+    prog = cpm.get("programmatic") or [None, None]
+    host = cpm.get("host_read_midtier") or [None, None]
+    dl30 = op3.get("network_downloads_30d")
+    podcast_cap = None
+    if op3.get("configured") and dl30 and prog[0] and host[1]:
+        annual_impressions = float(dl30) * 12.0 / 1000.0
+        podcast_cap = [
+            int(annual_impressions * float(prog[0]) * 1),   # 1 programmatic slot
+            int(annual_impressions * float(host[1]) * 2),   # 2 host-read slots
+        ]
+    ytb = (audience or {}).get("youtube") or {}
+    rpm = (bm.get("youtube") or {}).get("blended_rpm_usd") or [None, None]
+    yt_cap = None
+    views_window = ytb.get("network_views")
+    window_days = ytb.get("window_days") or 90
+    if ytb.get("configured") and views_window and rpm[0]:
+        annual_views_k = float(views_window) * (365.0 / window_days) / 1000.0
+        yt_cap = [int(annual_views_k * float(rpm[0])),
+                  int(annual_views_k * float(rpm[1]))]
+    section["monetization_capacity"] = {
+        "monthly_downloads": dl30 if op3.get("configured") else None,
+        "podcast_ads_annual_usd": podcast_cap,
+        "youtube_annual_usd": yt_cap,
+        "cpm_assumptions": {"programmatic": prog, "host_read": host,
+                            "youtube_rpm": rpm},
+        "note": (
+            "Illustrative capacity if inventory were sold at 2026 industry "
+            "rates — the network currently runs ZERO ads by design. Podcast "
+            "range = 1 programmatic slot at the low CPM to 2 host-read "
+            "slots at the high CPM."
+        ),
+    }
+    return section
+
+
+def _grow(value: float, monthly_pct: float, months: int) -> float:
+    return value * ((1.0 + monthly_pct / 100.0) ** months)
+
+
+def build_investor_section(
+    root: Path,
+    *,
+    audience: Dict[str, Any],
+    costs: Dict[str, Any],
+    catalog: Dict[str, Any],
+    lake: Dict[str, Any],
+    gallery: Dict[str, Any],
+    network: Dict[str, Any],
+    benchmarks: Dict[str, Any],
+) -> Dict[str, Any]:
+    bm = _load_industry_benchmarks(root)
+    if not bm or not benchmarks.get("configured"):
+        return {"configured": False}
+
+    op3 = (audience or {}).get("op3") or {}
+    ytb = (audience or {}).get("youtube") or {}
+    nl = (audience or {}).get("newsletter") or {}
+    episodes_to_date = (catalog or {}).get("network_episodes_to_date") or 0
+    shows_count = (catalog or {}).get("shows_count") or 0
+    # Real published episodes/week + per-episode cost from the feeds
+    # (via benchmarks), not credit-file counts — see _feed_episodes_last_7d.
+    eps_per_week = (benchmarks.get("network") or {}).get("episodes_7d") or 0
+    avg_cost = (benchmarks.get("network") or {}).get("cost_per_episode_usd")
+
+    prod = bm.get("production_cost_per_episode_usd") or {}
+    boutique = prod.get("boutique_agency") or [200, 400]
+    library_replacement = (
+        [int(episodes_to_date * boutique[0]),
+         int(episodes_to_date * boutique[1])]
+        if episodes_to_date else None
+    )
+    # Finished-audio estimate from transcript words at a 150 wpm speaking
+    # rate — an estimate, and labelled as one.
+    total_words = ((lake or {}).get("stats") or {}).get("total_words") or 0
+    audio_hours_est = int(total_words / 150 / 60) if total_words else None
+
+    val = bm.get("valuation") or {}
+    nl_per_sub = val.get("newsletter_value_per_free_subscriber_usd") or [1, 8]
+    ma_multiple = val.get("podcast_ma_revenue_multiple") or [1, 4]
+
+    yt_subs = sum(
+        (c or {}).get("subscribers") or 0
+        for c in (ytb.get("channels") or {}).values()
+    )
+    yt_views_lifetime = sum(
+        (c or {}).get("total_views") or 0
+        for c in (ytb.get("channels") or {}).values()
+    )
+
+    assets = [
+        {
+            "label": "Content library",
+            "value": (f"{episodes_to_date:,} episodes"
+                      + (f" · ~{audio_hours_est:,} h finished audio (est.)"
+                         if audio_hours_est else "")),
+            "framing": (
+                "Replacement cost at boutique-agency production rates "
+                f"(${boutique[0]}–${boutique[1]}/episode) — what a "
+                "traditional studio would charge to produce this catalog."
+            ),
+            "usd_range": library_replacement,
+        },
+        {
+            "label": "Production engine",
+            "value": (f"{shows_count} shows · ~{eps_per_week}/wk · "
+                      + (f"${avg_cost:.2f}/episode marginal cost"
+                         if avg_cost else "cost not measured")),
+            "framing": (
+                "Fully autonomous pipeline: fetch → write → voice → mix → "
+                "video → publish → analytics → self-review, in 5 languages, "
+                "with no per-episode human labor. The engine, not any one "
+                "show, is the core asset — a 17th show costs one YAML file."
+            ),
+            "usd_range": None,
+        },
+        {
+            "label": "Audience & channels",
+            "value": (
+                f"{(op3.get('network_downloads_30d') or 0):,} podcast "
+                f"downloads/30d · {yt_subs:,} YouTube subs · "
+                f"{yt_views_lifetime:,} lifetime views · "
+                f"{(nl.get('subscriber_count') or 0):,} newsletter subs"
+            ),
+            "framing": (
+                "Early but compounding: distribution live on Apple, "
+                "Spotify and 3 YouTube channels; every video ends on a "
+                "funnel-tagged site showcase feeding the newsletter."
+            ),
+            "usd_range": None,
+        },
+        {
+            "label": "Image & data assets",
+            "value": (
+                f"{((gallery or {}).get('image_count') or 0):,} CC-licensed "
+                "images · full-text content lake · per-episode analytics "
+                "joined across 6 platforms"
+            ),
+            "framing": (
+                "The feedback loops (retention-ranked imagery, adaptive "
+                "publishing policy, experiment registry) compound output "
+                "quality without adding headcount."
+            ),
+            "usd_range": None,
+        },
+    ]
+
+    # ---- Value scenarios: now / 1 year / 5 years ----
+    dl30 = op3.get("network_downloads_30d") if op3.get("configured") else None
+    scenarios: Dict[str, Any] = {"configured": dl30 is not None}
+    if dl30 is not None:
+        cpm = bm.get("podcast_cpm_usd") or {}
+        prog_lo = float((cpm.get("programmatic") or [12])[0])
+        host_hi = float((cpm.get("host_read_midtier") or [25, 50])[1])
+
+        def capacity(monthly_dl: float) -> List[int]:
+            impressions_k = monthly_dl * 12.0 / 1000.0
+            return [int(impressions_k * prog_lo * 1),
+                    int(impressions_k * host_hi * 2)]
+
+        def ev(cap: List[int]) -> List[int]:
+            return [int(cap[0] * ma_multiple[0]), int(cap[1] * ma_multiple[1])]
+
+        # Growth assumptions: deliberately DETACHED from the hot trailing
+        # trend (recently ~double-digit weekly), because extrapolating a
+        # small base's hot streak for years is how dishonest decks are
+        # made. Year 1 runs at the named monthly rate; years 2-5 taper to
+        # the long-run rate. All three are scenarios, not forecasts.
+        specs = [
+            {"name": "hold", "y1_monthly_pct": 0.0, "later_monthly_pct": 0.0,
+             "story": "growth stops today; the factory keeps publishing"},
+            {"name": "base", "y1_monthly_pct": 5.0, "later_monthly_pct": 2.0,
+             "story": "5%/mo year one, tapering to 2%/mo"},
+            {"name": "upside", "y1_monthly_pct": 10.0, "later_monthly_pct": 3.0,
+             "story": "10%/mo year one, tapering to 3%/mo"},
+        ]
+        eps_y1 = episodes_to_date + eps_per_week * 52
+        eps_y5 = episodes_to_date + eps_per_week * 52 * 5
+        rows = []
+        for spec in specs:
+            dl_y1 = _grow(float(dl30), spec["y1_monthly_pct"], 12)
+            dl_y5 = _grow(dl_y1, spec["later_monthly_pct"], 48)
+            cap_now = capacity(float(dl30))
+            cap_y1 = capacity(dl_y1)
+            cap_y5 = capacity(dl_y5)
+            rows.append({
+                "name": spec["name"],
+                "story": spec["story"],
+                "downloads_month": {"now": int(dl30), "y1": int(dl_y1),
+                                    "y5": int(dl_y5)},
+                "revenue_capacity_annual_usd": {
+                    "now": cap_now, "y1": cap_y1, "y5": cap_y5},
+                "implied_ev_usd": {
+                    "now": ev(cap_now), "y1": ev(cap_y1), "y5": ev(cap_y5)},
+            })
+        scenarios.update({
+            "rows": rows,
+            "library": {
+                "episodes": {"now": episodes_to_date, "y1": eps_y1,
+                             "y5": eps_y5},
+                "replacement_usd": {
+                    "now": library_replacement,
+                    "y1": [eps_y1 * boutique[0], eps_y1 * boutique[1]],
+                    "y5": [eps_y5 * boutique[0], eps_y5 * boutique[1]],
+                },
+            },
+            "assumptions": [
+                "Scenarios, not forecasts — none of this is booked revenue.",
+                ("Revenue capacity = monthly downloads × 12 ÷ 1,000 × CPM × "
+                 f"slots (low: 1 programmatic slot at ${prog_lo:.0f} CPM; "
+                 f"high: 2 host-read slots at ${host_hi:.0f} CPM). The "
+                 "network currently sells zero ads."),
+                (f"Implied EV applies the {ma_multiple[0]}–{ma_multiple[1]}x "
+                 "revenue multiple observed across 2020-24 podcast M&A to "
+                 "that capacity IF it were realized."),
+                ("Episode counts assume the current cadence "
+                 f"(~{eps_per_week}/week) simply continues — the factory's "
+                 "marginal cost makes that the default, not a stretch."),
+                (f"Library replacement value prices episodes at boutique "
+                 f"production rates (${boutique[0]}–${boutique[1]}). It is "
+                 "a cost-basis framing, not a resale price."),
+                (f"Trailing reality check: median WoW download growth over "
+                 "recent weeks is "
+                 f"{benchmarks.get('network', {}).get('wow_growth_median_pct')}"
+                 "% — the scenarios deliberately assume much less."),
+            ],
+        })
+    section = {
+        "configured": True,
+        "as_of": bm.get("as_of"),
+        "thesis": {
+            "shows": shows_count,
+            "episodes_per_week": eps_per_week,
+            "episodes_to_date": episodes_to_date,
+            "languages": None,  # filled by caller (needs multilingual)
+            "cost_per_episode_usd": avg_cost,
+            "newsletter_per_sub_usd": nl_per_sub,
+        },
+        "assets": assets,
+        "scenarios": scenarios,
+    }
+    return section
+
+
 def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optional[int] = None) -> Dict[str, Any]:
     shows = load_shows_from_yaml(root / "shows", root)
     rss = audit_rss_enclosures(root, offline=offline)
@@ -2250,6 +2689,27 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
     audience = build_audience_section(root)
     efficiency = build_efficiency_section(costs, audience)
 
+    multilingual = aggregate_multilingual(root, shows)
+    catalog_section = build_catalog_section(root, shows, rss)
+    lake_section = build_content_lake_section(root)
+    gallery_section = build_gallery_section(root)
+
+    # Industry benchmarks + investor view (Aug 2026): built from the
+    # sections above so every comparison uses the same numbers the rest
+    # of the dashboard renders.
+    benchmarks = build_benchmarks_section(
+        root, audience=audience, costs=costs, network=network)
+    investor = build_investor_section(
+        root, audience=audience, costs=costs, catalog=catalog_section,
+        lake=lake_section, gallery=gallery_section, network=network,
+        benchmarks=benchmarks)
+    if investor.get("configured"):
+        langs = {"en"}
+        for entry in (multilingual.get("per_show") or {}).values():
+            for lang in entry.get("languages") or []:
+                langs.add(str(lang))
+        investor["thesis"]["languages"] = len(langs)
+
     return {
         "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "network": network,
@@ -2258,18 +2718,20 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "alerts": alerts,
         "voice_config": voice,
         "cost_rollup": costs,
-        "multilingual": aggregate_multilingual(root, shows),
+        "multilingual": multilingual,
         "pipeline_health": metrics,
         "rss_audit": rss,
         "mit_performance": aggregate_mit_performance(root),
         "audience": audience,
         "efficiency": efficiency,
-        "catalog": build_catalog_section(root, shows, rss),
-        "gallery": build_gallery_section(root),
-        "content_lake": build_content_lake_section(root),
+        "catalog": catalog_section,
+        "gallery": gallery_section,
+        "content_lake": lake_section,
         "distribution": build_distribution_section(root),
         "youtube_policy": build_youtube_policy_section(root),
         "funnel": build_funnel_section(root),
+        "benchmarks": benchmarks,
+        "investor": investor,
         # Growth levers (Aug 2026): trends, experiments, stagger, specials.
         "growth": {
             "channel_scorecard": build_channel_scorecard(root),

--- a/tests/test_investor_dashboard.py
+++ b/tests/test_investor_dashboard.py
@@ -1,0 +1,248 @@
+"""Drift guards for the industry-benchmarks + investor dashboard sections
+(Aug 2026).
+
+The dashboard now compares the network against published industry
+figures and renders an investor view with value scenarios. Under guard:
+
+* ``docs/industry_benchmarks.yaml`` — the ONE place external market
+  numbers live; schema pinned so the generator can rely on it.
+* ``build_benchmarks_section`` — percentile placement, feed-based
+  episode counting (credit files include dub tracks and must not be the
+  denominator), WoW-median pairing, null-honesty.
+* ``build_investor_section`` — asset inventory + now/1y/5y scenarios
+  with serialized assumptions; scenarios never render without a
+  measured download base.
+* ``management.html`` — three-view switch + the new sections' wiring.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location(
+        "generate_dashboard_test", PROJECT_ROOT / "scripts" / "generate_dashboard.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["generate_dashboard_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def gd():
+    return _load_generator()
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks file schema
+# ---------------------------------------------------------------------------
+
+class TestBenchmarksFile:
+    def test_schema(self):
+        data = yaml.safe_load(
+            (PROJECT_ROOT / "docs" / "industry_benchmarks.yaml").read_text(
+                encoding="utf-8"))
+        assert data.get("as_of"), "benchmarks need an as_of date"
+        assert data.get("sources"), "benchmarks must cite sources"
+        ladder = data["podcast_episode_downloads_7d_percentiles"]
+        # The ladder must be strictly increasing — a mis-edit here would
+        # silently misplace every show.
+        rungs = [ladder["median"], ladder["top_25pct"], ladder["top_10pct"],
+                 ladder["top_5pct"], ladder["top_1pct"]]
+        assert rungs == sorted(rungs) and len(set(rungs)) == 5
+        for key in ("podcast_cpm_usd", "production_cost_per_episode_usd",
+                    "valuation", "industry_structure", "youtube"):
+            assert key in data, key
+        for name, rng in data["podcast_cpm_usd"].items():
+            assert len(rng) == 2 and rng[0] < rng[1], name
+
+
+# ---------------------------------------------------------------------------
+# Percentile mapping + WoW median
+# ---------------------------------------------------------------------------
+
+class TestBenchmarksSection:
+    LADDER = {"median": 28, "top_25pct": 119, "top_10pct": 434,
+              "top_5pct": 1029, "top_1pct": 4615}
+
+    def test_percentile_band_mapping(self, gd):
+        f = gd._percentile_band
+        assert f(10, self.LADDER) == "below median"
+        assert f(28, self.LADDER) == "top 50%"
+        assert f(120, self.LADDER) == "top 25%"
+        assert f(500, self.LADDER) == "top 10%"
+        assert f(2000, self.LADDER) == "top 5%"
+        assert f(9999, self.LADDER) == "top 1%"
+
+    def test_wow_median_short_history_not_zero(self, gd, tmp_path, monkeypatch):
+        """Regression: with <9 weeks of history the old slice logic paired
+        each week with itself and reported 0% growth."""
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "industry_benchmarks.yaml").write_text(
+            (PROJECT_ROOT / "docs" / "industry_benchmarks.yaml").read_text(
+                encoding="utf-8"), encoding="utf-8")
+        audience = {"op3": {
+            "configured": True,
+            "network_downloads_7d": 700,
+            "network_downloads_30d": 2800,
+            "per_show": {},
+            "network_weekly_history": [
+                ["2026-07-06", 500], ["2026-07-13", 550],
+                ["2026-07-20", 605], ["2026-07-27", 700],
+            ],
+        }, "youtube": {}}
+        out = gd.build_benchmarks_section(
+            tmp_path, audience=audience, costs={}, network={"shows": []})
+        wow = out["network"]["wow_growth_median_pct"]
+        assert wow is not None and wow == pytest.approx(10.0, abs=0.5)
+
+    def test_unconfigured_without_file(self, gd, tmp_path):
+        out = gd.build_benchmarks_section(
+            tmp_path, audience={}, costs={}, network={})
+        assert out == {"configured": False}
+
+    def test_feed_episode_denominator(self, gd, tmp_path):
+        """Episodes come from RSS pubDates, not credit files."""
+        now = _dt.datetime.now(_dt.timezone.utc)
+        recent = (now - _dt.timedelta(days=2)).strftime(
+            "%a, %d %b %Y %H:%M:%S +0000")
+        old = (now - _dt.timedelta(days=30)).strftime(
+            "%a, %d %b %Y %H:%M:%S +0000")
+        (tmp_path / "feed.rss").write_text(
+            f"<rss><channel><item><pubDate>{recent}</pubDate></item>"
+            f"<item><pubDate>{recent}</pubDate></item>"
+            f"<item><pubDate>{old}</pubDate></item></channel></rss>",
+            encoding="utf-8")
+        counts = gd._feed_episodes_last_7d(
+            tmp_path, {"shows": [{"slug": "x", "rss_file": "feed.rss"}]})
+        assert counts == {"x": 2}
+
+    def test_monetization_null_without_op3(self, gd, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "industry_benchmarks.yaml").write_text(
+            (PROJECT_ROOT / "docs" / "industry_benchmarks.yaml").read_text(
+                encoding="utf-8"), encoding="utf-8")
+        out = gd.build_benchmarks_section(
+            tmp_path, audience={"op3": {"configured": False}, "youtube": {}},
+            costs={}, network={"shows": []})
+        mc = out["monetization_capacity"]
+        assert mc["monthly_downloads"] is None
+        assert mc["podcast_ads_annual_usd"] is None
+
+
+# ---------------------------------------------------------------------------
+# Investor section
+# ---------------------------------------------------------------------------
+
+class TestInvestorSection:
+    def _fixture_root(self, tmp_path):
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "industry_benchmarks.yaml").write_text(
+            (PROJECT_ROOT / "docs" / "industry_benchmarks.yaml").read_text(
+                encoding="utf-8"), encoding="utf-8")
+        return tmp_path
+
+    def _audience(self):
+        return {
+            "op3": {"configured": True, "network_downloads_30d": 4000,
+                    "network_downloads_7d": 1000, "per_show": {},
+                    "network_weekly_history": []},
+            "youtube": {"configured": True, "channels": {
+                "en": {"subscribers": 100, "total_views": 50000}}},
+            "newsletter": {"configured": True, "subscriber_count": 5},
+        }
+
+    def test_scenarios_shape(self, gd, tmp_path):
+        root = self._fixture_root(tmp_path)
+        bm = gd.build_benchmarks_section(
+            root, audience=self._audience(),
+            costs={"network_last_7_days": {"total": 30.0}},
+            network={"shows": []})
+        inv = gd.build_investor_section(
+            root, audience=self._audience(),
+            costs={"network_last_7_days": {"total": 30.0}},
+            catalog={"network_episodes_to_date": 1000, "shows_count": 16},
+            lake={"stats": {"total_words": 900000}},
+            gallery={"image_count": 4000},
+            network={"shows": []}, benchmarks=bm)
+        assert inv["configured"] is True
+        sc = inv["scenarios"]
+        assert sc["configured"] is True
+        names = [r["name"] for r in sc["rows"]]
+        assert names == ["hold", "base", "upside"]
+        for r in sc["rows"]:
+            # hold never grows; growth is monotone across scenarios.
+            assert r["downloads_month"]["y5"] >= r["downloads_month"]["now"]
+            for k in ("now", "y1", "y5"):
+                lo, hi = r["implied_ev_usd"][k]
+                assert 0 <= lo <= hi
+        assert sc["rows"][0]["downloads_month"]["y5"] == \
+            sc["rows"][0]["downloads_month"]["now"]
+        # Assumptions must ship WITH the numbers — scenarios without
+        # their assumptions are how dishonest decks are made.
+        assert len(sc["assumptions"]) >= 4
+        assert any("not forecasts" in a for a in sc["assumptions"])
+
+    def test_scenarios_need_measured_base(self, gd, tmp_path):
+        root = self._fixture_root(tmp_path)
+        audience = {"op3": {"configured": False}, "youtube": {},
+                    "newsletter": {}}
+        bm = gd.build_benchmarks_section(
+            root, audience=audience, costs={}, network={"shows": []})
+        inv = gd.build_investor_section(
+            root, audience=audience, costs={},
+            catalog={"network_episodes_to_date": 100, "shows_count": 16},
+            lake={}, gallery={}, network={"shows": []}, benchmarks=bm)
+        assert inv["scenarios"]["configured"] is False
+
+    def test_asset_inventory_labels(self, gd, tmp_path):
+        root = self._fixture_root(tmp_path)
+        bm = gd.build_benchmarks_section(
+            root, audience=self._audience(), costs={}, network={"shows": []})
+        inv = gd.build_investor_section(
+            root, audience=self._audience(), costs={},
+            catalog={"network_episodes_to_date": 1000, "shows_count": 16},
+            lake={}, gallery={}, network={"shows": []}, benchmarks=bm)
+        labels = [a["label"] for a in inv["assets"]]
+        assert "Content library" in labels
+        assert "Production engine" in labels
+        lib = next(a for a in inv["assets"] if a["label"] == "Content library")
+        assert lib["usd_range"][0] < lib["usd_range"][1]
+
+
+# ---------------------------------------------------------------------------
+# Dashboard JSON + page wiring
+# ---------------------------------------------------------------------------
+
+class TestWiring:
+    def test_dashboard_json_carries_sections(self):
+        d = json.loads((PROJECT_ROOT / "api" / "dashboard.json").read_text(
+            encoding="utf-8"))
+        assert d.get("benchmarks", {}).get("configured") is True
+        assert d.get("investor", {}).get("configured") is True
+
+    def test_management_html_three_views(self):
+        src = (PROJECT_ROOT / "management.html").read_text(encoding="utf-8")
+        for needle in (
+            'id="view-investor"', 'id="benchmarks-grid"', 'id="investor-grid"',
+            'id="investor-hero"', "view-investor",
+            "data.benchmarks", "data.investor",
+            # Honesty labels must survive future edits.
+            "scenarios, not forecasts", "ZERO ads",
+        ):
+            assert needle in src, needle
+
+    def test_sponsor_hides_econ_css(self):
+        src = (PROJECT_ROOT / "management.html").read_text(encoding="utf-8")
+        assert "body.view-sponsor [data-econ]" in src
+        assert "body.view-investor [data-ops]" in src

--- a/tests/test_management_views.py
+++ b/tests/test_management_views.py
@@ -99,8 +99,15 @@ class TestViewSwitch:
         assert 'id="view-sponsor" aria-pressed="false"' in src
 
     def test_sponsor_hides_ops_and_shows_sponsor_surfaces(self):
+        """Aug 2026: the sponsor view hides ops, econ AND investor
+        surfaces (one grouped rule); the investor view hides ops only."""
         src = _page()
-        assert "body.view-sponsor [data-ops] { display: none !important; }" in src
+        assert re.search(
+            r"body\.view-sponsor \[data-ops\],\s*"
+            r"body\.view-sponsor \[data-econ\],\s*"
+            r"body\.view-sponsor \[data-investor\] \{ display: none !important; \}",
+            src)
+        assert "body.view-investor [data-ops] { display: none !important; }" in src
         assert "[data-sponsor] { display: none; }" in src
         assert "body.view-sponsor [data-sponsor] { display: revert; }" in src
 
@@ -116,12 +123,15 @@ class TestViewSwitch:
         for section in ("operations", "library", "guards", "voice", "feeds"):
             assert f'<section class="mc-section" data-ops id="{section}">' in src, section
 
-    def test_spend_tiles_are_operator_only(self):
+    def test_spend_tiles_are_econ_tagged(self):
+        """Aug 2026: spend tiles moved from data-ops to data-econ —
+        still hidden from sponsors, but visible in the investor view
+        (unit economics are the pitch)."""
         src = _page()
         spend = src[src.index('statTile("Spend · 7d"'):]
-        assert "ops: true" in spend[:400]
+        assert "econ: true" in spend[:400]
         episodes = src[src.index('statTile("Episodes · 7d"'):]
-        assert "ops: true" in episodes[:400]
+        assert "econ: true" in episodes[:400]
 
     def test_url_parameter_overrides_the_stored_preference(self):
         """A shared ?view=sponsor link must open in sponsor view even for


### PR DESCRIPTION
Deep review of management.html + a research pass over 2026 dashboard-design practice, podcast-industry benchmarks, YouTube analytics norms and media-asset valuation — turned into an upgraded mission control that speaks to three audiences from one page.

## Three views, one page

| View | URL | Shows | Hides |
|---|---|---|---|
| **Operator** (default) | `management.html` | everything | — |
| **Sponsor** | `?view=sponsor` | audience, reach, catalogue | spend, valuation, plumbing |
| **Investor** (NEW) | `?view=investor` | thesis hero, audience, unit economics, benchmarks, value scenarios | internal pipeline plumbing |

Also fixed: the Unit-economics card (internal spend) was previously visible in the sponsor view — it's now `data-econ` (sponsors never see spend; investors do, because unit economics are the pitch).

## New: Industry benchmarks — where Nerra sits

Every external market figure lives ONLY in **`docs/industry_benchmarks.yaml`** (with sources and an `as_of` date the page renders) — the generator never hardcodes an industry number, so a stale benchmark is a one-file fix.

- **Percentile ladder**: each show's downloads-per-episode placed on the Buzzsprout first-7-days ladder (log-scale visual: median 28 → top 1% 4,615). Today: SpaceX Daily ~50/ep (top 50%), network 14.6/ep, **median +17.1% week-over-week growth**.
- **The economics gap**: $0.39/published episode tracked spend vs $50–$1,000 market production rates — **1,000–2,500× cheaper** than full-service, with the untracked-lines caveat stated.
- **Survival context**: ~6M indexed podcasts, ~400K still publishing, 42% of new shows quit within 6 months — consistency is the moat automation buys.
- **Monetization capacity**: illustrative annual capacity at 2026 CPM/RPM rates, loudly labelled — the network runs **ZERO ads** today.

## New: Investor view — what's being built & what it's worth

- **Thesis hero**: 16 shows · ~82 episodes/week · 5 languages · $0.39/episode marginal cost. The asset is the engine, not any one show — a 17th show costs one YAML file.
- **Asset inventory** with market-comp framing: content-library replacement value at boutique production rates ($370K–$741K today for 1,852 episodes), the autonomous production engine, audience & channels, image + data assets.
- **Value scenarios — now / 1 year / 5 years**: hold / base / upside rows with downloads/mo, annual revenue capacity, and implied EV at the 1–4× revenue multiples observed across 2020-24 podcast M&A. Library replacement value grows to **$4.6M–$9.3M by year 5** at the current cadence alone.
- **Honesty is structural**: every scenario ships with its assumptions serialized next to it in the JSON and rendered under the table; the header says "scenarios, not forecasts"; the growth assumptions (5–10%/mo year one, tapering) deliberately sit far below the observed +17%/wk trailing trend rather than extrapolating a hot streak.

## Data-honesty bugs found and fixed while building

1. **Episode denominators**: the cost rollup counts credit_usage *files*, which include multilingual dub tracks — 145 "episodes"/week vs 82 real ones, deflating every per-episode figure. New `_feed_episodes_last_7d` counts RSS pubDates (the publication record). True tracked cost/episode is **$0.39**, not $0.22.
2. **WoW growth median read 0.0%** while downloads grew ~17%/week: the two slices in the pairing logic misalign when history is shorter than the window, pairing each week with itself. Fixed (pairs built first, then windowed) + regression test.

## Verification

- `tests/test_investor_dashboard.py` — 12 guards: benchmarks-file schema (ladder strictly increasing), percentile mapping, the WoW misalignment regression, feed-based episode counting, null-honesty (no measured base → no scenarios, unmeasured capacity → null never 0), scenario shape + assumptions-required, three-view wiring + honesty labels pinned in the HTML.
- 87 tests green across dashboard suites; full regeneration of `api/dashboard.json` committed (benchmarks + investor sections live on merge).
- All three views rendered in a real browser and screenshot-verified: no JS errors; sponsor view computedly hides every `data-econ` element; investor view hides every `data-ops` section.

Benchmark sources (cited in the YAML): Buzzsprout platform stats; Acast/ADOPTER CPM guides; Jahani & Associates podcast M&A review; Flippa newsletter multiples; Podchaser active-show counts; production-cost guides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_