### PR TITLE
Offshore North editorial review v2: standing facts, single-source rule, scope, lengths

### DIFF
--- a/docs/offshore_north_show_bible.md
+++ b/docs/offshore_north_show_bible.md
@@ -437,3 +437,51 @@ Ocean Race Atlantic. Design for it rather than being surprised by it.
    (interview access, corrections channel) or a relationship to keep at
    arm's length for editorial independence. Either is defensible; drifting
    into it accidentally is not.
+
+---
+
+## August 2026 editorial review (v2)
+
+Dan reviewed Ep001-002 and supplied a standing-facts file, a master-prompt
+rewrite, and source-automation guidance. Shipped 2026-08-14:
+
+- **Standing facts layer** — `shows/prompts/offshore_north_standing_facts.txt`
+  is injected into the digest AND podcast prompts via `<<include:>>`.
+  Authoritative campaign background (EMIRA IV's pedigree, Shawyer's bio, the
+  published schedule, the Route du Rhum focal point), plus **standing
+  corrections** (Ep2 asserted the campaign has no boat — from one article,
+  against the campaign's own site) and **open items** that must stay flagged
+  until sourced (the Vendée 2028 qualification mechanism). A weekly source
+  conflicting with standing facts is flagged for editorial review, never
+  asserted. Maintained by Dan; review monthly and after milestones.
+- **Single-source rule** — one article supporting a claim means report it,
+  attribute it, stop. No extrapolated consequences/timelines/risks (the Ep2
+  crisis-narrative failure). In digest, system, and podcast prompts.
+- **Scope exclusions** — America's Cup/AC75, SailGP, Olympic/dinghy/kite,
+  inshore, cruising/charter, general marine industry: dropped before the
+  brief. A shorter Fleet beats an off-topic one.
+- **Lengths** — episode band 1,400–1,800 words (~12 min, was 1,500–2,200);
+  segments ~350–450 each; Plain Sailing hard ceiling 600 → 450 words and it
+  must contain specifics (real numbers/names/races/distances) or pick a
+  different concept; Countdown ≈60 words = days to the Vendée Globe + next
+  concrete milestone with date (qualification specifics stay out until
+  sourced from IMOCA/Vendée official sites).
+- **Short display title** — the digest emits an optional `**TITLE:**` line
+  (≤60-char headline; podcast apps truncate). `run_show._extract_short_title`
+  uses it for RSS/chapters/summaries display titles, falls back to the hook,
+  and the sanitizer strips the line from body text. The hard cap remains
+  `engine.titles.PODCAST_EPISODE_TITLE_MAX` — no new truncation surface.
+- **Sources** — the campaign site's WordPress feeds were already wired at
+  launch; added the official YouTube channel Atom feed
+  (`channel_id=UCbyLJ8WsopLJ0fLjkCAVQjg`, verified serving 15 entries).
+  The channel posts ~biweekly, so the prompt treats a new video as bonus
+  tier-1 material. Facebook/Instagram deliberately parked (no native RSS,
+  brittle bridges, content mirrors site+YouTube). Google News stays as a
+  discovery backfill only — never a primary source, never a cited URL.
+- **Deferred**: yt-dlp auto-captions of campaign videos (turns biweekly
+  videos into pipeline-readable text — revisit if descriptions prove thin);
+  a host-notes input channel for Dan's firsthand dock observations (the
+  bible's open question #2, still the cheapest authenticity upgrade).
+
+Drift guards: `tests/test_offshore_north_weekly_fixes.py` (August 2026
+section). Prompt edits change shipped audio — A/B-listen per landmine #17.

--- a/engine/newsletter_sanitizer.py
+++ b/engine/newsletter_sanitizer.py
@@ -82,6 +82,10 @@ _RAW_RULES: List[Tuple[str, str, str]] = [
     # Tesla / generic single-line labels at the top of a daily digest.
     # Match the whole line including a trailing newline.
     (r"(?im)^\s*\*\*HOOK:\*\*\s*", "", "**HOOK:**"),
+    # **TITLE:** is a whole-line strip, unlike **HOOK:** (whose text doubles
+    # as the content lead): the short display title is pure metadata
+    # (offshore_north v2 prompt) and must vanish entirely from body text.
+    (r"(?im)^\s*\*{0,2}TITLE:\*{0,2}[^\n]*\n?", "", "**TITLE:** line"),
     (r"(?im)^\s*\*\*Date:\*\*[^\n]*\n?", "", "**Date:** line"),
     (r"(?im)^\s*\*\*Theme:\*\*[^\n]*\n?", "", "**Theme:** line"),
     (r"(?im)^\s*\*\*Episode:\*\*[^\n]*\n?", "", "**Episode:** line"),

--- a/run_show.py
+++ b/run_show.py
@@ -1906,6 +1906,14 @@ def run(args: argparse.Namespace) -> None:
         else:
             logger.warning("No HOOK found in digest — using generic episode title")
 
+        # Optional short display title (**TITLE:** digest line — offshore_north
+        # v2 prompt). Used for the episode's display-title surfaces (RSS item
+        # title, chapters, summaries); the hook remains the spoken cold open
+        # and the blog/description material. Absent line = hook, unchanged.
+        title_hook = _extract_short_title(x_thread) or hook
+        if title_hook != hook:
+            logger.info("Short title: %s", title_hook)
+
         # Log slow news mode but do NOT tag the episode title — slow news
         # episodes should be indistinguishable from regular episodes.
         if slow_news_mode:
@@ -3032,7 +3040,7 @@ def run(args: argparse.Namespace) -> None:
                         music_intro_offset=music_intro_offset,
                     )
 
-                    ep_title = f"Ep {episode_num}: {hook}" if hook else f"{config.name} - Episode {episode_num}"
+                    ep_title = f"Ep {episode_num}: {title_hook}" if title_hook else f"{config.name} - Episode {episode_num}"
                     chapters_json_path = digests_dir / f"chapters_ep{episode_num:03d}.json"
                     write_chapters_json(
                         episode_chapters,
@@ -3283,7 +3291,7 @@ def run(args: argparse.Namespace) -> None:
         # action is required. 75% of items were over the cap before this.
         from engine.titles import episode_title as _build_episode_title
         episode_title = _build_episode_title(
-            hook,
+            title_hook,
             episode_num,
             prefix=_ep_prefix,
             fallback=f"{config.name} - {_ep_word} {episode_num} - {today_str}",
@@ -3434,7 +3442,7 @@ def run(args: argparse.Namespace) -> None:
         podcast_name=config.publishing.summaries_podcast_name or config.slug,
         episode_num=episode_num,
         episode_title=_titles.episode_title(
-            hook, episode_num,
+            title_hook, episode_num,
             fallback=f"{config.name} - Episode {episode_num} - {today_str}"),
         audio_url=audio_url,
         rss_url=f"{config.publishing.base_url}/{config.publishing.rss_file}",
@@ -3952,6 +3960,33 @@ def _extract_hook(digest: str) -> str | None:
             hook = m.group(1).strip()
             if hook:
                 return hook
+    return None
+
+
+def _extract_short_title(digest: str) -> str | None:
+    """Extract the optional ``**TITLE:**`` line from a generated digest.
+
+    Opt-in per show: only a digest prompt that asks for a TITLE line emits
+    one (offshore_north's August 2026 v2 prompt — a <=60-char headline for
+    podcast apps, distinct from the spoken HOOK, which is a full consequence
+    sentence the apps would truncate). Shows without the line return None
+    and fall back to the hook everywhere, byte-identical to before.
+
+    The 60-char figure is a WRITING guideline enforced by the prompt, not a
+    truncation surface: the hard cap on the RSS item title stays in
+    engine.titles (PODCAST_EPISODE_TITLE_MAX) exactly as for every show.
+    The sanitizer strips the line from the canonical digest, so it never
+    reaches the blog / RSS notes / newsletter (same contract as **HOOK:**).
+    """
+    import re
+
+    for line in digest.splitlines():
+        m = re.match(r"^\s*\*{0,2}TITLE:?\*{0,2}\s*(.+)", line, re.IGNORECASE)
+        if m:
+            title = m.group(1).strip()
+            title = re.sub(r"^\[|\]$", "", title).strip()
+            if title:
+                return title
     return None
 
 def _clean_digest_for_podcast(digest: str) -> str:

--- a/shows/offshore_north.yaml
+++ b/shows/offshore_north.yaml
@@ -44,6 +44,17 @@ sources:
     label: Canada Ocean Racing
   - url: "https://www.canadaoceanracing.com/category/news/feed/"
     label: Canada Ocean Racing — News
+  # Official YouTube channel feed (Atom; feedparser handles it like RSS).
+  # Channel ID resolved from youtube.com/@CanadaOceanRacing page source and
+  # the feed VERIFIED serving 15 entries on 2026-08-14. The channel posts
+  # roughly every two weeks, so most weeks it contributes nothing — the
+  # digest prompt treats a new video as bonus tier-1 material, never as an
+  # expected weekly input. (Facebook/Instagram deliberately NOT wired:
+  # no native RSS, third-party bridges are brittle, and their posts mirror
+  # the site + YouTube. Parked until the automated sources prove to miss
+  # something — August 2026 editorial review.)
+  - url: "https://www.youtube.com/feeds/videos.xml?channel_id=UCbyLJ8WsopLJ0fLjkCAVQjg"
+    label: Canada Ocean Racing — YouTube
 
   # ---- Tier 2: class + organizers ----
   # NOTE: imoca.org and theoceanrace.com publish NO RSS feed (verified
@@ -256,10 +267,11 @@ llm:
   podcast_temperature: 0.7
   max_tokens: 4500
   podcast_max_tokens: 8000
-  # ONE length target: 10-15 minutes ≈ 1,500-2,200 words at ~150 wpm.
-  # 1,600 sits inside that band so the expand-retry fires on genuinely
-  # short episodes, not on every good 1,550-word one.
-  min_podcast_words: 1600
+  # ONE length target: ~12 minutes = 1,400-1,800 words (August 2026
+  # editorial review — was 1,500-2,200). 1,500 sits inside the band so the
+  # digest-side expand-retry fires on genuinely short episodes, not on
+  # every good 1,450-word one.
+  min_podcast_words: 1500
   # Lowered 1150 -> 950 on 2026-08-04. Ep001 generated a 1124-word script
   # and was skipped for being 26 words under its own floor, which was set
   # nearly 2x the network default of 600. 950 still sits just under the

--- a/shows/prompts/offshore_north_digest.txt
+++ b/shows/prompts/offshore_north_digest.txt
@@ -12,20 +12,40 @@ REQUIRED SECTIONS, in this order (never omit any):
 
 {news_section}
 
-You are the research editor for "Offshore North," the Nerra Network's weekly offshore ocean racing briefing. This brief is the ONLY input the script writer will have, so it must be complete, precise, and honest about what is not known. Use ONLY the pre-fetched news above. Never invent or guess a URL — use the exact links provided.
+You are the research editor for "Offshore North," the Nerra Network's weekly offshore ocean racing briefing. This brief is the ONLY input the script writer will have, so it must be complete, precise, and honest about what is not known. Use ONLY the pre-fetched news above plus the STANDING FACTS block below. Never invent or guess a URL — use the exact links provided.
+
+━━━━━━━━━━━━━━━━━━━━
+### STANDING FACTS — verified background, AUTHORITATIVE
+
+The block below is verified campaign background maintained by the show's editorial team and reviewed monthly. Treat it as settled baseline knowledge:
+- NEVER re-derive campaign basics — who the skipper is, whether the team has a boat, the boat's pedigree, the published schedule — from whatever single article this week happens to supply. The standing facts outrank any one weekly source.
+- If a weekly source CONFLICTS with the standing facts, do not assert either version. Report the source's claim, attribute it, and flag it: [VERIFY: conflicts with standing facts — <which fact>]. Editorial review resolves it, not you.
+- The "Standing corrections" section lists errors this show has already made on air. Repeating one of them is the single worst outcome an episode can have.
+- The "Open items to verify" section is the opposite of settled: those subjects must NOT be described in specifics until sourced from the named official sites. Generalities about them carry a [VERIFY:] flag.
+- You may state standing facts without a flag; they count as sourced.
+
+<<include: offshore_north_standing_facts.txt>>
+
+### END STANDING FACTS
+━━━━━━━━━━━━━━━━━━━━
+
+SCOPE — drop these before writing anything: America's Cup and AC75 news (inshore match racing), SailGP, Olympic classes, dinghies, kites and boards, inshore regattas, cruising and yacht-charter news, general marine-industry news. If an item mentions sailing but is not offshore ocean racing, it does not enter the brief. A shorter Fleet section beats an off-topic one, every time.
 
 THE WINDOW: the seven days ending today. A story reported earlier and merely re-aggregated this week is NOT this week's news — check the primary source's own date, not the aggregator's, and skip anything that has already been covered (see RECENTLY COVERED below).
 
 SOURCE PRIORITY when sources conflict, highest first:
-1. Canada Ocean Racing's own channels
+1. Canada Ocean Racing's own channels (site, YouTube)
 2. IMOCA class (imoca.org)
 3. Race organizers (Vendée Globe, The Ocean Race, event sites)
 4. Tip & Shaft / Sailorz (English edition)
 5. Scuttlebutt, Sail-World and other aggregation
 6. Seahorse and the magazines
-Primary beats aggregator. Always. If two sources genuinely disagree, REPORT THE DISAGREEMENT rather than picking one.
+Primary beats aggregator. Always. If two sources genuinely disagree, REPORT THE DISAGREEMENT rather than picking one. Never treat Google News aggregation as a primary source — it is a discovery layer; the claim belongs to the publisher underneath it.
+
+The campaign's YouTube channel posts roughly every two weeks. A new video appearing in this week's items is tier-1 campaign material — use its description as the report and lead The Canadian Boat with it. Most weeks there is no new video, and its absence is not news.
 
 ACCURACY — THIS IS THE WHOLE JOB:
+- THE SINGLE-SOURCE RULE: never build an argument on one article. If only one source supports a claim, report the claim, attribute it, and stop — do not extrapolate consequences, timelines, or risks from a single report. A previous episode built a multi-paragraph crisis narrative out of one newspaper article and got the facts backwards; that must not recur. On a single-sourced item, the "why it matters" line states the direct factual stake only — no scenario-building.
 - Never invent quotes, statistics, dates, boat specifications, sail numbers, finishing times, or race results.
 - Boat names, skipper names, foil generations, race editions, hull pedigree and dates come DIRECTLY from a source or they do not appear.
 - Mark anything you are less than fully certain about inline as [VERIFY: reason]. Flagging is always correct; a confidently-stated wrong fact is the one unforgivable error on this show.
@@ -56,6 +76,8 @@ CONTINUITY BUDGET: at most ONE callback in the whole brief. Prefer a date over a
 
 **HOOK:** [One sentence, under 140 characters, that leads with the consequence or the stake — not just the event. It must be a FACT, not a tease. WEAK: "Big week for Canada Ocean Racing." STRONG: "A Vendée Globe podium boat is now training on Georgian Bay, and its skipper has one shot left at 2026 qualification." No URLs, no dates, no emoji, no question marks.]
 
+**TITLE:** [The episode title for podcast apps: MAXIMUM 60 characters, a headline, not a sentence — podcast apps truncate anything longer. Shape: "EMIRA IV's last week in Collingwood". No episode number, no date, no trailing period. It names the week's biggest story; it is NOT the hook restated.]
+
 ━━━━━━━━━━━━━━━━━━━━
 ## The Canadian Boat
 Canada Ocean Racing this week. 1–3 items, richest first. For each: what the team or a source actually reported (with names, dates, places, numbers as given), then a CONSEQUENCE paragraph — what this changes about the road to the Vendée Globe on 12 November 2028. Where a fact bears on qualification, say so explicitly.
@@ -81,7 +103,9 @@ Source: [EXACT URL FROM PRE-FETCHED] — one per item.
 
 ━━━━━━━━━━━━━━━━━━━━
 ## Plain Sailing
-The explainer — the flagship section, and the show's length lever. ONE concept, explained for someone who loves this sport but does not live inside it. Target 300–400 words, three paragraphs.
+The explainer — the flagship section, and the show's length lever. ONE concept, explained for someone who loves this sport but does not live inside it. Target 300–450 words, three paragraphs.
+
+IT MUST CONTAIN SPECIFICS: real numbers, real names, real races, real distances. "Foils lift the hull and reduce drag" is a definition; "Sébastien Simon finished the Vendée Globe on this exact hull with one foil broken since early December" is an explainer. If you cannot source the specifics — from the fetched material, the standing facts, or the licence below for established figures — pick a different concept. Never restate the same general point in different words to fill the slot. A listener should finish able to state one concrete fact they did not know.
 
 Pick the concept that a listener needs in order to understand THIS week's news, when there is one — qualification rules in a week about entry lists, foil generations in a week about a new launch, ice gates in a week about a Southern Ocean course. When the week offers no natural hook, pick a durable fundamental instead (see the show's segment library).
 
@@ -95,11 +119,11 @@ ON A THIN NEWS WEEK, LENGTHEN THIS SECTION FIRST — go deeper on the mechanism,
 ## The Countdown
 Two facts, no more:
 1. Days remaining until the Vendée Globe start on 12 November 2028, counted from today.
-2. Where the Canadian campaign's qualification actually stands — what is banked, what is still required — stated ONLY from sourced facts. If the current qualification state is not established in the sources, write the countdown plus the single next scheduled milestone and stop. Never estimate, never infer.
+2. The campaign's next concrete milestone, with its date where known — the standing facts carry the published schedule (through autumn 2026 that is the Route du Rhum in November, Shawyer's first solo transatlantic on a foiling IMOCA). If this week's sources update the schedule, the sourced update wins, with its attribution. Qualification specifics stay OUT of the countdown until sourced from the IMOCA class or the Vendée Globe official site (standing open item). Never estimate, never infer.
 
 ━━━━━━━━━━━━━━━━━━━━
 ## Sources
 Every source used, formatted for show notes:
 - Outlet — "Headline" (date) — URL
 
-One line per source, exact URLs from the pre-fetched list only. This section is never spoken aloud.
+One line per source, exact URLs from the pre-fetched list only — the original article's working direct URL, never a Google News redirect. This section is never spoken aloud.

--- a/shows/prompts/offshore_north_podcast.txt
+++ b/shows/prompts/offshore_north_podcast.txt
@@ -29,8 +29,10 @@ Use these only where they make a decision or a sensation suddenly make sense. NE
 AUDIENCE: keenly interested followers, not racing insiders. Assume enthusiasm, not expertise. EVERY piece of jargon gets a one-sentence plain-language explanation the first time it appears in the episode — one sentence, then move on. Never assume knowledge; never condescend.
 
 STRUCTURAL REQUIREMENTS (NON-NEGOTIABLE):
-- You are writing a 10–15 minute episode: 1,500–2,200 words. This is the ONE length target for this script — there is no other. Fifteen minutes is a hard ceiling. When in doubt, cut.
-- Use ONLY information from the brief below. If the brief is thin, DEEPEN Plain Sailing — never invent, never pad, never repeat a fact you have already stated.
+- You are writing a roughly 12-minute episode: 1,400–1,800 words. This is the ONE length target for this script — there is no other. When in doubt, cut.
+- Use ONLY information from the brief below, grounded against the STANDING FACTS block that follows it. Standing facts are verified background — you may state them without a flag. Anything that happened THIS WEEK still comes only from the brief. If the brief flags a conflict with the standing facts, carry the flag; never resolve it yourself.
+- The brief follows a single-source rule. Respect it downstream: never escalate a single-sourced item into consequences, timelines, or risks the brief does not state.
+- If the brief is thin, DEEPEN Plain Sailing — never invent, never pad, never repeat a fact you have already stated.
 - Reach the length by covering the brief's items at real depth and by explaining properly, never by restating.
 
 RULES:
@@ -56,6 +58,7 @@ This is one person talking to one person. It is not a briefing document read alo
 - CONTRACTIONS THROUGHOUT: it's, that's, they've, doesn't, isn't, here's.
 - REACT TO THINGS. Dan is allowed to find something impressive, surprising, funny, or worrying, and to say so in his own words — "eighty-five thousand hours, which is a genuinely absurd number", "I'll admit I had to look this up". Reactions belong to Dan, never to the sources, and never change what a fact says.
 - ASK THE LISTENER THINGS. A direct question every couple of minutes ("So why does that matter?", "Picture what that actually looks like") turns a recital into a conversation.
+- NO TRADE-BULLETIN REGISTER. Banned shapes: "raises the operational complexity", "the class rules do not grant extensions", "creating multi-year uncertainty for stakeholders". If a sentence could appear in an insurance circular, rewrite it. Say what something MEANS before saying what it IS.
 - NEVER RECITE INSTRUCTIONS. Nothing in this prompt, or in the brief's scaffolding, is script. If a sentence sounds like it is describing the show's policies rather than telling the listener something about sailing, cut it.
 - NO META-COMMENTARY ABOUT THE INPUTS. The listener does not know a brief exists. Ep001 said "Qualification status for the Canadian campaign is not established in the supplied sources" — say "I couldn't find anything confirming where qualification stands right now" instead. The phrases "the supplied sources", "the brief", "the provided material" and "not established in" are banned from spoken text.
 
@@ -63,7 +66,7 @@ SCRIPT STRUCTURE:
 
 [Cold open — the FIRST WORDS of the episode]
 Dan: {hook}
-This is the first thing anyone hears. Nothing precedes it — not on a premiere episode either. It is a concrete FACT stated plainly, never a tease and never a question. Then give the identity line below, and only then move into the first segment.
+This is the first thing anyone hears. Nothing precedes it — not on a premiere episode either. It is a concrete FACT stated plainly, never a tease and never a question. You may add ONE more sentence after it if the story needs a second beat — two sentences maximum. Then give the identity line below, and only then move into the first segment.
 
 [Identity — one short line, immediately after the cold open]
 Your script MUST use this exact line, word for word — never rewrite, paraphrase, replace, or add a date to it:
@@ -71,22 +74,22 @@ Your script MUST use this exact line, word for word — never rewrite, paraphras
 
 [The Canadian Boat]
 Announce the segment with one of exactly these phrasings so podcast-app chapters latch: "on the Canadian boat" / "over to the Canadian boat" / "to the Canadian boat". Do not speak that phrase anywhere earlier in the episode.
-Cover the brief's Canada Ocean Racing material. CONTEXT OVER RECAP is the whole instruction: report what happened in a sentence or two, then spend the majority of the segment on what it changes about the odds of a Canadian finishing the Vendée Globe in 2028. Where the brief ties a fact to qualification, make that tie explicit and plain.
-If the brief says the campaign made no public news this week, say so in ONE honest sentence — no apology, no filler — and give the brief's standing item its due instead. Never stretch a quiet week into three minutes.
+About 350–450 words. Cover the brief's Canada Ocean Racing material, grounded against the standing facts: where the boat physically is, what is next on the published calendar, how this week moves them toward it. CONTEXT OVER RECAP is the whole instruction: report what happened in a sentence or two, then spend the majority of the segment on what it changes about the odds of a Canadian finishing the Vendée Globe in 2028.
+If the brief says the campaign made no public news this week, say so in ONE honest sentence — no apology, no filler — and use the space to advance the story that is actually running (the current training block, the delivery, the next race, or the brief's standing item) rather than inventing significance. Never stretch a quiet week into three minutes.
 
 [The Fleet]
 Announce it with one of exactly these phrasings: "out in the fleet" / "now, the fleet" / "the rest of the fleet this week". Do not speak those phrases earlier.
-Cover EVERY item in the brief's Fleet section at 4–6 fact-bearing sentences each, then its "why it matters" in Dan's own words — the consequence layer is the reason the item is in the show, not a coda. Vary the delivery: a launch or a win gets energy and short punchy sentences; a business or governance story gets clarity and a slower rhythm; a setback gets honesty without catastrophizing.
+About 350–450 words. Cover EVERY item in the brief's Fleet section at 4–6 fact-bearing sentences each, then its "why it matters" in Dan's own words — the consequence layer is the reason the item is in the show, not a coda. Quality over count: three real offshore stories beat five padded ones. Vary the delivery: a launch or a win gets energy and short punchy sentences; a business or governance story gets clarity and a slower rhythm; a setback gets honesty without catastrophizing.
 
 [Plain Sailing]
 Announce it with one of exactly these phrasings: "time for Plain Sailing" / "that brings us to Plain Sailing" / "now for Plain Sailing". Do not speak the words "Plain Sailing" anywhere earlier in the episode — this announcement is what podcast-app chapters key off.
-About two minutes, roughly 300–400 spoken words. ONE concept, explained properly, from the brief's Plain Sailing section. Concrete before abstract. One number where a number helps. Build the logic so the listener SEES why it works rather than being told that it does — and land on the single sentence they could repeat to someone else.
-THIS IS THE LENGTH LEVER. On a thin news week, deepen it here — more of the mechanism, the trade-off, a comparison — rather than padding the news. It is the one segment licensed to draw on general sailing and physics knowledge beyond the brief, because it explains established concepts. That licence covers mechanisms and definitions ONLY: any claim about a specific boat, skipper, campaign, result, or date still comes from the brief or carries its flag.
-HARD CEILING: even on the thinnest week this segment never exceeds 600 spoken words, and it never exceeds one quarter of the episode. Ep001 ran it to roughly 700 words and 38% of the runtime — it became the show — and it got there by re-opening the same subject three times ("The newest boats add further variables", "The foil system itself introduces new variables", "Wave impact adds another layer"). Deepening means going FURTHER INTO one mechanism, not restating it under a new heading. When you have said the thing properly, stop and go to the countdown; a genuinely short episode is a better product than a padded one.
+About two minutes, roughly 350–450 spoken words. ONE concept, explained properly, from the brief's Plain Sailing section. IT MUST CONTAIN SPECIFICS — real numbers, real names, real races, real distances; if the brief's section lacks them, use only what it does establish and go no wider. Concrete before abstract. Build the logic so the listener SEES why it works rather than being told that it does — and land on the single concrete fact they could repeat to someone else.
+THIS IS THE LENGTH LEVER. On a thin news week, deepen it here — more of the mechanism, the trade-off, a comparison — rather than padding the news. It is the one segment licensed to draw on general sailing and physics knowledge beyond the brief, because it explains established concepts. That licence covers mechanisms and definitions ONLY: any claim about a specific boat, skipper, campaign, result, or date still comes from the brief, the standing facts, or carries its flag.
+HARD CEILING: even on the thinnest week this segment never exceeds 450 spoken words, and it never exceeds one quarter of the episode. Ep001 ran it to roughly 700 words and 38% of the runtime — it became the show — and it got there by re-opening the same subject three times ("The newest boats add further variables", "The foil system itself introduces new variables", "Wave impact adds another layer"). Deepening means going FURTHER INTO one mechanism, not restating it under a new heading — never the same general point in five different phrasings. When you have said the thing properly, stop and go to the countdown; a genuinely short episode is a better product than a padded one.
 
 [The Countdown]
 Announce it with one of exactly these phrasings: "and the countdown" / "before we go, the countdown" / "the countdown stands". Do not speak those phrases earlier.
-About twenty seconds, and no longer. Two facts from the brief: days remaining until the Vendée Globe start on the twelfth of November two thousand twenty-eight, and where the Canadian campaign's qualification actually stands. Deliver it flat and factual — the countdown is the show's spine, and it works because it is true, not because it is dramatised. If the brief gives only the countdown and the next scheduled milestone, say exactly that and stop.
+About twenty seconds — roughly sixty words, and no longer. Two facts from the brief: days remaining until the Vendée Globe start on the twelfth of November two thousand twenty-eight, and the campaign's next concrete milestone with its date where known. Deliver it flat and factual — the countdown is the show's spine, and it works because it is true, not because it is dramatised. Say the two facts and stop.
 
 [Closing] Use this exact closing, word for word (do not rewrite it):
 {closing_block}
@@ -115,7 +118,11 @@ BEFORE YOU FINISH — verify silently (do not output this checklist):
 - Nothing in the script states a fact the brief does not contain.
 - A Sources section is appended AFTER the closing, exactly as it appears in the brief, under the heading "SOURCES (SHOW NOTES — NOT SPOKEN)". It is never part of the spoken script.
 
-Here is this week's complete brief. Use ONLY this content:
+STANDING FACTS (verified background — you may state these without a flag; this-week news still comes only from the brief):
+
+<<include: offshore_north_standing_facts.txt>>
+
+Here is this week's complete brief. Use ONLY this content, grounded against the standing facts above:
 
 {digest}
 

--- a/shows/prompts/offshore_north_standing_facts.txt
+++ b/shows/prompts/offshore_north_standing_facts.txt
@@ -1,0 +1,66 @@
+# Offshore North — Standing Facts
+
+**Purpose:** This file is injected into every episode prompt as verified background. The pipeline must treat it as authoritative baseline knowledge and must NOT re-derive these facts from whatever single article it finds in a given week. If a weekly source conflicts with anything here, flag the conflict for editorial review rather than asserting either version.
+
+**Maintained by:** Dan. Review monthly and after any major campaign milestone.
+**Last verified:** August 2026
+
+---
+
+## The campaign
+
+**Canada Ocean Racing** — Canadian offshore racing team founded and led by **Scott Shawyer**, who is both president and skipper. The campaign's stated goal is for Shawyer to become the first Canadian to complete the Vendée Globe, targeting the **2028 edition**. The team's public-facing initiative is branded **Be Water Positive**, focused on water scarcity awareness, alongside a **Youth Pathway Programme** for young Canadian sailors.
+
+**Scott Shawyer** is not a traditional offshore skipper — he came to the sport from business and engineering rather than through the French Mini/Figaro/Class40 pathway. He spent 26 years as president and CEO of JMP Solutions, an industrial automation and engineering company. He has sailed since childhood. He holds the double-handed course record for the Royal Ocean Racing Club Transatlantic Race. In 2024 he completed the New York Vendée — Les Sables d'Olonne, his first solo IMOCA race, aboard a 2011 Owen Clarke design named *Be Water Positive*. He is a Collingwood, Ontario resident.
+
+## The boat
+
+**EMIRA IV** — a current-generation foiling IMOCA 60, over 18 metres, capable of speeds over 40 knots. Acquired by Canada Ocean Racing in 2025. This is Shawyer's first foiling IMOCA.
+
+The boat has a significant history under previous names:
+- Built and campaigned as **11th Hour Racing Team — Mālama**
+- **Won The Ocean Race 2023** under Charlie Enright
+- Sold to Sébastien Simon, raced as **Groupe Dubreuil**
+- **Third place in the 2024–25 Vendée Globe** with Simon, despite a broken foil reported in early December
+- Simon set a solo 24-hour speed record aboard this boat
+- Handed over to Shawyer in early 2025 and renamed EMIRA IV
+
+Under Canada Ocean Racing: 6th in The Ocean Race Europe 2025; abandoned the 2025 Rolex Fastnet Race.
+
+## Where the boat is now (2026 season)
+
+EMIRA IV was delivered from France to Canada in spring 2026 — an Atlantic crossing followed by the St. Lawrence Seaway, the Welland Canal and the Great Lakes, with mechanical problems in the Seaway requiring repairs en route. Delivery crew included Alan Roura, Clovis Gautier, Gaby Bucau and Martin Amescua.
+
+Stops included Quebec City, Montreal and the Toronto waterfront before arriving in **Collingwood, Ontario** at the start of June 2026 for the team's **first Canadian summer training programme**, based on **Georgian Bay** with support from the Town of Collingwood and Collingwood Yacht Club. Collingwood harbour is one of very few Canadian harbours deep enough for the boat's roughly 15-foot keel. Free public tours were held on 13 and 20 June 2026. The boat is scheduled to be in Collingwood until roughly **mid-August 2026**, then return across the Atlantic to France.
+
+## The near-term schedule
+
+- **Autumn 2026** — transatlantic delivery back to France, then Route du Rhum preparation
+- **November 2026 — Route du Rhum.** This will be Shawyer's **first solo transatlantic race on a foiling IMOCA**. This is the campaign's next major competitive milestone and should be the gravitational centre of the show through the autumn.
+- **Transat Café L'OR** — also a stated 2026 goal
+- **12 November 2028** — Vendée Globe start
+
+## Standing corrections — errors already made on this show
+
+- **The campaign HAS a boat, and has had one since 2025.** Any framing suggesting Canada Ocean Racing has not secured an IMOCA, has no declared boat, or has just announced an intention is false. (This error ran in Ep 2.)
+- **This is not a new announcement.** Shawyer's Vendée Globe 2028 intention has been public since at least 2025.
+- **"First Canadian to target a solo non-stop round-the-world race" is unverified and probably wrong.** The verified claim is narrower: **no Canadian has completed the Vendée Globe**, and Shawyer aims to be the first. Use the narrow version.
+- **Do not treat America's Cup / AC75 content as offshore racing.** It is inshore match racing and is out of scope. Same for Olympic dinghy and kite classes unless there is a direct IMOCA or offshore connection.
+
+## Open items to verify before use
+
+- The exact Vendée Globe 2028 qualification mechanism, points table and designated race list. Do not describe the system in specifics until sourced from the IMOCA class or Vendée Globe official site. Ep 2's Plain Sailing segment described this in generalities and should be treated as unverified.
+- Current sponsor roster and the EMIRA relationship.
+- Team's shore/technical base in France.
+
+## Source URLs for these facts
+
+- https://www.canadaoceanracing.com/
+- https://www.canadaoceanracing.com/scotts-story/
+- https://www.canadaoceanracing.com/new-foiling-imoca/
+- https://www.canadaoceanracing.com/emira-iv-arrives-in-collingwood-ontario-for-a-summer-of-training/
+- https://www.canadaoceanracing.com/from-refit-to-race-2026/
+- https://www.imoca.org/en/boats/emira-iv
+- https://www.imoca.org/en/skippers-1/scott-shawyer
+- https://www.vendeeglobe.org/en/article/canadian-skipper-scott-shawyer-acquires-sebastien-simons-imoca-boat
+- https://www.theoceanrace.com/en/crew/991_Scott-Shawyer

--- a/shows/prompts/offshore_north_system.txt
+++ b/shows/prompts/offshore_north_system.txt
@@ -6,6 +6,13 @@ Offshore ocean racing is one of the great endurance sports on earth and it is re
 THE SPINE:
 Canada Ocean Racing and skipper Scott Shawyer are attempting something no Canadian has done — finish the Vendée Globe. The next edition starts 12 November 2028. That attempt has a hard date, a real qualification path, and a boat with a serious pedigree, and it runs underneath every episode as a continuing story. Canada is the door. The wider offshore world is the room, and the room gets most of the airtime.
 
+SCOPE:
+In scope: IMOCA 60 racing and campaigns; the Vendée Globe; The Ocean Race and The Ocean Race Europe; Route du Rhum, Transat Café L'OR, Transat Jacques Vabre, Fastnet and similar offshore events; Canadian offshore sailing; offshore boat technology, weather routing, safety and rules.
+Out of scope — never include: America's Cup and AC75 (inshore match racing); SailGP; Olympic classes, dinghies, kites and boards; inshore regattas; cruising and yacht-charter news; general marine-industry news. If an item mentions sailing but is not offshore ocean racing, drop it. A shorter episode beats an off-topic one.
+
+STANDING FACTS:
+Every prompt carries a STANDING FACTS block — verified campaign background maintained by the show's editorial team and reviewed monthly. It is authoritative baseline knowledge: never re-derive campaign basics from whatever single article a given week supplies, and when a weekly source conflicts with it, flag the conflict for editorial review rather than asserting either version.
+
 THE HOST:
 DAN — Nerra Network co-founder and commercial airline pilot. He sails, surfs, foils, skis and mountain bikes, and has raced Hobie Cats in Red Bull events. So he is not a spectator: he has raced a fast boat in anger, and he knows first-hand what it feels like when a hull comes unstuck and starts flying. That earns him the right to say "I've felt a version of this" — but only a version, and he says so. He is NOT an offshore racing expert and never pretends to be.
 What he IS expert in is the thing this sport is secretly about: reading weather, choosing between a shorter track and a faster one, and managing risk on incomplete information at three in the morning. Weather routing is flight planning. When that parallel genuinely illuminates a decision, he can use it — at most once an episode, never as a bit. His own foiling and multihull racing is the same kind of seasoning: a way in for the listener, not a credential he leans on.
@@ -27,6 +34,7 @@ You NEVER:
 - Hype, pad, or use filler transitions ("in today's episode we'll dive into", "buckle up", "without further ado")
 
 ACCURACY RULES (the one unforgivable error on this show is a confidently-stated wrong fact):
+- The single-source rule: never build an argument on one article. One source supporting a claim means the claim gets reported, attributed, and left alone — no extrapolated consequences, timelines, or risks.
 - Sailing details are load-bearing. Boat names, skipper names, foil generations, race editions, hull pedigree, and dates come DIRECTLY from sources or they do not appear. This audience will catch an error the show does not catch itself.
 - Mark any claim you are less than fully certain about inline as [VERIFY: reason] for editorial review. Flagging uncertainty is always correct. A draft with five flags is a good draft.
 - Most primary reporting in this sport is French. Any substantive claim reaching you only through a translated French source is flagged [VERIFY: translated from French source] unless an English primary source confirms it.

--- a/tests/test_offshore_north_weekly_fixes.py
+++ b/tests/test_offshore_north_weekly_fixes.py
@@ -331,7 +331,10 @@ class TestScriptNaturalness:
     def test_plain_sailing_has_a_hard_ceiling(self):
         src = self._prompt()
         assert "HARD CEILING" in src
-        assert "600 spoken words" in src
+        # Tightened 600 -> 450 by the August 2026 editorial review (v2
+        # prompt): 350-450 target, never more than a quarter of the episode.
+        assert "450 spoken words" in src
+        assert "600 spoken words" not in src
 
 
 class TestXSourcingIsScaffoldedButDormant:
@@ -348,3 +351,182 @@ class TestXSourcingIsScaffoldedButDormant:
             assert "VERIFY" in acct["label"], (
                 f"{acct['handle']}: handle was never confirmed against live X"
             )
+
+
+# ---------------------------------------------------------------------------
+# August 2026 editorial review (v2): standing facts, scope, single-source
+# rule, tightened lengths, short display title, YouTube source feed.
+# Canonical inputs: the reviewer's standing-facts file + master prompt v2.
+# ---------------------------------------------------------------------------
+
+_PROMPTS = _ROOT / "shows" / "prompts"
+_FACTS = _PROMPTS / "offshore_north_standing_facts.txt"
+
+
+def _digest_prompt():
+    return (_PROMPTS / "offshore_north_digest.txt").read_text(encoding="utf-8")
+
+
+def _podcast_prompt():
+    return (_PROMPTS / "offshore_north_podcast.txt").read_text(encoding="utf-8")
+
+
+def _system_prompt():
+    return (_PROMPTS / "offshore_north_system.txt").read_text(encoding="utf-8")
+
+
+class TestStandingFactsLayer:
+    """Ep002 asserted the campaign has no boat — from one article, against
+    a fact the campaign's own site has carried since 2025. The standing
+    facts file is the fix: verified background injected into every prompt,
+    outranking any single weekly source."""
+
+    def test_facts_file_exists_and_carries_the_essentials(self):
+        text = _FACTS.read_text(encoding="utf-8")
+        for essential in ("EMIRA IV", "Scott Shawyer", "Canada Ocean Racing",
+                          "12 November 2028", "Route du Rhum"):
+            assert essential in text, f"standing facts lost: {essential}"
+
+    def test_facts_file_carries_the_ep2_standing_correction(self):
+        text = _FACTS.read_text(encoding="utf-8")
+        assert "HAS a boat" in text, (
+            "the Ep2 boat-denial correction is the reason this file exists"
+        )
+        assert "Standing corrections" in text
+
+    def test_both_generation_prompts_include_the_facts(self):
+        inc = "<<include: offshore_north_standing_facts.txt>>"
+        assert inc in _digest_prompt(), "digest prompt must inject standing facts"
+        assert inc in _podcast_prompt(), "podcast prompt must inject standing facts"
+
+    def test_includes_actually_resolve(self):
+        """load_prompt must expand the include — a typo'd path would ship
+        the literal directive as prompt text."""
+        from engine.generator import load_prompt
+        for name in ("offshore_north_digest.txt", "offshore_north_podcast.txt"):
+            rendered = load_prompt(str(_PROMPTS / name))
+            assert "<<include" not in rendered, f"{name}: include did not resolve"
+            assert "Standing corrections" in rendered, (
+                f"{name}: standing facts content missing after include expansion"
+            )
+
+    def test_conflict_rule_flags_rather_than_asserts(self):
+        src = _digest_prompt()
+        assert "conflicts with standing facts" in src.lower() or (
+            "CONFLICTS with the standing facts" in src
+        ), "the digest prompt must route conflicts to a VERIFY flag"
+
+    def test_facts_file_has_no_prompt_placeholders(self):
+        """The include expands BEFORE {placeholder} substitution; a stray
+        brace in the facts file would crash every render."""
+        text = _FACTS.read_text(encoding="utf-8")
+        assert "{" not in text and "}" not in text
+
+
+class TestScopeExclusions:
+    """The reviewer's Fleet complaint: aggregation pulls in America's Cup
+    and Olympic content that is not offshore ocean racing."""
+
+    def test_digest_prompt_names_the_exclusions(self):
+        src = _digest_prompt()
+        for banned in ("America's Cup", "SailGP", "Olympic"):
+            assert banned in src, f"digest scope must exclude: {banned}"
+
+    def test_system_prompt_names_the_exclusions(self):
+        src = _system_prompt()
+        for banned in ("America's Cup", "SailGP"):
+            assert banned in src, f"system scope must exclude: {banned}"
+
+
+class TestSingleSourceRule:
+    """Ep002 built a multi-paragraph crisis narrative from one newspaper
+    article. One source = report the claim and stop."""
+
+    def test_digest_prompt_carries_the_rule(self):
+        assert "SINGLE-SOURCE RULE" in _digest_prompt()
+
+    def test_system_prompt_carries_the_rule(self):
+        assert "single-source rule" in _system_prompt()
+
+    def test_podcast_prompt_respects_it_downstream(self):
+        assert "single-source rule" in _podcast_prompt()
+
+
+class TestEpisodeLengthBandV2:
+    def test_podcast_prompt_uses_the_v2_band(self):
+        src = _podcast_prompt()
+        assert "1,400–1,800" in src
+        assert "1,500–2,200" not in src
+
+    def test_yaml_target_sits_inside_the_band(self):
+        words = _cfg().llm.min_podcast_words
+        assert 1400 <= words <= 1800, (
+            f"min_podcast_words={words} is outside the 1,400-1,800 band — "
+            "the expand-retry would fire on every good episode"
+        )
+
+
+class TestShortDisplayTitle:
+    """The v2 prompt adds a **TITLE:** metadata line (<=60-char headline —
+    podcast apps truncate). run_show extracts it for display-title surfaces
+    and falls back to the hook; the sanitizer strips the line from body
+    text. The hard RSS cap stays in engine.titles, unchanged."""
+
+    def _extract(self):
+        import run_show
+        return run_show._extract_short_title
+
+    def test_digest_prompt_asks_for_the_line(self):
+        src = _digest_prompt()
+        assert "**TITLE:**" in src
+        assert "60 characters" in src
+
+    def test_extractor_finds_the_line(self):
+        fn = self._extract()
+        digest = (
+            "# Offshore North\n**HOOK:** A full consequence sentence.\n\n"
+            "**TITLE:** [EMIRA IV's last week in Collingwood]\n\n## The Canadian Boat\n"
+        )
+        assert fn(digest) == "EMIRA IV's last week in Collingwood"
+
+    def test_extractor_returns_none_when_absent(self):
+        fn = self._extract()
+        assert fn("**HOOK:** Something happened.\n\n## Body\n") is None
+
+    def test_extractor_does_not_eat_the_hook(self):
+        import run_show
+        digest = (
+            "**HOOK:** The real hook.\n**TITLE:** Short headline\n## Body\n"
+        )
+        assert run_show._extract_hook(digest) == "The real hook."
+
+    def test_sanitizer_strips_the_title_line(self):
+        from engine.newsletter_sanitizer import scrub_scaffold
+        body = "**HOOK:** Kept as lead.\n**TITLE:** Metadata only\nReal prose stays.\n"
+        cleaned = scrub_scaffold(body)
+        assert "Metadata only" not in cleaned
+        assert "TITLE" not in cleaned
+        assert "Real prose stays." in cleaned
+
+    def test_run_show_wires_title_hook_into_rss_title(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "title_hook = _extract_short_title(x_thread) or hook" in src
+        assert "_build_episode_title(\n            title_hook," in src
+
+
+class TestYouTubeSourceFeed:
+    """Reviewer item 2: the campaign's YouTube channel has an official
+    Atom feed keyed by raw channel ID (verified serving entries Aug 2026)."""
+
+    def test_feed_is_wired_with_the_verified_channel_id(self):
+        urls = [s["url"] for s in yaml.safe_load(
+            _SHOW_YAML.read_text(encoding="utf-8"))["sources"]]
+        yt = [u for u in urls if "youtube.com/feeds/videos.xml" in u]
+        assert yt, "Canada Ocean Racing YouTube feed missing from sources"
+        assert "channel_id=UCbyLJ8WsopLJ0fLjkCAVQjg" in yt[0]
+
+    def test_digest_prompt_treats_video_as_bonus(self):
+        src = _digest_prompt()
+        assert "every two weeks" in src, (
+            "the prompt must not expect a weekly video from a biweekly channel"
+        )


### PR DESCRIPTION
Applies Dan's review package (standing-facts file + master prompt v2 + source-automation notes) after Ep001–002.

## ⚠️ A/B-listen required (landmine #17)

Every prompt change here alters generated scripts and therefore shipped audio. Listen to the first post-merge episode (Monday) against Ep002 before trusting it.

## What shipped

**Standing facts layer** — `shows/prompts/offshore_north_standing_facts.txt` (Dan's file, near-verbatim) is injected into the digest **and** podcast prompts via the existing `<<include:>>` mechanism. Rules around it: authoritative baseline, never re-derived from a single weekly article; a conflicting weekly source gets `[VERIFY: conflicts with standing facts]` instead of being asserted; the "Standing corrections" (Ep2 claimed the campaign has no boat) and "Open items" (Vendée 2028 qualification mechanism stays flagged until sourced from IMOCA/VG official sites) are binding.

**Single-source rule** — in digest, system, and podcast prompts: one source = report, attribute, stop. No extrapolated consequences/timelines/risks (the Ep2 crisis-narrative failure).

**Scope exclusions** — America's Cup/AC75, SailGP, Olympic/dinghy/kite, inshore regattas, cruising/charter, general marine industry dropped before the brief; shorter Fleet beats off-topic Fleet. Google News explicitly demoted to discovery-only.

**Lengths** — episode band 1,400–1,800 (~12 min); segments ~350–450; Plain Sailing hard ceiling 600 → **450** words + a specifics requirement (real numbers/names/races/distances or pick a different concept); Countdown ≈60 words = days to VG + next concrete milestone. `min_podcast_words` 1600 → 1500 (inside the band; floor tests still pass).

**Short display title (≤60 chars)** — new optional `**TITLE:**` digest line. `run_show._extract_short_title` feeds the RSS item title, chapters title, and summaries title, falling back to the hook; shows without the line are byte-identical. Sanitizer strips the line from body text; the hard cap stays in `engine/titles.py` — no new truncation surface, honoring the titles-module rule.

**Sources** — added the campaign's official YouTube Atom feed (`channel_id=UCbyLJ8WsopLJ0fLjkCAVQjg`, resolved from the @CanadaOceanRacing page source and verified serving 15 entries on 2026-08-14). The site's WordPress `/feed/` was **already wired at launch** — Dan's item 1 was done. The prompt treats a new video as bonus tier-1 material (~biweekly channel). Facebook/Instagram parked per the review, with the reasoning recorded in the YAML.

**Voice** — banned trade-bulletin register with Dan's examples ("raises the operational complexity", the insurance-circular test); "say what something means before saying what it is"; cold open may run two sentences.

## Deliberately not done

- **yt-dlp auto-captions** of campaign videos — real value at biweekly cadence is modest vs. a new dependency in the fetch path; deferred, noted in the show bible. Revisit if video descriptions prove thin.
- **Host-notes input channel** (Dan's dock visits as primary source) — no pipeline mechanism exists for per-episode operator notes; flagged in the bible as the cheapest authenticity upgrade if wanted.
- **Byline** — `publishing.host_name: Dan` already drives the `podcast:person` tag; blog JSON-LD attributes to the show as an Organization (network-wide pattern, unchanged).
- **Ep002's published error** stands live on the blog/feed; the standing-corrections file arms Ep003 to correct on air if you want it to.

## Testing

Full suite: **6,777 passed, 6 skipped**. New guards in `tests/test_offshore_north_weekly_fixes.py` (standing facts resolve through `load_prompt`, conflict rule, scope, single-source, length band, TITLE extraction/sanitization/wiring, YouTube feed pin). `validate_show.py offshore_north` OK.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKDLL1fvxxFMpZiXVyKe9d)_