### PR TITLE
Video/YouTube pipeline review: fix broken Age of AI feed + nightly analytics starvation, plus pipeline improvements

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -181,7 +181,14 @@ jobs:
         run: python scripts/build_shorts_ab_report.py --out api/shorts_ab.json || echo "::warning::Shorts A/B report failed (non-fatal)"
 
       - name: Generate Management Dashboard
-        run: python scripts/generate_dashboard.py --out api/dashboard.json
+        # The generator exits 1 when any landmine card is "fail" — keep that
+        # loud (an ::error:: annotation) but never let it kill the job: this
+        # step runs AFTER the analytics fetches and BEFORE the commit step,
+        # so a hard failure here throws away a whole night of fetched
+        # YouTube/OP3 data and starves the adaptive publishing policy
+        # (observed 2026-08-10/11: a malformed feed flipped one card to fail
+        # and two nights of analytics were computed and discarded).
+        run: python scripts/generate_dashboard.py --out api/dashboard.json || echo "::error::Dashboard reports a failing landmine card — investigate, but nightly commit proceeds"
 
       - name: Daily Show Health Check (Grok Tier 1)
         # Pattern-based surface checks (chapters, phonetic garbles, word count).

--- a/age_of_ai_podcast.rss
+++ b/age_of_ai_podcast.rss
@@ -48,4 +48,5 @@
       <itunes:title>Ep1: Patrick Novak — Patrick Novak scaled a multilingual daily podcast network by using AI for research and synthesis while retaining human editorial control over Mira-hosted AI briefings.</itunes:title>
       <itunes:episodeType>full</itunes:episodeType>
     </item>
-    
+      </channel>
+</rss>


### PR DESCRIPTION
## What this fixes so far

**1. `age_of_ai_podcast.rss` was unparseable since Aug 10.** The manual removal of Ep2 (commit `ffb62541`) deleted the feed's closing `</channel></rss>` tags. Every podcast app fetching the feed since then got malformed XML. Restored the closing tags — feed parses again with Ep1 intact.

**2. Nightly maintenance silently discarded two nights of analytics.** The malformed feed flipped the dashboard's RSS-integrity card to `fail`, and `generate_dashboard.py` exits 1 on any failing card. In `nightly-maintenance.yml` that step runs *after* the YouTube/OP3 analytics fetches and *before* the commit step — so the Aug 10 and Aug 11 runs fetched everything, then died and threw it away. The adaptive publishing policy has been steering on 3-day-old data. The dashboard step is now loud-but-non-fatal (`::error::` annotation) so a red card can never starve the feedback loop again.

## In progress

A detailed review of the video + YouTube pipelines (render performance, viewing experience, audience reach) is underway; further improvements will land on this branch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_