### PR TITLE
Video/YouTube pipeline deep review: reach, render quality, and feedback-loop fixes

### DIFF
--- a/tests/test_age_of_ai_show.py
+++ b/tests/test_age_of_ai_show.py
@@ -397,15 +397,23 @@ class TestPublishSweep:
         src = self._src()
         assert "one bad row must not block the rest" in src
 
-    def test_workflow_is_scheduled(self):
+    def test_workflow_is_not_scheduled(self):
+        """OPERATOR RULE (Aug 10 2026): publishing is ALWAYS a deliberate
+        human act after the final-listen gate. The daily sweep republished
+        an already-published interview as a duplicate Ep2 from a stale
+        artifact, so the schedule trigger was removed (commit ffb62541)
+        with an explicit "Do NOT re-add" in the workflow header. This
+        guard pins that rule — it used to assert the opposite."""
         import yaml
         raw = yaml.safe_load((ROOT / self._WF).read_text(encoding="utf-8"))
         triggers = raw.get(True) or raw.get("on") or {}
-        assert "schedule" in triggers, "publish is dispatch-only again"
-        assert triggers["schedule"][0]["cron"]
+        assert "schedule" not in triggers, (
+            "the publish sweep is back — operator rule forbids scheduled "
+            "publishing (see the workflow header + commit ffb62541)")
+        assert "workflow_dispatch" in triggers
 
     def test_interview_id_input_is_optional(self):
-        """A blank id is the sweep; requiring it would defeat the schedule."""
+        """A blank id sweeps all eligible rows on a manual dispatch."""
         import yaml
         raw = yaml.safe_load((ROOT / self._WF).read_text(encoding="utf-8"))
         triggers = raw.get(True) or raw.get("on") or {}


### PR DESCRIPTION
Fixes main's red CI: `test_workflow_is_scheduled` asserted `nerra_voices_publish.yml` has a schedule trigger, but commit `ffb62541` (operator rule, Aug 10) removed the sweep after it republished a stale duplicate Ep2 — publishing is always a deliberate human act after the final-listen gate. The guard now pins the sanctioned dispatch-only shape so re-adding a schedule fails CI.

(The wider video/YouTube pipeline review shipped separately in the follow-up PR from this branch.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA