### PR TITLE
Offshore North: web_search_always — fire the load-bearing queries every episode

### DIFF
--- a/engine/config.py
+++ b/engine/config.py
@@ -975,6 +975,13 @@ class ShowConfig:
     # history") — see engine.utils.drop_excluded_titles.
     exclude_title_patterns: List[str] = field(default_factory=list)
     web_search_queries: List[str] = field(default_factory=list)
+    # Run web_search_queries on EVERY episode, not only when the on-topic
+    # article count falls below min_articles. For shows whose key sources
+    # publish no RSS (offshore_north: imoca.org, theoceanrace.com), web
+    # search is load-bearing — a healthy RSS count from aggregators must
+    # not silence the only route to the primary sources. Default False:
+    # every other show keeps the count-gated behavior.
+    web_search_always: bool = False
     min_articles: int = 3  # Minimum articles before expanding search
     min_articles_skip: int = 3  # Hard cutoff — skip episode if fewer articles
     # Progressive fetch-window ladder, in hours, widest last. Empty = use
@@ -1197,6 +1204,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         keywords=data.get("keywords", []),
         exclude_title_patterns=data.get("exclude_title_patterns", []),
         web_search_queries=data.get("web_search_queries", []),
+        web_search_always=bool(data.get("web_search_always", False)),
         min_articles=data.get("min_articles", 3),
         min_articles_skip=data.get("min_articles_skip", 3),
         fetch_expansion_hours=[

--- a/run_show.py
+++ b/run_show.py
@@ -1008,15 +1008,27 @@ def run(args: argparse.Namespace) -> None:
                 "Relevance check: %d of %d articles match this show's keywords",
                 _relevant, len(articles),
             )
+        # web_search_always (offshore_north, Aug 2026): a healthy on-topic
+        # COUNT from aggregators is not the same as usable material. The
+        # 2026-08-14 rerun had 16 on-topic articles (mostly Google News
+        # Vendée aggregation), the gate stayed shut, and the digest came
+        # out at 493 words — the show's only route to imoca.org and
+        # theoceanrace.com never ran. Shows that declare web search
+        # load-bearing fire it every episode.
+        _search_wanted = (
+            min(len(articles), _relevant) < min_quality
+            or getattr(config, "web_search_always", False)
+        )
         if (
             not _topic_driven
-            and min(len(articles), _relevant) < min_quality
+            and _search_wanted
             and getattr(config, "web_search_queries", None)
         ):
             logger.info(
-                "Articles (%d total, %d on-topic) below quality threshold (%d) "
-                "— trying web search ...",
+                "Web search firing (%d articles, %d on-topic, threshold %d, "
+                "always=%s) ...",
                 len(articles), _relevant, min_quality,
+                getattr(config, "web_search_always", False),
             )
             try:
                 from engine.fetcher import fetch_web_search_articles

--- a/shows/offshore_north.yaml
+++ b/shows/offshore_north.yaml
@@ -123,7 +123,13 @@ sources:
 
 # Web search is load-bearing on this show, not a supplement: the two most
 # important non-campaign sources (imoca.org, theoceanrace.com) are only
-# reachable this way.
+# reachable this way — so it runs on EVERY episode, not only when the
+# article count is low. Added 2026-08-14 after the Ep2 redo starved: 16
+# on-topic articles (mostly Google News Vendée aggregation) kept the
+# count gate shut, the load-bearing queries never ran, and the digest
+# came out at 493 words -> 904-word script -> skip. Count was never the
+# right proxy for material quality on a weekly show. Cost: 8 queries/wk.
+web_search_always: true
 # ---- X / Twitter as a CONTENT source (not posting) ----
 # Offshore racing breaks on X and Instagram before it reaches any RSS feed:
 # campaigns post launches, damage and routing calls in real time, and the

--- a/tests/test_offshore_north_weekly_fixes.py
+++ b/tests/test_offshore_north_weekly_fixes.py
@@ -530,3 +530,41 @@ class TestYouTubeSourceFeed:
         assert "every two weeks" in src, (
             "the prompt must not expect a weekly video from a biweekly channel"
         )
+
+
+class TestWebSearchAlways:
+    """2026-08-14 Ep2 redo: 16 on-topic articles (mostly Google News
+    Vendée aggregation) kept the count gate shut, so the eight
+    load-bearing queries — the only route to imoca.org and
+    theoceanrace.com — never ran. Digest 493 words, script 904, skip.
+    The show's YAML has declared web search load-bearing since launch;
+    the gate now honors that with a per-show always-on flag."""
+
+    def test_yaml_flag_survives_into_dataclass(self):
+        """Silent config-drop class (landmine: _build_nested)."""
+        raw = yaml.safe_load(_SHOW_YAML.read_text(encoding="utf-8"))
+        assert raw.get("web_search_always") is True
+        assert _cfg().web_search_always is True
+
+    def test_dataclass_defaults_false(self):
+        from engine.config import ShowConfig
+        assert ShowConfig().web_search_always is False
+
+    def test_every_other_show_keeps_the_count_gate(self):
+        offenders = []
+        for path in sorted((_ROOT / "shows").glob("*.yaml")):
+            if path.stem.startswith("_") or path.stem == "offshore_north":
+                continue
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            if not isinstance(data, dict) or "slug" not in data:
+                continue
+            if data.get("web_search_always"):
+                offenders.append(path.stem)
+        assert not offenders, (
+            f"these shows gained always-on web search — intentional? {offenders}"
+        )
+
+    def test_gate_honors_the_flag(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'getattr(config, "web_search_always", False)' in src
+        assert "_search_wanted" in src


### PR DESCRIPTION
## Why the Ep2 redo skipped

Your 20:16 UTC dispatch ran cleanly and **skipped the episode on purpose**: the script came out at 904 words against the 950 hard floor ($0.056 spent, no audio, skip marker written). Tracing upstream:

- The digest starved at **493 words** (expansion retry → 868, still far under the 1300 target)
- It starved because **web search never fired**: 16 on-topic articles (11 of them Google News Vendée aggregation) satisfied the `min_articles=6` count gate, so the eight queries — the **only route to imoca.org and theoceanrace.com**, which publish no RSS — stayed silent
- The v2 prompt then did exactly what it should: the 7-day window, single-source rule, and scope exclusions correctly compressed the aggregator pile instead of padding it

Count was never the right proxy for usable material on a weekly show. The gates worked; the inputs failed.

## The fix

New per-show flag **`web_search_always`** (dataclass default `False`, factory-read, round-trip guarded against the silent-config-drop class): when true, the web-search stage fires on every episode instead of only below the count threshold. Set for `offshore_north` only — matching its YAML's since-launch declaration that web search is "load-bearing on this show, not a supplement." A no-offenders test pins every other show to the count-gated behavior.

Cost: 8 queries/week on a weekly show (~$0.20/wk at the per-source rate).

Note: I cancelled a duplicate rerun I had dispatched at 21:18 (we'd crossed wires — you had already dispatched at 20:16). It was 4 minutes in, nothing uploaded; it would have skipped identically anyway.

## Testing

Full suite: **6,794 passed, 6 skipped**. New guards: `tests/test_offshore_north_weekly_fixes.py::TestWebSearchAlways`.

**On merge I'll re-dispatch the Ep2 redo automatically** — with the primary-source queries feeding the digest, the brief should clear the floor it starved under.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKDLL1fvxxFMpZiXVyKe9d)_