### PR TITLE
Video quality round 2: real scene cadence on long episodes, dub channel parity, retention curves

### DIFF
--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -236,3 +236,43 @@ experiments:
       runs after the end-card overlay (last ~3 s of speech kept its
       text hidden under the opaque CTA card). Render-only — outside
       landmine #17.
+
+  - id: shorts-motion-ab-stalled
+    title: "Shorts motion A/B — enrollment stalled, decide: re-enable or end"
+    area: retention
+    shipped: 2026-07-30
+    readout: 2026-08-21
+    status: decide
+    criteria: >
+      The treatment arm has been frozen at n=4 since ~Aug 9:
+      shows/spacex.yaml carries shorts_ab_enabled: false (arrived via
+      the merged spacex review PR #973), so no new grok_video Shorts
+      enroll and the 14-per-arm bar can never be reached. Operator
+      decision: (a) re-enable enrollment on spacex (one YAML flag) and
+      let it run ~2 more weeks, or (b) formally end the experiment as
+      unreadable — which also un-holds the four render items gated on
+      its verdict (Shorts transition split, progress bar, punch-ins,
+      long-form ending beat) for fresh evaluation on their own merits.
+    notes: >
+      Interim data (n=4 vs 12, NOT significant): treatment mean AVP
+      reads higher but is dominated by one outlier; views are flat.
+      ~$1.05/enrolled episode while enrollment is on.
+
+  - id: scene-cadence-36-slots
+    title: "Long-form scene cadence — input dedup + 36-slot cap + adaptive Ken Burns"
+    area: retention
+    shipped: 2026-08-14
+    readout: 2026-08-28
+    status: reading
+    metric: long_form_median_avp_en_14d
+    target: >
+      Long-form median AVP up vs the 13.4%/11.4% (14d) recent band. A
+      17-min episode now changes scene every ~29 s instead of holding
+      85+ s, the accelerating open survives, and Ken Burns speed no
+      longer collapses on long holds (0.006/s adaptive amplitude).
+      Reads jointly with youtube-chapters-live (both target the same
+      metric; this is the render half).
+    notes: >
+      Enabled by ffmpeg input dedup (one -i per unique image + split),
+      which removed the per-slot demuxer cost behind the old 24-slot
+      cap. Render-only — outside landmine #17.

--- a/docs/reviews/video_pipeline_review_2026_08_12.md
+++ b/docs/reviews/video_pipeline_review_2026_08_12.md
@@ -96,6 +96,21 @@ the tests named per item.
   candidate index is carried instead of dict-equality `.index()`
   (duplicate filler segments scored the wrong window; O(n²)).
 
+## Round 2 — shipped 2026-08-14 (from the list below)
+
+Items 1, 2, 4 (in full: guarded tags + caption tracks + Short
+thumbnails + Shorts out of dub podcast playlists), 6 (traffic sources,
+search terms, retention curves for top recent longs), 7 (shorts-count
+hysteresis; retention gating still open), 8 (FR channel + policy-driven
+dub Shorts count + caption-track cost), and 9 (transport-error retry).
+The slot cap rose 24 → 36 on the back of item 1, with
+`gallery_blend_max_long` 16 → 24 so the pool covers the deeper plan.
+Performance context at ship time: RU Shorts median retention 43→54%
+WoW, FR Shorts 46→71% (small n), EN Shorts flat ~44-46%; the motion
+A/B is STALLED (treatment frozen at n=4 — `shorts_ab_enabled: false`
+landed via the merged spacex review PR #973) and is now a `decide`
+entry in the experiments register.
+
 ## Proposed — NOT shipped (each needs its own decision)
 
 1. **ffmpeg input dedup for cycled slideshows** (render #12): one

--- a/engine/config.py
+++ b/engine/config.py
@@ -807,7 +807,7 @@ class YouTubeConfig:
     # for — the only cost of a bigger pool is R2 download volume during the
     # render, which is free egress. Generating more *fresh* images is the
     # alternative and it is not free: ~$0.02 each across eleven daily shows.
-    gallery_blend_max_long: int = 16   # 16:9 library scenes per long-form
+    gallery_blend_max_long: int = 24   # 16:9 library scenes per long-form (36-slot cap needs a deeper pool)
     gallery_blend_max_short: int = 6   # 9:16 library scenes per Short
     # Align long-form scene switches with the episode's chapters.json
     # boundaries (engine.scene_scheduler.plan_chapter_schedule) instead of

--- a/engine/lang_dub.py
+++ b/engine/lang_dub.py
@@ -42,6 +42,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from engine.ru_dub import _dub_tags
 from engine.youtube_policy import MAX_SHORTS_PER_EPISODE
 from engine.ru_dub import (  # language-neutral helpers — single source
     PROJECT_ROOT,
@@ -77,6 +78,7 @@ class DubLanguage:
     end_card_sub: str
     comment_full_episode: str  # "{url}" placeholder; funnel comment on Shorts
     second_short_tail: str    # appended when a 2nd Short needs a fallback title
+    caption_track_name: str = ""   # CC track display name (native), e.g. "Français"
     # Leading episode-label to strip when deriving the Short title
     ep_prefix_re: re.Pattern = field(
         default_factory=lambda: re.compile(
@@ -105,6 +107,7 @@ DUB_LANGUAGES: Dict[str, DubLanguage] = {
             "🔔 Abonnez-vous — nouveaux épisodes chaque jour"
         ),
         second_short_tail=" — encore un moment",
+        caption_track_name="Français",
         ep_prefix_re=re.compile(
             r"^\s*(?:Ép\.?|Épisode|Ep\.?)\s*#?\s*\d+\s*[:：.\-—]\s*",
             re.IGNORECASE),
@@ -459,13 +462,14 @@ def publish_lang_dub(
                     description=_long_description(config, desc, lang,
                                                   episode_num=episode_num,
                                                   kind="long"),
-                    tags=list(getattr(config, "keywords", []) or []),
+                    tags=_dub_tags(config, title),
                     category_id=int(getattr(yt, "category_id", 28)),
                     default_language=lang.default_language,
                     privacy_status=getattr(yt, "privacy_status", "public"),
                     thumbnail_path=thumb_path,
                 )
                 long_url = up.watch_url
+                long_video_id = up.video_id
                 result["long_url"] = long_url
                 record_video(
                     video_id=up.video_id, show_slug=config.slug,
@@ -529,6 +533,30 @@ def publish_lang_dub(
                 logger.warning("lang_dub[%s]: transcript/selection failed "
                                "(%s) — voice-start short without captions",
                                lang.code, exc)
+
+            # Caption track on the dub long-form (Aug 2026 parity): the
+            # Whisper transcript exists in-process — one captions.insert
+            # gives the dub a CC button, auto-translate into 100+
+            # locales, and caption search indexing. Best-effort.
+            if tr_json is not None and result.get("long_url"):
+                try:
+                    from engine.captions import transcript_to_srt
+                    from engine.youtube import upload_caption_track
+                    _srt = tmp / f"{lang.code}_ep{episode_num:03d}_long.srt"
+                    transcript_to_srt(tr_json, _srt,
+                                      audio_offset_seconds=base_offset)
+                    if _srt.exists() and _srt.stat().st_size > 0:
+                        _cc_ok = upload_caption_track(
+                            credentials=creds, video_id=long_video_id,
+                            srt_path=_srt,
+                            language=lang.default_language,
+                            name=(lang.caption_track_name
+                                  or lang.default_language.upper()))
+                        result["caption_track_uploaded"] = bool(_cc_ok)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("lang_dub[%s]: caption-track upload "
+                                   "failed (%s) — ships without CC",
+                                   lang.code, exc)
 
             # Hook-first (July 31 2026 operator directive, all channels):
             # Short #1 is the dub's opening hook sequence — same rule as
@@ -686,17 +714,36 @@ def publish_lang_dub(
                         and (short_idx - 1) < len(_stagger_times)
                         else None
                     )
+                    # Custom Short thumbnail (Aug 2026 parity with EN):
+                    # otherwise YouTube auto-picks a frame, frequently a
+                    # mid-crossfade blur on a slideshow render.
+                    _short_thumb = None
+                    if short_scenes:
+                        try:
+                            from engine.publisher import (
+                                generate_shorts_thumbnail,
+                            )
+                            _cand = (tmp / f"{lang.code}_short"
+                                     f"{short_idx + 1}_thumb.jpg")
+                            generate_shorts_thumbnail(
+                                short_scenes[short_idx % len(short_scenes)],
+                                _cand, show_name=config.name)
+                            if _cand.exists():
+                                _short_thumb = _cand
+                        except Exception:  # noqa: BLE001
+                            _short_thumb = None
                     sup = upload_video(
                         short_mp4, credentials=creds,
                         title=st,
                         description=_long_description(config, desc, lang,
                                                       episode_num=episode_num,
                                                       kind="short"),
-                        tags=list(getattr(config, "keywords", []) or []),
+                        tags=_dub_tags(config, opening_text or title),
                         category_id=int(getattr(yt, "category_id", 28)),
                         default_language=lang.default_language,
                         privacy_status=getattr(yt, "privacy_status",
                                                "public"),
+                        thumbnail_path=_short_thumb,
                         publish_at=_publish_at)
                     short_urls_out.append(sup.watch_url)
                     record_video(
@@ -710,13 +757,9 @@ def publish_lang_dub(
                         watch_url=sup.watch_url,
                         channel=lang.channel, window=window_label,
                         index_path=idx_path)
-                    if playlist:
-                        try:
-                            add_video_to_playlist(credentials=creds,
-                                                  video_id=sup.video_id,
-                                                  playlist_id=playlist)
-                        except Exception:  # noqa: BLE001
-                            pass
+                    # Shorts never join the podcast playlist (YouTube
+                    # Music ingests it as the show's podcast) — same fix
+                    # as the EN + RU paths, Aug 2026.
                     # Funnel comment — only when a language long exists
                     # this run (never link a different-language video).
                     if long_url and bool(getattr(yt, "auto_comment", True)):

--- a/engine/ru_dub.py
+++ b/engine/ru_dub.py
@@ -207,6 +207,34 @@ def _cover_path(config) -> Optional[Path]:
     return next((c for c in cands if c.exists()), None)
 
 
+def _dub_tags(config, topic_text: str = "") -> list:
+    """Length-guarded tag list for a dub upload (Aug 2026 parity fix).
+
+    The dub paths used to pass raw ``config.keywords`` with no 500-char
+    guard (modern_investing measured 40 chars from a 400 on every dub
+    upload), no per-episode entities, and no dedupe. Routes through
+    ``engine.video_metadata.build_tags`` — the same builder the EN path
+    uses. Entity extraction is Latin-script (helps FR titles; a Cyrillic
+    title just yields the guarded static set).
+    """
+    try:
+        from engine.shorts_hashtags import extract_entity_phrases
+        from engine.video_metadata import build_tags
+
+        entities = extract_entity_phrases(
+            topic_text or "",
+            show_keywords=list(getattr(config, "keywords", []) or []),
+            max_phrases=8,
+        )
+        return build_tags(
+            entities + list(getattr(config.youtube, "tags", []) or []),
+            list(getattr(config, "keywords", []) or []),
+            network_tags=[],
+        )
+    except Exception:  # noqa: BLE001 — tags must never block an upload
+        return list(getattr(config, "keywords", []) or [])[:20]
+
+
 def _hashtags(config) -> str:
     tags = [t for t in (getattr(config, "keywords", []) or [])][:3]
     parts = []
@@ -649,13 +677,14 @@ def publish_ru_dub(
                     description=_ru_long_description(
                         config, ru_desc,
                         episode_num=episode_num, kind="long"),
-                    tags=list(getattr(config, "keywords", []) or []),
+                    tags=_dub_tags(config, ru_title),
                     category_id=int(getattr(yt, "category_id", 28)),
                     default_language="ru",
                     privacy_status=getattr(yt, "privacy_status", "public"),
                     thumbnail_path=thumb_path,
                 )
                 long_url = up.watch_url
+                long_video_id = up.video_id
                 result["long_url"] = long_url
                 record_video(
                     video_id=up.video_id, show_slug=config.slug, episode=episode_num,
@@ -731,6 +760,28 @@ def publish_ru_dub(
             except Exception as exc:  # noqa: BLE001
                 logger.warning("ru_dub: RU transcript/selection failed (%s) — "
                                "voice-start short without captions", exc)
+
+            # Caption track on the RU long-form (Aug 2026 parity): the
+            # Whisper RU transcript already exists in-process for the
+            # Shorts — writing it as an SRT and uploading it gives the
+            # dub a CC button, YouTube's auto-translate into 100+
+            # locales, and caption search indexing, all for one API
+            # call. Best-effort; the video already shipped.
+            if tr_json is not None and result.get("long_url"):
+                try:
+                    from engine.captions import transcript_to_srt
+                    from engine.youtube import upload_caption_track
+                    _srt = tmp / f"ru_ep{episode_num:03d}_long.srt"
+                    transcript_to_srt(tr_json, _srt,
+                                      audio_offset_seconds=base_offset)
+                    if _srt.exists() and _srt.stat().st_size > 0:
+                        _cc_ok = upload_caption_track(
+                            credentials=creds, video_id=long_video_id,
+                            srt_path=_srt, language="ru", name="Русский")
+                        result["caption_track_uploaded"] = bool(_cc_ok)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("ru_dub: caption-track upload failed "
+                                   "(%s) — long-form ships without CC", exc)
 
             # Hook-first (July 31 2026 operator directive, all channels):
             # Short #1 is the dub's opening hook sequence — the RU/FR
@@ -889,16 +940,36 @@ def publish_ru_dub(
                         and (short_idx - 1) < len(_stagger_times)
                         else None
                     )
+                    # Custom Short thumbnail (Aug 2026 parity): dub
+                    # Shorts used to take YouTube's auto-picked frame —
+                    # frequently a mid-crossfade blur on a slideshow
+                    # render. Cycle the episode's scene images like the
+                    # EN path does. Best-effort.
+                    _short_thumb = None
+                    if short_scenes:
+                        try:
+                            from engine.publisher import (
+                                generate_shorts_thumbnail,
+                            )
+                            _cand = tmp / f"ru_short{short_idx + 1}_thumb.jpg"
+                            generate_shorts_thumbnail(
+                                short_scenes[short_idx % len(short_scenes)],
+                                _cand, show_name=config.name)
+                            if _cand.exists():
+                                _short_thumb = _cand
+                        except Exception:  # noqa: BLE001
+                            _short_thumb = None
                     sup = upload_video(
                         short_mp4, credentials=creds,
                         title=short_title,
                         description=_ru_long_description(
                             config, ru_desc,
                             episode_num=episode_num, kind="short"),
-                        tags=list(getattr(config, "keywords", []) or []),
+                        tags=_dub_tags(config, opening_text or ru_title),
                         category_id=int(getattr(yt, "category_id", 28)),
                         default_language="ru",
                         privacy_status=getattr(yt, "privacy_status", "public"),
+                        thumbnail_path=_short_thumb,
                         publish_at=_publish_at)
                     short_urls_out.append(sup.watch_url)
                     # July 18 2026 (operator-approved): RU funnel comment.
@@ -968,7 +1039,10 @@ def publish_ru_dub(
                         window=window_label,
                         index_path=PROJECT_ROOT / config.episode.output_dir
                         / "youtube_videos.ru.json")
-                    pl = (getattr(yt, "ru_podcast_playlist_id", None) or "").strip()
+                    # Shorts never join the PODCAST playlist (YouTube
+                    # Music ingests it as the show's podcast) — same fix
+                    # as the EN path, Aug 2026.
+                    pl = ""
                     if pl:
                         try:
                             add_video_to_playlist(credentials=creds,

--- a/engine/scene_scheduler.py
+++ b/engine/scene_scheduler.py
@@ -81,14 +81,18 @@ _MIN_CHAPTER_GAP_S = 1.0
 _OPEN_FAST_WINDOW_S = 60.0
 _OPEN_MAX_HOLD_S = 8.0
 
-# Hard cap on ffmpeg slideshow inputs. The xfade+zoompan filter graph
-# scales poorly past ~30–40 scenes; Tesla Ep537 (1044 s @ 15 s hold →
-# 74 slots, only 4 unique images after gallery CDN 403s) timed out the
-# 2400 s pipeline mid-slideshow. 24 matches the historical ~10-min /
-# 25 s-hold cadence and keeps a 17-min episode renderable (~43 s holds,
-# still watchable under Ken Burns). Shared with engine.video's uniform
-# cycling path.
-_MAX_SLIDESHOW_SLOTS = 24
+# Hard cap on slideshow SLOTS (scene holds), shared with engine.video's
+# uniform cycling path. History: Tesla Ep537 (1044 s @ 15 s hold -> 74
+# slots over only 4 unique images) timed out the 2400 s pipeline, and
+# the cap was set to 24 — because every slot was its own ffmpeg input
+# (74 demuxers/decoders of identical pixels). Aug 2026: the command
+# builders dedupe inputs (one -i per UNIQUE image + split fan-out), so
+# input count no longer scales with slots and the cap can afford real
+# scene changes on long episodes: 36 slots holds a 17-min episode to
+# ~29 s per scene (was 85+ s after the old cap's merges). Still a cap —
+# each slot is a zoompan+xfade stage, and 36 keeps the graph well under
+# the shapes that have ever timed out.
+_MAX_SLIDESHOW_SLOTS = 36
 
 
 def _tokenize(text: Optional[str]) -> frozenset:

--- a/engine/video.py
+++ b/engine/video.py
@@ -636,6 +636,13 @@ _KB_LEGACY_MOVE_COUNT = 4
 # between the stronger pushes. The legacy path stays pinned at
 # ``_ZOOM_MAX`` (1.09).
 _KB_ZOOM_AMPLITUDES = (1.06, 1.09, 1.12)
+# Duration-adaptive Ken Burns (Aug 2026): amplitude per second of hold,
+# with floor/ceiling. 0.006/s x 15 s = 0.09 — the historical middle rung,
+# so the common case is unchanged; longer holds travel proportionally
+# further instead of slowing to sub-perceptual drift.
+_KB_AMP_PER_SECOND = 0.006
+_KB_AMP_MIN = 0.04
+_KB_AMP_MAX = 0.24
 
 
 def _kb_seed_from_stem(stem) -> int:
@@ -726,8 +733,27 @@ def _ken_burns_chain(src: str, out_label: str, *, frames: int, index: int,
     pre_w, pre_h = int(width * prescale), int(height * prescale)
     if kb_extended:
         move = _KB_MOVES[(index + kb_seed) % len(_KB_MOVES)]
-        zoom_max = _KB_ZOOM_AMPLITUDES[(index + kb_seed) % len(_KB_ZOOM_AMPLITUDES)]
+        ladder = _KB_ZOOM_AMPLITUDES[
+            (index + kb_seed) % len(_KB_ZOOM_AMPLITUDES)] - 1.0
+        if trim_seconds and trim_seconds > 0:
+            # Duration-adaptive amplitude (Aug 2026): a fixed amplitude
+            # means perceived velocity is inversely proportional to hold
+            # length — a 4 s Shorts segment moved at ~2.3%/s while a
+            # post-cap 29 s hold crawls at ~0.3%/s (functionally the
+            # frozen still the motion pass exists to eliminate). Scale
+            # the zoom range with the hold so travel speed stays in a
+            # visible band; the ladder survives as a ±1/3 rhythm
+            # multiplier (0.006/s reproduces the 1.09 middle rung at
+            # the historical 15 s hold exactly). Floor keeps short
+            # segments calm; ceiling keeps long holds from swimming.
+            rel = ladder / 0.09
+            amp = min(_KB_AMP_MAX,
+                      max(_KB_AMP_MIN, _KB_AMP_PER_SECOND * trim_seconds * rel))
+            zoom_max = round(1.0 + amp, 4)  # clean float repr in the graph
+        else:
+            zoom_max = 1.0 + ladder
     else:
+        # Legacy mode stays byte-pinned (Shorts motion A/B control arm).
         move = _KB_MOVES[index % _KB_LEGACY_MOVE_COUNT]
         zoom_max = _ZOOM_MAX
     z, x, y = _ken_burns(frames, move, zoom_max=zoom_max)

--- a/engine/video.py
+++ b/engine/video.py
@@ -756,7 +756,8 @@ def _slideshow_filter_graph(scene_count: int, *,
                             fps: int = 30,
                             crossfade: float = _SLIDESHOW_XFADE_S,
                             kb_seed: int = 0,
-                            kb_extended: bool = True) -> str:
+                            kb_extended: bool = True,
+                            input_map: Optional[Sequence[int]] = None) -> str:
     """Build the filter_complex for a Ken Burns slideshow.
 
     Each scene gets a 1.00 → 1.12 zoom over its window. When *crossfade* > 0
@@ -785,6 +786,10 @@ def _slideshow_filter_graph(scene_count: int, *,
             f"scene_durations length {len(scene_durations)} != "
             f"scene_count {scene_count}"
         )
+    if input_map is not None and len(input_map) != scene_count:
+        raise ValueError(
+            f"input_map length {len(input_map)} != scene_count {scene_count}"
+        )
     use_xfade = crossfade and crossfade > 0 and scene_count >= 2
     xfade_pad = crossfade if use_xfade else 0.0
     durs: List[float] = (
@@ -794,11 +799,43 @@ def _slideshow_filter_graph(scene_count: int, *,
     )
 
     chains: List[str] = []
+
+    # Input dedup (Aug 2026): a cycled plan used to open the SAME 4-8
+    # image files once per slot — 24+ demuxers/decoders/input buffers of
+    # identical pixels, the actual mechanism behind the Ep537 input
+    # blowup the slot cap papered over. With ``input_map`` (slot ->
+    # unique ffmpeg input index), each unique file is one ``-i`` and a
+    # ``split`` fans its frames out to the per-slot Ken Burns chains
+    # (zoompan pulls lazily, so each branch still only decodes a frame
+    # or two). ``None`` keeps the legacy one-input-per-slot graph
+    # byte-for-byte.
+    if input_map is not None:
+        from collections import Counter
+
+        counts = Counter(input_map)
+        for j in sorted(set(input_map)):
+            k = counts[j]
+            if k > 1:
+                outs = "".join(f"[in{j}c{m}]" for m in range(k))
+                chains.append(f"[{j}:v]split={k}{outs}")
+        _consumed: dict = {}
+
+        def _src(i: int) -> str:
+            j = input_map[i]
+            if counts[j] == 1:
+                return f"[{j}:v]"
+            m = _consumed.get(j, 0)
+            _consumed[j] = m + 1
+            return f"[in{j}c{m}]"
+    else:
+        def _src(i: int) -> str:
+            return f"[{i}:v]"
+
     for i in range(scene_count):
         clip_len = durs[i] + xfade_pad
         frames_per_scene = max(2, round(clip_len * fps))
         chains.append(_ken_burns_chain(
-            f"[{i}:v]", f"[s{i}]",
+            _src(i), f"[s{i}]",
             frames=frames_per_scene, index=i,
             width=width, height=height, fps=fps,
             trim_seconds=clip_len,
@@ -827,6 +864,27 @@ def _slideshow_filter_graph(scene_count: int, *,
     return ";".join(chains)
 
 
+def _dedupe_scene_inputs(
+    scene_paths: Sequence[Path],
+) -> Tuple[List[Path], List[int]]:
+    """Collapse a (cycled) slot list to unique ffmpeg inputs.
+
+    Returns ``(unique_paths, input_map)`` where ``input_map[slot]`` is the
+    index into ``unique_paths``. A cycled 24-slot plan over 4 images
+    becomes 4 inputs instead of 24 demuxers of identical pixels.
+    """
+    unique: List[Path] = []
+    index_of: dict = {}
+    input_map: List[int] = []
+    for p in scene_paths:
+        key = str(p)
+        if key not in index_of:
+            index_of[key] = len(unique)
+            unique.append(p)
+        input_map.append(index_of[key])
+    return unique, input_map
+
+
 def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                    *, scene_duration: float = _SCENE_DURATION_SECONDS,
                    scene_durations: Optional[Sequence[float]] = None,
@@ -853,12 +911,17 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
         if scene_durations is not None
         else [scene_duration] * len(scene_paths)
     )
+    unique_inputs, input_map = _dedupe_scene_inputs(scene_paths)
+    # Each unique input's -t must cover its LONGEST consumer slot.
+    input_t = {}
+    for i, j in enumerate(input_map):
+        input_t[j] = max(input_t.get(j, 0.0), durs[i] + input_pad)
     inputs: List[str] = []
-    for i, path in enumerate(scene_paths):
+    for j, path in enumerate(unique_inputs):
         inputs.extend([
             "-loop", "1",
             "-framerate", str(fps),
-            "-t", f"{durs[i] + input_pad:.2f}",
+            "-t", f"{input_t[j]:.2f}",
             "-i", str(path),
         ])
     return [
@@ -870,7 +933,8 @@ def _slideshow_cmd(scene_paths: Sequence[Path], output: Path,
                                 scene_durations=scene_durations,
                                 width=width, height=height, fps=fps,
                                 crossfade=crossfade,
-                                kb_seed=kb_seed, kb_extended=kb_extended),
+                                kb_seed=kb_seed, kb_extended=kb_extended,
+                                input_map=input_map),
         "-map", "[v]",
         "-r", str(fps),
         *_VIDEO_ENCODE_FAST,
@@ -2054,6 +2118,7 @@ def _single_pass_long_form_filter_graph(
     hook: Optional[str] = None,
     kb_seed: int = 0,
     kb_extended: bool = True,
+    input_map: Optional[Sequence[int]] = None,
 ) -> str:
     """One filter graph for slideshow + overlays + captions (P1-2).
 
@@ -2084,6 +2149,7 @@ def _single_pass_long_form_filter_graph(
         width=width, height=height, fps=fps,
         crossfade=crossfade,
         kb_seed=kb_seed, kb_extended=kb_extended,
+        input_map=input_map,
     )
     # The slideshow graph's terminal label is always ``[v]``; the
     # composite needs it as ``[bg]``. Only the final occurrence is the
@@ -2100,9 +2166,12 @@ def _single_pass_long_form_filter_graph(
     # different chroma handling on overlay edges vs the two-stage path).
     graph = slideshow[: -len("[v]")] + f",{_GRADE_CHAIN},format=yuv420p[bg]"
 
-    # Scenes consume inputs 0..n-1, so audio/brand/pill shift up.
-    brand_idx = scene_count + 1
-    pill_idx = scene_count + 2
+    # Scene inputs occupy 0..n_inputs-1 (deduped when input_map is
+    # given — a cycled plan's audio/brand/pill sit right after the
+    # UNIQUE images, not after every slot), so audio/brand/pill shift up.
+    n_inputs = (max(input_map) + 1) if input_map else scene_count
+    brand_idx = n_inputs + 1
+    pill_idx = n_inputs + 2
 
     graph += (
         f";[{brand_idx}:v]format=rgba[brand];"
@@ -2188,16 +2257,20 @@ def _single_pass_long_form_cmd(
         else [scene_duration] * len(scene_paths)
     )
 
+    unique_inputs, input_map = _dedupe_scene_inputs(scene_paths)
+    input_t = {}
+    for i, j in enumerate(input_map):
+        input_t[j] = max(input_t.get(j, 0.0), durs[i] + input_pad)
     inputs: List[str] = []
-    for i, path in enumerate(scene_paths):
+    for j, path in enumerate(unique_inputs):
         inputs.extend([
             "-loop", "1",
             "-framerate", str(fps),
-            "-t", f"{durs[i] + input_pad:.2f}",
+            "-t", f"{input_t[j]:.2f}",
             "-i", str(path),
         ])
 
-    n = len(scene_paths)
+    n = len(unique_inputs)
     inputs.extend(["-i", audio_in])
     inputs.extend(["-loop", "1", "-framerate", str(fps), "-i", brand_in])
     next_index = n + 2
@@ -2225,7 +2298,8 @@ def _single_pass_long_form_cmd(
         meta_map = ["-map_metadata", str(next_index)]
 
     graph = _single_pass_long_form_filter_graph(
-        n,
+        len(scene_paths),
+        input_map=input_map,
         scene_duration=scene_duration,
         scene_durations=scene_durations,
         width=width, height=height, fps=fps,

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -276,14 +276,30 @@ def _load_description_body_from_template(
     return _strip_markdown(body)
 
 
-def _build_tags(
+def _quoted_tag_cost(tags: List[str]) -> int:
+    """YouTube's real accounting: a tag containing a space is stored
+    quoted (+2 chars), and the commas between tags count too. A naive
+    ``len(",".join(tags))`` under-counts space-y tag sets and ships a
+    400 invalidTags on the whole upload."""
+    if not tags:
+        return 0
+    per = [len(t) + (2 if " " in t else 0) for t in tags]
+    return sum(per) + (len(tags) - 1)
+
+
+def build_tags(
     extra: List[str],
     keywords: List[str],
     *,
     network_tags: List[str],
     max_tags: int = 30,
 ) -> List[str]:
-    """Build a deduped list of tags that fits inside YouTube's 500-char cap."""
+    """Build a deduped tag list inside YouTube's 500-char cap.
+
+    Public since Aug 2026 so the RU/FR dub upload paths can stop passing
+    raw ``config.keywords`` with no length guard (modern_investing's dub
+    tag set measured 40 chars from a 400 on every upload).
+    """
     seen = set()
     ordered: List[str] = []
     for tag in list(extra) + list(network_tags) + list(keywords):
@@ -297,10 +313,14 @@ def _build_tags(
         if len(ordered) >= max_tags:
             break
 
-    # Trim from the tail while the comma-joined length exceeds the cap.
-    while ordered and len(",".join(ordered)) > YOUTUBE_TAG_TOTAL_MAX:
+    # Trim from the tail while the QUOTED cost exceeds the cap.
+    while ordered and _quoted_tag_cost(ordered) > YOUTUBE_TAG_TOTAL_MAX:
         ordered.pop()
     return ordered
+
+
+# Backwards-compatible alias for in-module callers.
+_build_tags = build_tags
 
 
 # ---------------------------------------------------------------------------

--- a/engine/youtube.py
+++ b/engine/youtube.py
@@ -217,17 +217,30 @@ def _build_video_body(
 
 
 def _is_retryable_upload_error(exc: BaseException) -> bool:
-    """Retry transient failures only — not 400 invalidDescription / auth."""
+    """Retry transient failures only — not 400 invalidDescription / auth.
+
+    A resumable multi-chunk upload of a 40-minute MP4 fails far more
+    often with a plain transport error (connection reset, TLS EOF,
+    incomplete read, broken pipe) than with a retryable HTTP status —
+    and the old HttpError-only predicate meant a single TCP hiccup cost
+    the whole long-form for the day. socket.timeout is TimeoutError and
+    ConnectionResetError/BrokenPipeError are ConnectionError subclasses
+    on py3.10+, so the tuple below covers the observed failure set.
+    """
     if _is_retryable_http_error(exc):
         return True
-    try:
-        from googleapiclient.errors import HttpError
-    except ImportError:  # pragma: no cover
-        return False
-    if isinstance(exc, HttpError):
-        status = getattr(getattr(exc, "resp", None), "status", 0)
-        return status in (429, 500, 502, 503, 504)
-    return False
+    import http.client
+    import ssl
+
+    if isinstance(exc, ssl.SSLCertVerificationError):
+        return False  # deterministic — surface it, don't retry
+    return isinstance(exc, (
+        ConnectionError,          # ConnectionResetError, BrokenPipeError, …
+        TimeoutError,             # socket.timeout
+        ssl.SSLError,             # SSLEOFError mid-chunk
+        http.client.IncompleteRead,
+        http.client.RemoteDisconnected,
+    ))
 
 
 @retry(

--- a/engine/youtube_quota.py
+++ b/engine/youtube_quota.py
@@ -9,6 +9,8 @@ from typing import List, Optional
 
 import yaml
 
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
 # Documented costs (units per call) — keep in sync with engine/youtube.py.
 QUOTA_VIDEO_INSERT = 1600
 QUOTA_THUMBNAIL_SET = 50
@@ -162,22 +164,40 @@ def estimate_network_daily_units(
     per_show_uploads: dict[str, int] = {}
     show_channel: dict[str, str] = {}
 
-    def _add_ru_dub(slug: str, publish_shorts: bool) -> None:
-        # RU-dub uploads (July 2026 fix): shows with youtube.ru_dub_enabled
-        # push 1 long + 1 Short per episode to @NerraRU via the decoupled
-        # multilingual flow — previously invisible to the estimate because
-        # only youtube.channel was bucketed. No caption track is inserted on
-        # the dub; the thumbnail/playlist paper costs match the main model.
+    def _policy_shorts(channel: str, slug: str, default: int = 1) -> int:
+        # Read the ACTUAL Shorts count from the committed policy — the
+        # ru dub was hardcoded at 1 while the 3-Short band's members are
+        # exactly the RU dubs, so the paper model undercounted the
+        # hottest channel by up to 2 uploads/show/day.
+        try:
+            import json as _json
+
+            pol = _json.loads(
+                (PROJECT_ROOT / "api" / "youtube_policy.json").read_text(
+                    encoding="utf-8"))
+            entry = (pol.get("channels", {}).get(channel, {})
+                     .get(slug) or {})
+            return max(1, int(entry.get("shorts_per_episode") or default))
+        except Exception:  # noqa: BLE001 — paper model, best-effort
+            return default
+
+    def _add_dub(slug: str, channel: str, publish_shorts: bool) -> None:
+        # Dub uploads: shows with youtube.ru_dub_enabled push to @NerraRU;
+        # shows with youtube.dub_languages push to each language channel
+        # (@NerraFR, ...). The FR channel was previously INVISIBLE to the
+        # estimate — dub_languages was never read, so the whole channel
+        # was missing from estimate_network_daily_units and the preflight.
+        # Aug 2026: the dubs now upload a caption track too.
         est = estimate_episode_units(
             publish_long_form=True,
             publish_shorts=publish_shorts,
-            shorts_count=1,
-            with_caption_track=False,
+            shorts_count=_policy_shorts(channel, slug),
+            with_caption_track=True,
         )
-        key = f"{slug} (ru dub)"
+        key = f"{slug} ({channel} dub)"
         per_show[key] = est.units
         per_show_uploads[key] = est.uploads
-        show_channel[key] = "ru"
+        show_channel[key] = channel
 
     for slug in discover_show_slugs(shows_dir):
         yaml_path = shows_dir / f"{slug}.yaml"
@@ -185,7 +205,10 @@ def estimate_network_daily_units(
             cfg = load_config(yaml_path)
             yt = getattr(cfg, "youtube", None)
             if getattr(yt, "ru_dub_enabled", False):
-                _add_ru_dub(slug, bool(getattr(yt, "publish_shorts", True)))
+                _add_dub(slug, "ru", bool(getattr(yt, "publish_shorts", True)))
+            for _lang in (getattr(yt, "dub_languages", None) or []):
+                _add_dub(slug, str(_lang).lower(),
+                         bool(getattr(yt, "publish_shorts", True)))
             if not getattr(yt, "enabled", False):
                 continue
             est = estimate_episode_units(
@@ -201,7 +224,10 @@ def estimate_network_daily_units(
             raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
             yt = raw.get("youtube") or {}
             if yt.get("ru_dub_enabled") is True:
-                _add_ru_dub(slug, bool(yt.get("publish_shorts", True)))
+                _add_dub(slug, "ru", bool(yt.get("publish_shorts", True)))
+            for _lang in (yt.get("dub_languages") or []):
+                _add_dub(slug, str(_lang).lower(),
+                         bool(yt.get("publish_shorts", True)))
             if yt.get("enabled") is not True:
                 continue
             est = estimate_episode_units(

--- a/scripts/fetch_youtube_analytics.py
+++ b/scripts/fetch_youtube_analytics.py
@@ -268,6 +268,96 @@ def _geography(service, start: str, end: str, limit: int = 25) -> List[dict]:
     return rows
 
 
+def _traffic_sources(service, start: str, end: str) -> List[dict]:
+    """Views by traffic source type (Shorts feed / browse / SEARCH /
+    suggested / external). [] on any failure.
+
+    Aug 2026: the policy treated a search-driven view and a Shorts-feed
+    view as identical evidence; this is the free split that says whether
+    titles/tags are doing anything at all.
+    """
+    try:
+        resp = service.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics="views,estimatedMinutesWatched",
+            dimensions="insightTrafficSourceType",
+            sort="-views", maxResults=25,
+        ).execute()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("traffic-source query skipped: %s", str(exc)[:160])
+        return []
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    rows = []
+    for row in resp.get("rows", []) or []:
+        rec = dict(zip(headers, row))
+        rows.append({
+            "source": rec.get("insightTrafficSourceType", ""),
+            "views": int(float(rec.get("views") or 0)),
+            "minutes": round(float(
+                rec.get("estimatedMinutesWatched") or 0), 1),
+        })
+    return rows
+
+
+def _search_terms(service, start: str, end: str, limit: int = 20) -> List[dict]:
+    """The literal YouTube search queries that reached this channel.
+
+    The single best free input for tags and the title prompt. [] on any
+    failure (the detail dimension needs YT_SEARCH traffic to exist).
+    """
+    try:
+        resp = service.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics="views", dimensions="insightTrafficSourceDetail",
+            filters="insightTrafficSourceType==YT_SEARCH",
+            sort="-views", maxResults=limit,
+        ).execute()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("search-terms query skipped: %s", str(exc)[:160])
+        return []
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    rows = []
+    for row in resp.get("rows", []) or []:
+        rec = dict(zip(headers, row))
+        term = str(rec.get("insightTrafficSourceDetail", "")).strip()
+        if term:
+            rows.append({"term": term,
+                         "views": int(float(rec.get("views") or 0))})
+    return rows
+
+
+def _retention_curve(service, video_id: str, start: str, end: str) -> List[dict]:
+    """The audience-retention curve for ONE video — where viewers leave.
+
+    averageViewPercentage is one scalar; the curve says WHERE the drop
+    happens, which is what the scene scheduler and the hook-first
+    directive actually need measured. [] on any failure.
+    """
+    try:
+        resp = service.reports().query(
+            ids="channel==MINE", startDate=start, endDate=end,
+            metrics="audienceWatchRatio",
+            dimensions="elapsedVideoTimeRatio",
+            filters=f"video=={video_id}",
+        ).execute()
+    except Exception as exc:  # noqa: BLE001
+        logger.info("retention-curve query skipped (%s): %s",
+                    video_id, str(exc)[:120])
+        return []
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    curve = []
+    for row in resp.get("rows", []) or []:
+        rec = dict(zip(headers, row))
+        try:
+            curve.append({
+                "t": round(float(rec.get("elapsedVideoTimeRatio")), 3),
+                "ratio": round(float(rec.get("audienceWatchRatio")), 4),
+            })
+        except (TypeError, ValueError):
+            continue
+    return curve
+
+
 def _summarise_demographics(rows: List[dict]) -> dict:
     """Marginals worth putting on a dashboard card."""
     if not rows:
@@ -441,13 +531,37 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
                     demo[kind] = kind_rows
                     demo[f"{kind}_summary"] = _summarise_demographics(kind_rows)
         geo = _geography(service, demo_start, end)
+        traffic = _traffic_sources(service, demo_start, end)
+        search_terms = _search_terms(service, demo_start, end)
 
-        if snap or series or all_rows or geo:
+        # Retention curves for the channel's top recent LONGS (28d, by
+        # views, capped at 5 — one API call each). The curve is the
+        # measurement the scene scheduler + hook-first directive have
+        # been missing; Shorts curves are less actionable (35 s clips).
+        _recent_longs = sorted(
+            (r for r in rows
+             if (r.get("kind") or "") == "long"
+             and (r.get("published") or "") >= demo_start),
+            key=lambda r: -float((metrics_by_video.get(r["video_id"]) or {})
+                                 .get("views", 0) or 0))[:5]
+        for r in _recent_longs:
+            curve = _retention_curve(service, r["video_id"],
+                                     demo_start, end)
+            if curve:
+                m = metrics_by_video.get(r["video_id"])
+                if m is not None:
+                    m["retention_curve"] = curve
+
+        if snap or series or all_rows or geo or traffic:
             snap["day_series"] = series
             if all_rows:
                 snap["demographics"] = demo
             if geo:
                 snap["geography"] = geo
+            if traffic:
+                snap["traffic_sources"] = traffic
+            if search_terms:
+                snap["search_terms"] = search_terms
             channels_block[channel] = snap
 
     if not any_data:
@@ -487,6 +601,10 @@ def fetch(digests_dir: Path, days: int) -> Optional[dict]:
             "average_view_percentage": float(m.get("averageViewPercentage", 0) or 0),
             "subscribers_gained": int(float(m.get("subscribersGained", 0) or 0)),
             "subscribers_lost": int(float(m.get("subscribersLost", 0) or 0)),
+            # Present only on the channel's top recent longs (one API
+            # call each) — where viewers actually leave the video.
+            **({"retention_curve": m["retention_curve"]}
+               if m.get("retention_curve") else {}),
         })
 
     return {

--- a/scripts/update_youtube_policy.py
+++ b/scripts/update_youtube_policy.py
@@ -335,10 +335,39 @@ def build_policy(
             # once.
             if short_vpd is not None:
                 shorts = shorts_for_vpd(short_vpd)
+            # Asymmetric hysteresis on the COUNT (Aug 2026): the July 30
+            # ladder added a 20 vpd -> 3 band, and a show oscillating
+            # around a band edge toggled 2<->3 nightly — render cost,
+            # upload cadence, and the marginal window's quality all
+            # flapping with it. RAISING the count now needs the same
+            # computed value on 2 consecutive runs (own pending/streak
+            # pair, mirroring the tier state machine); LOWERING applies
+            # immediately, matching resolve_publish_plan's rule that
+            # cutting supply is always allowed.
+            prev_shorts = None
+            if isinstance(prev_entry, dict):
+                try:
+                    prev_shorts = int(
+                        prev_entry.get("shorts_per_episode") or 0) or None
+                except (TypeError, ValueError):
+                    prev_shorts = None
+            shorts_pending = shorts
+            shorts_streak = 1
+            if prev_shorts is not None and shorts > prev_shorts:
+                prev_sp = prev_entry.get("shorts_pending")
+                try:
+                    prev_ss = int(prev_entry.get("shorts_streak") or 0)
+                except (TypeError, ValueError):
+                    prev_ss = 0
+                shorts_streak = prev_ss + 1 if shorts == prev_sp else 1
+                if shorts_streak < STREAK_TO_FLIP:
+                    shorts = prev_shorts   # hold until the raise confirms
             channels[channel][slug] = {
                 "tier": active,
                 "publish_long_form": publish_long,
                 "shorts_per_episode": shorts,
+                "shorts_pending": shorts_pending,
+                "shorts_streak": shorts_streak,
                 "long_vpd": round(long_vpd, 3) if long_vpd is not None else None,
                 "short_vpd": round(short_vpd, 3) if short_vpd is not None else None,
                 "video_count_14d": len(long_vpds) + len(short_vpds),

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -454,7 +454,7 @@ youtube:
   # committed manifest) into the fresh Grok Imagine sets — zero new
   # image-generation cost; the caps bound the per-episode downloads.
   gallery_blend_enabled: true
-  gallery_blend_max_long: 16    # 16:9 library scenes per long-form video
+  gallery_blend_max_long: 24    # 16:9 library scenes per long-form video (raised with the 36-slot cap so images repeat ~1.3x, not 2x+)
   gallery_blend_max_short: 6    # 9:16 library scenes per Short
   # Scene switches land on chapters.json boundaries instead of the
   # uniform timer (<2 usable chapters falls back to uniform).

--- a/tests/test_ru_dub.py
+++ b/tests/test_ru_dub.py
@@ -728,3 +728,47 @@ class TestClauseTrim:
                     f"{name} word-trims a Short title from opening_text at "
                     f"offset {match.start()} — use _clause_trim"
                 )
+
+
+class TestDubMetadataParity:
+    """Aug 2026: dub uploads route tags through the guarded builder,
+    ship a caption track, give Shorts real thumbnails, and keep Shorts
+    out of the podcast playlist."""
+
+    def _srcs(self):
+        import pathlib
+        root = pathlib.Path(__file__).resolve().parent.parent
+        return {
+            n: (root / "engine" / f"{n}.py").read_text(encoding="utf-8")
+            for n in ("ru_dub", "lang_dub")
+        }
+
+    def test_no_raw_keyword_tags_remain(self):
+        for name, src in self._srcs().items():
+            assert 'tags=list(getattr(config, "keywords"' not in src, name
+            assert "_dub_tags(" in src, name
+
+    def test_caption_track_uploads_exist(self):
+        for name, src in self._srcs().items():
+            assert "upload_caption_track" in src, name
+            assert "transcript_to_srt" in src, name
+
+    def test_shorts_have_thumbnails(self):
+        for name, src in self._srcs().items():
+            assert "generate_shorts_thumbnail" in src, name
+
+    def test_dub_tags_are_length_guarded(self):
+        from types import SimpleNamespace
+        from engine.ru_dub import _dub_tags
+        cfg = SimpleNamespace(
+            keywords=[f"long keyword phrase number {i}" for i in range(40)],
+            youtube=SimpleNamespace(tags=[]),
+        )
+        tags = _dub_tags(cfg, "Tesla Cybercab wireless charging revealed")
+        from engine.video_metadata import _quoted_tag_cost
+        assert _quoted_tag_cost(tags) <= 500
+
+    def test_quoted_cost_counts_spaces(self):
+        from engine.video_metadata import _quoted_tag_cost
+        # "a b" stored quoted (+2) + comma + "c" -> 3+2+1+1 = 7
+        assert _quoted_tag_cost(["a b", "c"]) == 7

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -638,13 +638,21 @@ def test_slideshow_filter_graph_zoom_per_scene():
     range whatever the hold length and never stops. The ceiling is still
     asserted against the constant so the two cannot drift apart.
     """
-    from engine.video import _ZOOM_MAX
-
     graph = _slideshow_filter_graph(scene_count=2)
     # Duration-normalised: progress is a function of the output frame
     # number, not an accumulator against a cap.
     assert "on/" in graph
-    assert str(_ZOOM_MAX) in graph
+    # Aug 2026: amplitude is duration-adaptive — 0.006/s of hold, scaled
+    # by the rung's ±1/3 rhythm factor and clamped to [0.04, 0.24].
+    from engine.video import (_KB_AMP_PER_SECOND, _KB_AMP_MIN, _KB_AMP_MAX,
+                              _KB_ZOOM_AMPLITUDES, _SCENE_DURATION_SECONDS,
+                              _SLIDESHOW_XFADE_S)
+    trim = _SCENE_DURATION_SECONDS + _SLIDESHOW_XFADE_S
+    rung0 = (_KB_ZOOM_AMPLITUDES[0] - 1.0) / 0.09
+    expected = round(min(_KB_AMP_MAX,
+                         max(_KB_AMP_MIN,
+                             _KB_AMP_PER_SECOND * trim * rung0)), 4)
+    assert f"{expected}" in graph
     assert "min(zoom+0.0006" not in graph, (
         "the capped-accumulator zoom is back — it freezes the image for "
         "the remainder of every scene once the cap is reached"
@@ -2490,10 +2498,43 @@ class TestKenBurnsVocabulary:
         assert g0 != g1
 
     def test_extended_graph_alternates_amplitudes(self):
-        """Three consecutive slots at seed 0 carry the 1.06/1.09/1.12
-        alternation (rounded amps appear in the zoom expressions)."""
+        """Three consecutive slots at seed 0 carry three DISTINCT
+        rung-scaled amplitudes (the 1.06/1.09/1.12 ladder survives as a
+        ±1/3 rhythm multiplier on the duration-adaptive base)."""
+        import re as _re
         graph = _slideshow_filter_graph(scene_count=3, kb_seed=0)
-        assert "0.06" in graph and "0.09" in graph and "0.12" in graph
+        amps = set(_re.findall(r"zoompan=z='\((?:1\+|[0-9.]+-)([0-9.]+)\*", graph))
+        assert len(amps) == 3, amps
+
+    def test_amplitude_scales_with_hold_length(self):
+        """Aug 2026: a fixed amplitude made a 29 s hold crawl at
+        ~0.3%/s — sub-perceptual, functionally a frozen still. The zoom
+        range now grows with the hold so travel speed stays visible."""
+        import re as _re
+
+        def amp_of(graph):
+            return float(_re.search(r"zoompan=z='\((?:1\+|[0-9.]+-)([0-9.]+)\*", graph).group(1))
+
+        short_hold = _slideshow_filter_graph(
+            scene_count=2, scene_durations=[5.0, 5.0])
+        long_hold = _slideshow_filter_graph(
+            scene_count=2, scene_durations=[29.0, 29.0])
+        assert amp_of(long_hold) > amp_of(short_hold) * 2
+
+    def test_amplitude_floor_and_ceiling(self):
+        import re as _re
+        from engine.video import _KB_AMP_MIN, _KB_AMP_MAX
+
+        def amps(graph):
+            return [float(a) for a in
+                    _re.findall(r"zoompan=z='\((?:1\+|[0-9.]+-)([0-9.]+)\*", graph)]
+
+        tiny = _slideshow_filter_graph(scene_count=2,
+                                       scene_durations=[2.0, 2.0])
+        huge = _slideshow_filter_graph(scene_count=2,
+                                       scene_durations=[90.0, 90.0])
+        assert all(a >= _KB_AMP_MIN - 1e-9 for a in amps(tiny))
+        assert all(a <= _KB_AMP_MAX + 1e-9 for a in amps(huge))
 
     def test_legacy_mode_pins_four_moves_at_109(self):
         """kb_extended=False must reproduce the pre-A1 graph: first 4

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -1867,7 +1867,15 @@ def test_build_short_video_cut_times_scenes_rotate_across_segments(tmp_path,
     stage1 = captured_cmds[0]
     i_indices = [i for i, x in enumerate(stage1) if x == "-i"]
     input_paths = [stage1[i + 1] for i in i_indices]
-    assert input_paths == [str(scenes[i % 3]) for i in range(6)]
+    # Aug 2026 input dedup: 6 slots over a 3-scene pool open each unique
+    # file ONCE and fan out via split — the rotation now lives in the
+    # filter graph's consumption order, not in duplicate -i entries.
+    assert input_paths == [str(s) for s in scenes]
+    graph = stage1[stage1.index("-filter_complex") + 1]
+    for j in range(3):
+        assert f"[{j}:v]split=2[in{j}c0][in{j}c1]" in graph
+    # 6 Ken Burns chains still render — one per slot.
+    assert graph.count("zoompan=") == 6
 
 
 def test_build_short_video_none_cut_times_is_byte_identical(tmp_path,

--- a/tests/test_visual_reuse.py
+++ b/tests/test_visual_reuse.py
@@ -36,7 +36,7 @@ _NEW_KNOBS = {
     # generated per episode against up to 24 scheduler slots, so
     # the old pool repeated every image several times per episode.
     # Library scenes are already generated and already paid for.
-    "gallery_blend_max_long": 16,
+    "gallery_blend_max_long": 24,  # raised with the 36-slot cap
     "gallery_blend_max_short": 6,
     "chapter_aligned_scenes": True,
     "long_form_thumbnail_from_scene": True,

--- a/tests/test_youtube_policy.py
+++ b/tests/test_youtube_policy.py
@@ -869,3 +869,44 @@ class TestMaxShortsCeiling:
             policy, slug="tesla", channel="ru", yaml_publish_long=False,
             yaml_shorts=1, smart_mode=False, adaptive_enabled=True)
         assert plan["shorts"] == 1
+
+
+class TestShortsCountHysteresis:
+    """Aug 2026: raising the Shorts count needs 2 consecutive computed
+    runs (band-edge oscillation around 20 vpd toggled 2<->3 nightly);
+    lowering applies immediately."""
+
+    def _build(self, mod, prev_entry, short_vpd):
+        stats = _stats([])
+        # Build a minimal previous policy carrying the entry under test.
+        previous = {"channels": {"ru": {"spacex": prev_entry}}}
+        vids = []
+        import datetime as dt
+        gen = dt.date.fromisoformat(stats["generated"][:10])
+        for i in range(6):
+            pub = (gen - dt.timedelta(days=i + 1)).isoformat()
+            vids.append({"show_slug": "spacex", "channel": "ru",
+                         "kind": "short", "published": pub,
+                         "views": int(short_vpd * (i + 1))})
+        stats["shows"]["somedir"]["videos"] = vids
+        return mod.build_policy(stats, previous)
+
+    def test_raise_holds_for_one_run_then_applies(self):
+        mod = _load_script()
+        prev = {"tier": "C", "shorts_per_episode": 2, "pending": "C",
+                "streak": 5}
+        out1 = self._build(mod, prev, short_vpd=25.0)
+        e1 = out1["channels"]["ru"]["spacex"]
+        assert e1["shorts_per_episode"] == 2      # held on first sighting
+        assert e1["shorts_pending"] == 3
+        out2 = self._build(mod, e1, short_vpd=25.0)
+        e2 = out2["channels"]["ru"]["spacex"]
+        assert e2["shorts_per_episode"] == 3      # confirmed on run 2
+
+    def test_lowering_applies_immediately(self):
+        mod = _load_script()
+        prev = {"tier": "C", "shorts_per_episode": 3, "pending": "C",
+                "streak": 5, "shorts_pending": 3, "shorts_streak": 9}
+        out = self._build(mod, prev, short_vpd=5.0)
+        e = out["channels"]["ru"]["spacex"]
+        assert e["shorts_per_episode"] == 2

--- a/tests/test_youtube_quality_pass.py
+++ b/tests/test_youtube_quality_pass.py
@@ -72,8 +72,13 @@ class TestSlideshowSceneCycling:
         sched_src = (_ROOT / "engine" / "scene_scheduler.py").read_text(
             encoding="utf-8")
         assert "_MAX_SLIDESHOW_SLOTS" in video_src
-        assert "_MAX_SLIDESHOW_SLOTS = 24" in sched_src
-        assert _MAX_SLIDESHOW_SLOTS == 24
+        # Aug 2026: cap raised 24 -> 36 after the command builders began
+        # deduping ffmpeg inputs (one -i per unique image + split) — the
+        # Ep537 blowup was 74 DEMUXERS, not 74 zoompan stages, and input
+        # count no longer scales with slots.
+        assert "_MAX_SLIDESHOW_SLOTS = 36" in sched_src
+        assert _MAX_SLIDESHOW_SLOTS == 36
+        assert "_dedupe_scene_inputs" in video_src
         assert "PIPELINE_TIMEOUT_SECONDS: '3000'" in (
             _ROOT / ".github" / "workflows" / "run-show.yml"
         ).read_text(encoding="utf-8")

--- a/tests/test_youtube_quota.py
+++ b/tests/test_youtube_quota.py
@@ -154,7 +154,9 @@ def test_ru_dub_shows_count_against_ru_channel(tmp_path):
     assert "flag (ru dub)" in ru["enabled_slugs"]
     assert ru["uploads"] == 2  # dub long + dub Short count toward ru cadence
     # 2 video inserts + thumbnail/playlist each; no caption track on the dub.
-    assert ru["total_units"] == 2 * (1600 + 50 + 50)
+    # 2 uploads x (insert 1600 + thumbnail 50 + playlist 50) + the
+    # caption track the dub long-form uploads since Aug 2026 (400).
+    assert ru["total_units"] == 2 * (1600 + 50 + 50) + 400
     # The dub never leaks into the EN bucket.
     assert summary["per_channel"]["en"]["enabled_slugs"] == ["flag"]
 
@@ -206,3 +208,19 @@ def test_over_quota_is_per_channel(tmp_path):
     msg = format_quota_warning(summary)
     assert "channel 'en'" in msg
     assert "channel 'ru'" not in msg
+
+
+def test_dub_languages_channel_is_visible(tmp_path):
+    # Aug 2026: youtube.dub_languages was never read, so the whole FR
+    # channel was invisible to estimate_network_daily_units and the
+    # daily preflight.
+    shows = tmp_path / "shows"
+    shows.mkdir()
+    (shows / "flag.yaml").write_text(
+        "name: F\nslug: flag\nyoutube:\n  enabled: true\n  channel: en\n"
+        "  dub_languages: [fr]\n",
+        encoding="utf-8",
+    )
+    summary = estimate_network_daily_units(shows)
+    assert "fr" in summary["per_channel"]
+    assert "flag (fr dub)" in summary["per_channel"]["fr"]["enabled_slugs"]


### PR DESCRIPTION
Round 2 of the video/YouTube pipeline work: the remaining proposed items from `docs/reviews/video_pipeline_review_2026_08_12.md`, driven by fresh performance data. All render/metadata/orchestration-side — no audio changes (outside the landmine #17 gate).

## Video quality (the headline)

- **ffmpeg input dedup**: a cycled slideshow plan opened the same 4-8 image files once per slot — 24+ demuxers/decoders of identical pixels, the actual mechanism behind the Ep537 74-input timeout. Both command builders now emit one `-i` per unique image with `split` fan-out. Verified with real ffmpeg renders on the two-stage and fused paths.
- **Slot cap 24 → 36** (unlocked by the dedup): a 17-minute episode now changes scene every ~29 s where the old cap's merges shipped **85+ second static holds** — the worst remaining visual defect. `gallery_blend_max_long` 16 → 24 so the pool covers the deeper plan (~1.3× image reuse instead of 2×+).
- **Duration-adaptive Ken Burns**: fixed amplitude meant a 29 s hold crawled at ~0.3%/s — sub-perceptual, functionally frozen. Zoom range now scales at 0.006/s of hold (clamped [0.04, 0.24]); the 1.06/1.09/1.12 ladder survives as a ±1/3 rhythm multiplier; 15 s holds reproduce the historical middle rung exactly and the A/B control arm stays byte-pinned.

## Dub channel parity (@NerraRU / @NerraFR — the network's hottest surfaces)

- Tags route through the guarded builder with YouTube's **real** quoted-tag accounting (space-y tags store quoted +2; modern_investing's dub set was 40 chars from a 400 on every upload) instead of raw English keywords with no cap.
- Dub long-forms upload a **caption track** from the Whisper transcript that already exists in-process (was discarded after the Shorts burn-in): CC button, auto-translate into 100+ locales, caption search indexing — one `captions.insert` each.
- Dub Shorts get real thumbnails (scene images, cycled like EN) instead of YouTube's auto-picked mid-crossfade blur, and no longer pollute the podcast playlists YouTube Music ingests.

## Feedback loop + reliability

- Analytics fetch gains **audience-retention curves** for each channel's top 5 recent long-forms (*where* viewers leave — the measurement the scene scheduler and hook-first directive have been missing), the **traffic-source split** (search vs Shorts-feed vs browse), and the **literal search terms** reaching each channel.
- Shorts-per-episode count gains asymmetric hysteresis (raise needs 2 consecutive runs; cut is immediate) — band-edge oscillation around the 20 vpd threshold was toggling 2↔3 nightly.
- Quota estimator finally sees the **FR channel** (`dub_languages` was never read) and reads the real policy-driven dub Shorts count instead of a hardcoded 1.
- Upload retry now survives transport errors (`ConnectionResetError`/`SSLEOFError`/`IncompleteRead`/…) — the HttpError-only predicate meant one TCP reset cost the day's long-form.

## Performance review (last few days) + decisions surfaced

- RU Shorts median retention **43 → 54%** WoW; FR Shorts **46 → 71%** (small n, channel waking up: 469 → 1,224 views); EN Shorts flat ~44-46%.
- **The Shorts motion A/B is stalled**: `shorts_ab_enabled: false` (arrived via merged spacex review PR #973) froze the treatment arm at n=4/14 — it can never read out. New `decide` entry in `docs/experiments.yaml`: re-enable enrollment or formally end it (ending un-holds the four render items gated on its verdict).
- New register entry `scene-cadence-36-slots` (readout 08-28, reads jointly with `youtube-chapters-live`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_