### PR TITLE
End the Shorts motion A/B; ship the un-held render upgrades (transition split, punch-ins, closing beat)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,10 +797,16 @@ the starting hook sequence"). Render/metadata-only — outside landmine
   `\t` pop; 8-move episode-seeded Ken Burns at 1.06/1.09/1.12
   (CRC32-of-stem seed; `kb_extended=False` keeps byte-identical legacy
   for A/B-enrolled shows); accelerating open (<60s slots cap holds at
-  8s); supersampled v2/v3 pills. Deliberately HELD for the A/B verdict:
-  Shorts transition split, progress bar, punch-ins, long-form ending
-  beat (in `docs/…/video_render_plan` items A2/A3/E1/D2 — re-propose
-  after `api/shorts_ab.json` reads out).
+  8s); supersampled v2/v3 pills. The four items HELD for the motion-A/B
+  verdict all shipped once the A/B was formally ENDED as unreadable
+  (operator, 2026-08-14 — enrollment froze at n=4 via the merged spacex
+  review PR #973; see `docs/experiments.yaml` `shorts-motion-ab-stalled`):
+  progress bar (A3, earlier), Shorts transition split (A2 — vertical
+  slideshows join on `_SHORTS_XFADE_S` 0.25 s vs long-form 0.6 s),
+  punch-in easing (E1 — alternate Shorts segments front-load their Ken
+  Burns travel, `ease="out"`), long-form closing beat (D2 — the final
+  scene settles on a gentle centred push-in before the outro card).
+  Drift guards: `tests/test_video_commands.py::TestUnheldRenderUpgrades`.
 - **Learning loop:** title hints mined per-kind (Shorts retention no
   longer steers long-form titles) with fragment/dateline exemplars
   banned; gallery-retention flywheel CLOSED (bounded ±10 ranking prior

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -238,25 +238,25 @@ experiments:
       landmine #17.
 
   - id: shorts-motion-ab-stalled
-    title: "Shorts motion A/B — enrollment stalled, decide: re-enable or end"
+    title: "Shorts motion A/B — ENDED (operator, 2026-08-14): unreadable"
     area: retention
     shipped: 2026-07-30
-    readout: 2026-08-21
-    status: decide
+    readout: 2026-08-14
+    status: done
     criteria: >
-      The treatment arm has been frozen at n=4 since ~Aug 9:
-      shows/spacex.yaml carries shorts_ab_enabled: false (arrived via
-      the merged spacex review PR #973), so no new grok_video Shorts
-      enroll and the 14-per-arm bar can never be reached. Operator
-      decision: (a) re-enable enrollment on spacex (one YAML flag) and
-      let it run ~2 more weeks, or (b) formally end the experiment as
-      unreadable — which also un-holds the four render items gated on
-      its verdict (Shorts transition split, progress bar, punch-ins,
-      long-form ending beat) for fresh evaluation on their own merits.
+      RESOLVED 2026-08-14 — operator chose (b): formally ended as
+      unreadable. The treatment arm froze at n=4 when
+      shorts_ab_enabled: false landed via the merged spacex review PR
+      #973; final data (4 vs 12) is not significant and stills remain
+      the network default (no Grok Video spend on Shorts). The four
+      render items the verdict was holding are now shipped on their own
+      merits: progress bar (A3, shipped earlier), Shorts transition
+      split (A2), punch-in easing (E1), long-form closing beat (D2) —
+      all in the scene-cadence-36-slots reading window.
     notes: >
-      Interim data (n=4 vs 12, NOT significant): treatment mean AVP
-      reads higher but is dominated by one outlier; views are flat.
-      ~$1.05/enrolled episode while enrollment is on.
+      The A/B machinery (engine/shorts_ab.py, the nightly report) stays
+      dormant and re-usable; kb_extended=False keeps reproducing the
+      legacy control render if a future experiment wants it.
 
   - id: scene-cadence-36-slots
     title: "Long-form scene cadence — input dedup + 36-slot cap + adaptive Ken Burns"

--- a/engine/video.py
+++ b/engine/video.py
@@ -504,6 +504,13 @@ _MAX_SCENE_HOLD_S = 15.0
 # path falls back to hard-cut concat if the xfade chain ever fails, so this
 # can never make a render fail outright.
 _SLIDESHOW_XFADE_S = 0.6
+# A2 (Aug 2026, un-held when the motion A/B was formally ended): the
+# transition treatment SPLITS by format. A 0.6 s dissolve reads cinematic
+# on a 12-29 s long-form hold but eats 10-15% of a 4-8 s Shorts segment
+# and reads slow against short-form editing grammar — Shorts join on a
+# fast 0.25 s crossfade instead (still softer than a hard cut, so the
+# slideshow never looks broken).
+_SHORTS_XFADE_S = 0.25
 # dissolve/fadeblack were removed from the rotation (Aug 2026): ffmpeg's
 # dissolve is a random per-pixel threshold — on photographic stills it
 # reads as a burst of noise, and it is the worst possible input for the
@@ -657,16 +664,26 @@ def _kb_seed_from_stem(stem) -> int:
 
 
 def _ken_burns(frames: int, move: str, *,
-               zoom_max: float = _ZOOM_MAX) -> Tuple[str, str, str]:
+               zoom_max: float = _ZOOM_MAX,
+               ease: str = "linear") -> Tuple[str, str, str]:
     """Return ``(z, x, y)`` zoompan expressions for one scene.
 
     *frames* is the scene's own output frame count, which is what makes
     the motion duration-independent: a 4 s scene and a 15 s scene both
     travel the full zoom range over their own length.
+
+    ``ease="out"`` (Aug 2026 — E1 punch-ins, un-held when the motion
+    A/B was formally ended) front-loads the travel: progress runs
+    ``p*(2-p)`` instead of linear, so ~75% of the move lands in the
+    first half of the segment and then settles — the short-form
+    "punch-in" cut. Same total travel, same clamps; only the velocity
+    profile changes, so the feasibility math below is untouched.
     """
     n = max(2, int(frames))
     # Normalised progress 0..1 across this scene, in OUTPUT frames.
     p = f"(min(on/{n - 1},1))"
+    if ease == "out":
+        p = f"({p}*(2-{p}))"
     amp = round(zoom_max - 1.0, 6)
 
     if move.startswith("out"):
@@ -718,7 +735,9 @@ def _ken_burns_chain(src: str, out_label: str, *, frames: int, index: int,
                      prescale: float = _PRESCALE,
                      trim_seconds: Optional[float] = None,
                      kb_seed: int = 0,
-                     kb_extended: bool = True) -> str:
+                     kb_extended: bool = True,
+                     ease: str = "linear",
+                     closing_beat: bool = False) -> str:
     """The full scale -> crop -> zoompan chain for one still.
 
     ``kb_extended=True`` (July 31 2026, A1) uses the widened 8-move
@@ -756,7 +775,15 @@ def _ken_burns_chain(src: str, out_label: str, *, frames: int, index: int,
         # Legacy mode stays byte-pinned (Shorts motion A/B control arm).
         move = _KB_MOVES[index % _KB_LEGACY_MOVE_COUNT]
         zoom_max = _ZOOM_MAX
-    z, x, y = _ken_burns(frames, move, zoom_max=zoom_max)
+    if closing_beat and kb_extended:
+        # D2 (long-form ending beat): the FINAL scene always settles on
+        # a slow centred push-in at a gentle amplitude — the episode
+        # visually comes to rest before the outro card fades in, instead
+        # of ending mid-pan on whatever the rotation happened to deal.
+        move = "in_centre"
+        zoom_max = min(zoom_max, 1.06)
+    z, x, y = _ken_burns(frames, move, zoom_max=zoom_max,
+                         ease=ease if kb_extended else "linear")
     chain = (
         f"{src}"
         f"scale={pre_w}:{pre_h}:force_original_aspect_ratio=increase"
@@ -857,6 +884,7 @@ def _slideshow_filter_graph(scene_count: int, *,
         def _src(i: int) -> str:
             return f"[{i}:v]"
 
+    is_vertical = height > width
     for i in range(scene_count):
         clip_len = durs[i] + xfade_pad
         frames_per_scene = max(2, round(clip_len * fps))
@@ -866,6 +894,14 @@ def _slideshow_filter_graph(scene_count: int, *,
             width=width, height=height, fps=fps,
             trim_seconds=clip_len,
             kb_seed=kb_seed, kb_extended=kb_extended,
+            # E1: alternate Shorts segments punch in (ease-out travel —
+            # ~75% of the move in the first half, then settle); long-form
+            # keeps the linear drift.
+            ease=("out" if is_vertical and i % 2 == 1 else "linear"),
+            # D2: the final LONG-FORM scene settles on a gentle centred
+            # push-in before the outro card fades in.
+            closing_beat=(not is_vertical and i == scene_count - 1
+                          and scene_count >= 2),
         ))
 
     if not use_xfade:
@@ -978,7 +1014,8 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                       width: int = 1920, height: int = 1080,
                       fps: int = 30,
                       kb_seed: int = 0,
-                      kb_extended: bool = True) -> Path:
+                      kb_extended: bool = True,
+                      crossfade: float = _SLIDESHOW_XFADE_S) -> Path:
     """Render the stage-1 slideshow MP4. Idempotent (skips if output exists).
 
     Tries the crossfade graph first; if ffmpeg rejects it for any reason,
@@ -1005,6 +1042,7 @@ def _render_slideshow(scene_paths: Sequence[Path], output: Path,
                              scene_duration=scene_duration,
                              scene_durations=scene_durations,
                              width=width, height=height, fps=fps,
+                             crossfade=crossfade,
                              kb_seed=kb_seed, kb_extended=kb_extended)
         _run_ffmpeg(cmd, label="slideshow render (crossfade)")
     except (subprocess.CalledProcessError, RuntimeError) as exc:
@@ -3103,6 +3141,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
                         scene_durations=seg_durations,
                         width=1080, height=1920, fps=fps,
                         kb_seed=kb_seed, kb_extended=kb_extended,
+                        crossfade=_SHORTS_XFADE_S,
                     )
                     bg_path = slideshow_path
                     bg_is_video = True
@@ -3121,6 +3160,7 @@ def build_short_video(audio_path: Path, cover_path: Path,
                     scene_duration=_SHORT_SCENE_DURATION_SECONDS,
                     width=1080, height=1920, fps=fps,
                     kb_seed=kb_seed, kb_extended=kb_extended,
+                    crossfade=_SHORTS_XFADE_S,
                 )
                 bg_path = slideshow_path
                 bg_is_video = True

--- a/tests/test_video_commands.py
+++ b/tests/test_video_commands.py
@@ -2652,3 +2652,54 @@ class TestPillV2:
         # Stale v1 names must not be written.
         assert not (tmp_path / "_show_pill_tesla_shorts_time.png").exists()
         assert not (tmp_path / "_url_pill_v1.png").exists()
+
+
+class TestUnheldRenderUpgrades:
+    """A2/E1/D2 — un-held when the Shorts motion A/B was formally ended
+    (Aug 14 2026, operator-directed; treatment arm froze at n=4)."""
+
+    def test_shorts_transition_split(self):
+        # A2: vertical slideshows join on the fast 0.25 s crossfade;
+        # long-form keeps the cinematic 0.6 s.
+        from engine.video import _SHORTS_XFADE_S, _SLIDESHOW_XFADE_S
+        assert _SHORTS_XFADE_S == 0.25
+        assert _SLIDESHOW_XFADE_S == 0.6
+        import engine.video as _video
+        vsrc = Path(_video.__file__.replace(".pyc", ".py")).read_text(
+            encoding="utf-8")
+        # Both Shorts stage-1 render sites pass the split constant.
+        assert vsrc.count("crossfade=_SHORTS_XFADE_S") == 2
+
+    def test_punch_in_easing_on_alternate_vertical_segments(self):
+        # E1: odd vertical segments front-load their travel (p*(2-p));
+        # even segments and all long-form segments stay linear.
+        graph_v = _slideshow_filter_graph(
+            scene_count=3, width=1080, height=1920,
+            scene_durations=[5.0, 5.0, 5.0])
+        assert "*(2-" in graph_v
+        chains = graph_v.split(";")
+        eased = [c for c in chains if "*(2-" in c and "zoompan" in c]
+        assert len(eased) == 1  # exactly the middle (index 1) segment
+        graph_h = _slideshow_filter_graph(
+            scene_count=3, scene_durations=[12.0, 12.0, 12.0])
+        assert "*(2-" not in graph_h
+
+    def test_long_form_closing_beat(self):
+        # D2: the final long-form scene settles on a gentle centred
+        # push-in (zoom-in, no pan) before the outro card fades in.
+        import re as _re
+        graph = _slideshow_filter_graph(
+            scene_count=3, scene_durations=[12.0, 12.0, 12.0])
+        last = [c for c in graph.split(";") if "[s2]" in c][0]
+        # Zoom-in form, amplitude capped at the gentle 0.06...
+        m = _re.search(r"zoompan=z='\(1\+([0-9.]+)\*", last)
+        assert m, last
+        assert float(m.group(1)) <= 0.06 + 1e-9
+        # ...and centred (no pan ramp in x/y).
+        assert "0.5" in last and "ramp" not in last
+        # Shorts do NOT get the closing beat (the end card owns their
+        # ending) — pinned at the wiring: the flag is long-form only.
+        import engine.video as _video
+        vsrc = Path(_video.__file__.replace(".pyc", ".py")).read_text(
+            encoding="utf-8")
+        assert "closing_beat=(not is_vertical" in vsrc


### PR DESCRIPTION
Operator-directed follow-up to #1000: the Shorts motion A/B is **formally ended as unreadable** (enrollment froze at n=4 of 14 when `shorts_ab_enabled: false` landed via the merged spacex review PR #973; 4-vs-12 is not significant). Stills remain the network default — no Grok Video spend on Shorts. The register entry is resolved and the A/B machinery stays dormant/reusable.

Ending it un-holds the four render items gated on its verdict. The progress bar (A3) shipped earlier; the remaining three ship here, each verified with a real ffmpeg render:

- **A2 — Shorts transition split**: the transition treatment now splits by format. Vertical slideshows join on a fast **0.25 s crossfade** (`_SHORTS_XFADE_S`) — a 0.6 s dissolve eats 10–15% of a 4–8 s Shorts segment and reads slow against short-form editing grammar — while long-form keeps the cinematic 0.6 s.
- **E1 — punch-in easing**: alternate Shorts segments front-load their Ken Burns travel (progress runs `p*(2-p)` — ~75% of the move lands in the first half, then settles): the short-form punch-in cut. Same total travel and feasibility clamps; long-form stays linear.
- **D2 — long-form closing beat**: the final scene always settles on a gentle centred push-in (amplitude capped at 1.06, no pan), so every episode visually comes to rest before the outro card's fade-in instead of ending mid-pan on whatever the move rotation dealt.

Bookkeeping: `docs/experiments.yaml` verdict recorded on `shorts-motion-ab-stalled` (status `done`); CLAUDE.md's held-items note replaced with the shipped state. Drift guards: `tests/test_video_commands.py::TestUnheldRenderUpgrades`.

All render/metadata-side — outside the landmine #17 A/B gate. These land inside the `scene-cadence-36-slots` reading window (readout 08-28), so long-form AVP reads as the joint effect of the cadence + motion batch.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_