### PR TITLE
MIT: fix three silently-broken data loops + script-stage grok-4.6 A/B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,34 @@ today's work, not just explain yesterday's):
   is dormant behind a kill switch. Two operator to-dos remain open:
   `scripts/recompute_mit_benchmarks.py --apply` (needs market-data
   access) and SnapTrade Phase-0 verification.
+- **MIT speaks the VERIFIED-window alpha, never the blended one**
+  (Aug 15 2026 review:
+  [`docs/reviews/modern_investing_review_2026_08_15.md`](docs/reviews/modern_investing_review_2026_08_15.md)).
+  `matched_window_alpha_pct` compounds every trade with a
+  `nasdaq_return_pct` — including the 35 whose windows the July-3
+  integrity pass itself disowned, because the recompute above has never
+  run. That blend put **+9.28% across 45 trades** on air while the 10
+  pick-date-aligned trades were at **−1.95%**.
+  `verified_window_alpha_pct` / `verified_window_trades` (trades carrying
+  `entry_bar_date`) are the on-air numbers; the blended pair stays for
+  the performance page and the recompute script. Running
+  `recompute_mit_benchmarks.py --apply` collapses the split — do not
+  "simplify" the two back into one before then. Same pass fixed three
+  more silent-number failures: the digest FORMATTING template never
+  listed `### Portfolio Performance` (missing from 13 of 20 episodes, and
+  the script then told listeners the feed was down), `_build_trade_review`
+  only examined `closed[-1]` so 43 of 50 closed trades were never
+  narrated once the pick cadence went daily (now drains oldest-first,
+  bounded by `REVIEW_BACKLOG_MAX_DAYS`), and the source-collapse alarm's
+  10-episode rolling baseline decayed with the collapse it was watching
+  (article median 274 → ~57 for three weeks; now a second long baseline
+  catches a slide, and three hard-403 feeds were replaced). Drift guards:
+  `tests/test_mit_benchmark_integrity.py`.
+- **The lesson from that pass, network-wide:** loops that operate on TEXT
+  fail loudly (a tic shows up in a snapshot); loops that operate on
+  NUMBERS fail silently, because a wrong number looks exactly like a
+  right one. Any watchdog whose baseline is a rolling window of the thing
+  it watches can only catch a cliff, never a slide.
 
 - **FF and PT** are "nearly identical twins" — same structure, same functions,
   different news topics and X account

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -276,3 +276,55 @@ experiments:
       Enabled by ffmpeg input dedup (one -i per unique image + split),
       which removed the per-slot demuxer cost behind the old 24-slot
       cap. Render-only — outside landmine #17.
+
+  - id: mit-script-model-46
+    title: "Modern Investing script stage on grok-4.6 (podcast_model A/B)"
+    area: quality
+    shipped: 2026-08-15
+    readout: 2026-08-29
+    status: reading
+    baseline: "median script 1535w against an 1800w floor; 9 of the last 10 episodes below it"
+    target: >
+      Median script length reaches the 1800w floor (or at least clears
+      1700w) with NO facts, tickers, prices or performance figures beyond
+      what the digest carries. Length has been attacked at the digest
+      substrate since July 24 and moved only 1382w -> 1535w, which points
+      at the script stage as the remaining ceiling.
+    criteria: >
+      Operator A/B-listens the first post-merge episodes and checks the
+      spoken numbers against the digest. Keep grok-4.6 only if length
+      improves AND factuality is unchanged; revert is deleting the one
+      podcast_model line in shows/modern_investing.yaml. If ANY invented
+      number reaches a script, revert immediately — this is the show
+      where that costs the most.
+    notes: >
+      grok-4.6 (2026-08-12) is a post-training upgrade over 4.5, so the
+      confident-hallucination regression that keeps digests on 4.3 (25%
+      -> 54% on 4.5) is unmeasured for it, not disproven. That is exactly
+      why it is pointed at the one stage that introduces no facts. Digest
+      and fetch stages stay on grok-4.3. Audio change — landmine #17 A/B.
+      An unreachable model id falls back to grok-4.3 with a loud warning,
+      so a bad id costs the experiment, never the episode.
+
+  - id: mit-verified-window-alpha
+    title: "Modern Investing states verified-window alpha only"
+    area: quality
+    shipped: 2026-08-15
+    readout: 2026-08-29
+    status: decide
+    baseline: "+9.28% across 45 trades spoken on air; the 10 honestly-measured trades were at -1.95%"
+    target: >
+      Every alpha figure spoken on air comes from the 10 (and growing)
+      trades with pick-date-aligned benchmark windows, with the trade
+      count in the same sentence. No blended lifetime alpha reaches air.
+    criteria: >
+      OPERATOR DECISION at readout: run
+      `scripts/recompute_mit_benchmarks.py --apply` (needs market-data
+      access) to rebuild the 35 legacy windows. That collapses the split
+      — every trade gains entry_bar_date and the verified figure simply
+      becomes the whole record. Until it runs, the show's headline is
+      honest but built on n=10.
+    notes: >
+      The recompute has been an open operator item in the MIT ledger
+      since 2026-07-03. This change stops the unrun backfill from
+      silently flattering the on-air number in the meantime.

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -421,34 +421,173 @@ reviews:
         baseline: "Ep111 CNR.TO lost; Ep113 BTC-USD truncated to BTC"
         expected: "0 lost or mangled suffixed picks; every crypto pick
           resolves to the -USD pair"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-08-15: Ep133 IPCO.TO and Ep135 X.TO both recorded
+          with the suffix intact and resolved_symbol matching; no pick lost
+          to no_pick_extracted in the window. No crypto pick occurred, so
+          the -USD half is untested — carried into the next entry."
       - metric: non-voided trades with stop/reference ratio outside
           [1/3, 3]
         baseline: "1 (Ep113 BTC, open, stop 2240x reference)"
         expected: "0 — the tripwire voids at record time and the
           migration self-heals any that slip through"
-        verdict: pending
-        evidence: null
+        verdict: hit
+        evidence: "2026-08-15: 0 across all 50 non-voided trades; the Ep113
+          BTC pick remains voided with instrument_scale_mismatch."
       - metric: alpha mentions carrying the significance qualifier
           (while t<2)
         baseline: "1/6 (17%) with the em-dash instruction form"
         expected: ">=70% with the data-shaped parenthetical; a third
           miss escalates to an operator accept-or-abandon decision
           instead of a fourth mechanism"
-        verdict: pending
-        evidence: null
+        verdict: miss
+        evidence: "2026-08-15: 0 of 22 alpha mentions across Ep126-137
+          carried any significance hedge. THIRD miss on this metric; per
+          the playbook no fourth mechanism was written. Escalated to the
+          operator as accept-or-abandon (see the 2026-08-15 review).
+          Confound worth noting before abandoning: the alpha figure being
+          quoted was the blended 45-trade number, which the 08-15 pass
+          replaced with a verified-window figure that carries its own
+          sample size inside the sentence — re-score once that has run."
       - metric: median script words, last-10 snapshot
         baseline: "~1382w (all 10 below the 1800 floor)"
         expected: ">=1550w within 10 episodes of the digest retry
           shipping (digest-substrate lever, min_digest_words 1500)"
-        verdict: pending
-        evidence: null
+        verdict: partial
+        evidence: "2026-08-15: median 1535w over Ep128-137 (1382 -> 1535,
+          +11%) but short of the 1550 target and 9 of 10 still below the
+          1800 floor. The digest substrate moved and then plateaued, which
+          points at the script stage — hence the grok-4.6 script-model A/B
+          (experiment mit-script-model-46)."
       - metric: episodes with >2 x.com Source citations on a
           normal-fetch day (article_count > 100)
         baseline: "Ep115: 6/6 x.com (collapsed-fetch day)"
         expected: "0; collapsed-fetch days additionally emit
           article_count_degraded"
+        verdict: miss
+        evidence: "2026-08-15: 6 of the last 12 episodes exceed 2 x.com
+          citations (Ep128 6/7, Ep131 5/8, Ep134 5/8, Ep136 5/8). The
+          prediction's own >100-article precondition turned out to be
+          unmeetable: MIT's fetch had collapsed from a median of 274
+          (ep90-119) to 50-64 (ep120-137) because three RSS sources began
+          returning 403, and the degradation alarm went silent as its
+          rolling baseline decayed with the problem. Root cause fixed
+          2026-08-15 (dead feeds replaced + long-baseline decay alarm);
+          re-score against restored volume."
+    agent_cost_usd: null
+
+  - date: 2026-08-15
+    pr: null
+    doc: docs/reviews/modern_investing_review_2026_08_15.md
+    reviewer: claude-code (operator-directed pipeline/data/learning-loop pass)
+    summary: >
+      Operator asked for a deep pass on the pipeline's data, analytics,
+      recursive learning and goal adjustment. The mechanisms built by the
+      July 3-24 passes all still work; what had failed was three loops
+      whose correctness depended on data that moved underneath them, none
+      of them visible from the dashboard or metrics. P0: the on-air
+      headline alpha (+9.28% across 45 trades, spoken Ep137) was carried
+      by the 35 trades whose benchmark windows the July-3 pass itself
+      disowned — the 10 trades with pick-date-aligned windows were at
+      -1.95% — because the operator recompute has never run. P0: the
+      Portfolio Performance section was ABSENT from 13 of the last 20
+      digests and the podcast stage filled the gap by telling listeners
+      the performance feed was down (Ep134/135 verbatim); root cause was
+      that the digest prompt's FORMATTING template, the part the model
+      actually follows, never listed the section. P0: the July review-once
+      guard only ever examined closed[-1], so once the pick cadence became
+      roughly daily every close but the newest was skipped permanently —
+      43 of 50 closed trades never narrated, five within the preceding ten
+      days including MU's +5.12%, while their P&L still counted in the
+      totals the segment reported. P1: "Weekly Hold" holds ran 0-6 days
+      (median 3) against a five-day thesis, structurally, because exits
+      are pinned to the Friday pre-market run which prices Thursday's bar.
+      P1: article fetch had fallen 274 -> ~57 median for three weeks after
+      CNBC x2 and Benzinga began returning 403, and the July-24 collapse
+      alarm went quiet because its 10-episode rolling baseline decayed
+      with the problem.
+    shipped:
+      - verified-window alpha (verified_window_alpha_pct / _trades /
+        unverified_window_trades / verified t-stat) computed over
+        entry_bar_date trades only; on-air headline switched to it with
+        the trade count fused into the sentence and an explicit NOT-for-air
+        line on the blended figure (A/B-listen)
+      - "### Portfolio Performance added to the digest FORMATTING template
+        (the actual root cause), plus an explicit ban in both digest and
+        podcast prompts on narrating the performance data as unavailable
+        or pending (A/B-listen)"
+      - trade review drains the backlog oldest-first, one per episode,
+        bounded by REVIEW_BACKLOG_MAX_DAYS=14; stale backlog retired in
+        place; newest close never retired so an outage cannot silence the
+        segment
+      - "review block states the actual hold span (\"Actual hold: N
+        calendar day(s), Monday -> Thursday\") with a ban on five-day
+        framing the dates do not support (A/B-listen)"
+      - source-decay alarm — second, longer baseline (last 10 vs the 50
+        before) catches a slide as well as a cliff; both medians recorded
+        as metrics; metrics paths sorted by episode number
+      - three dead feeds (CNBC x2, Benzinga — hard 403 to the production
+        UA) replaced with live probed feeds (Yahoo Finance, Google News
+        earnings, Google News rates)
+      - "llm.podcast_model: grok-4.6 — SCRIPT STAGE ONLY A/B (experiment
+        mit-script-model-46); digest/fetch stay on grok-4.3 because 4.6 is
+        post-trained on 4.5 and 4.5's confident-hallucination regression
+        (25% -> 54%) is unmeasured for it, not disproven"
+      - engine/generator.py falls back to config.llm.model with a loud
+        warning when a script-stage override model is unreachable, so a
+        bad id costs the experiment and never an episode
+      - grok-4.6 pricing in engine/tracking.py
+      - 16 new drift guards in tests/test_mit_benchmark_integrity.py
+    deferred:
+      - "operator: run scripts/recompute_mit_benchmarks.py --apply — open
+        since 2026-07-03 and now the highest-value action on the show; it
+        collapses the verified/legacy split and takes the honest alpha
+        sample from n=10 to n=45"
+      - "operator: accept-or-abandon on the significance qualifier (third
+        miss, no fourth mechanism written per the playbook)"
+      - "operator: weekly-hold cadence — fixed five bars from entry vs the
+        current Friday-close calendar; the shadow executor's exit calendar
+        would have to move with it"
+      - "x.com source concentration — root cause (feed rot) fixed, but
+        re-score against restored volume before adding a source-mix rule"
+      - "carried: SnapTrade Phase-0 verification; closing-price lesson
+        retirement"
+    predictions:
+      - metric: episodes whose digest contains a Portfolio Performance
+          section
+        baseline: "7 of the last 20 (13 missing)"
+        expected: ">=18 of the next 20; ZERO episodes narrating the
+          performance data as unavailable/pending/awaiting a tracker
+          update"
+        verdict: pending
+        evidence: null
+      - metric: closed trades never narrated on air (excluding the
+          retired pre-2026-08-15 backlog)
+        baseline: "43 of 50; 5 closed within the preceding 10 days"
+        expected: "0 — the backlog drains one per episode and every new
+          close is narrated exactly once"
+        verdict: pending
+        evidence: null
+      - metric: alpha figures spoken on air that come from the blended
+          45-trade window
+        baseline: "every alpha mention; Ep137 said '9.3% across 45
+          benchmarked trades'"
+        expected: "0; every spoken alpha is the verified-window figure
+          and states its trade count in the same sentence"
+        verdict: pending
+        evidence: null
+      - metric: median article_count, last-10 snapshot
+        baseline: "~57 (down from 274 over ep90-119)"
+        expected: ">=120 within 10 episodes of the feed replacement; the
+          decay alarm fires on any future slide below half the long
+          baseline"
+        verdict: pending
+        evidence: null
+      - metric: median script words, last-10 snapshot
+        baseline: "1535w (9 of 10 below the 1800 floor)"
+        expected: ">=1700w under the grok-4.6 script stage, with zero
+          numbers/tickers/prices in the script that are absent from the
+          digest — a single invented figure reverts the experiment"
         verdict: pending
         evidence: null
     agent_cost_usd: null

--- a/docs/reviews/modern_investing_review_2026_08_15.md
+++ b/docs/reviews/modern_investing_review_2026_08_15.md
@@ -1,0 +1,298 @@
+# Modern Investing Techniques — pipeline, data & learning-loop review
+
+**Date:** 2026-08-15
+**Scope:** operator-directed — "review the MIT show pipeline in detail and
+especially data, analytics, recursive learning and goal adjustment
+process and optimize; review past shows for performance."
+**Window:** Ep118–Ep137 transcripts + digests, the full 57-trade tracker,
+137 episodes of pipeline metrics, and the five predictions left pending by
+the 2026-07-24 review.
+
+---
+
+## Verdict
+
+The measurement machinery this show has accumulated is genuinely good —
+pick-date-aligned benchmark windows, a multi-index scoreboard, stop
+enforcement, rule-effectiveness stamping, a shadow execution ledger, a
+t-stat on its own alpha. Four separate passes built it between July 3 and
+July 24 and every one of those mechanisms still works.
+
+What this pass found is that **three of the loops built to keep the show
+honest had quietly stopped closing**, and in each case the failure mode
+was the same shape: a mechanism that was correct when it shipped became
+wrong as the data around it changed, and nothing was watching the seam.
+
+1. The headline alpha the show states on air every episode was carried by
+   trades whose benchmark windows the pipeline itself had already
+   disowned.
+2. The segment that reports the track record was **absent from 13 of the
+   last 20 episodes**, and on those days the script told listeners the
+   performance feed was down. It was not.
+3. 43 of 50 closed trades were never narrated at all — the review-once
+   guard had flipped from over-reviewing to under-reviewing.
+
+None of these are visible from the dashboard, the metrics, or the
+ledger. All three were only findable by reading the tracker against the
+transcripts.
+
+---
+
+## P0 — the spoken alpha was built from windows we know are wrong
+
+`_recompute_summary` computed `matched_window_alpha_pct` over every closed
+trade carrying a `nasdaq_return_pct`. That is 45 trades. But only **10**
+of them were priced by the July-3 pick-date-aligned code path; the other
+**35** carry the pre-July-3 windows that the July-3 review itself
+described as "old-window inflation" and handed to an operator script
+(`scripts/recompute_mit_benchmarks.py --apply`) that **has never been
+run** — it has been an open item in the ledger for six weeks.
+
+Split the two sets and they disagree completely:
+
+| Subset | Trades | Portfolio | NASDAQ | Alpha |
+|---|---:|---:|---:|---:|
+| Verified windows (`entry_bar_date` present) | 10 | +2.69% | +4.64% | **−1.95%** |
+| Legacy windows (pre-July-3) | 35 | +23.55% | +12.38% | +11.17% |
+| Blended — **what shipped on air** | 45 | — | — | **+9.28%** |
+
+Ep137 said it out loud: *"Matched window alpha versus the NASDAQ reaches
+nine point three percent across forty five benchmarked trades."*
+
+A number that survives only because it is averaged with numbers we know
+are wrong is not a measurement. **Fixed:** `_recompute_summary` now also
+computes a verified-only set (`verified_window_alpha_pct`,
+`verified_window_trades`, `unverified_window_trades`, and a t-stat over
+the verified subset alone), and `_build_portfolio_summary` makes that the
+headline — with the trade count fused into the same sentence, and an
+explicit "NOT for air" line on the blended figure. The show will now say
+−1.9% across 10 verified-window trades.
+
+That is a worse-sounding number and a better show. It also stops being
+n=10 the moment the operator runs the recompute: every trade gains an
+`entry_bar_date` and the verified figure simply becomes the whole record.
+**That backfill is now the single highest-value operator action on this
+show.**
+
+## P0 — the track-record segment vanished from 65% of episodes, and the script invented a reason
+
+13 of the last 20 digests (Ep118-121, 124-127, 129, 133-136) contain **no
+Portfolio Performance section at all**. On those days the podcast stage —
+which only sees the digest — filled the gap by narrating an outage:
+
+> *"Portfolio performance numbers, including win rate and year-to-date
+> alpha versus the NASDAQ, are not available in today's data feed, so we
+> will resume that tracking once the next update arrives."* (Ep134)
+
+> *"Portfolio performance data including cumulative returns, win rate,
+> and alpha versus the NASDAQ is not available in today's briefing, so we
+> will report those figures once the tracker updates."* (Ep135)
+
+The data was never unavailable. `investment_tracker.json` is a committed
+file, it was healthy on every one of those days, and `{portfolio_summary}`
+was substituted into the prompt as always. The model omitted the section,
+then explained its own omission as a data failure — on the show whose
+entire premise is a published track record.
+
+**Root cause, and it is a single line:** the digest prompt supplies the
+figures under `**PORTFOLIO PERFORMANCE (use these exact numbers):**` as
+*input context* at line 159, and instructs "state every episode" at line
+34 — but the `### FORMATTING (EXACT — USE MARKDOWN AS SHOWN)` block, which
+is the template the model actually follows, **never listed the section**.
+Every other segment in the show appears there. This one did not, so it
+shipped roughly a third of the time.
+
+**Fixed:** `### Portfolio Performance` added to the FORMATTING template
+with the figures marked REQUIRED, plus an explicit ban — in both the
+digest and podcast prompts — on ever narrating the performance data as
+unavailable, pending, or awaiting a tracker update.
+
+## P0 — 43 of 50 closed trades were never reviewed on air
+
+The July 2 review found the opposite problem: the MU flash trade narrated
+as "yesterday's trade" three times. The fix stamped `reviewed_in_episode`
+on each trade the first time it was narrated. It worked, and it introduced
+a second bug in the same function.
+
+`_build_trade_review` only ever examined `closed[-1]` — the **last trade
+appended**. When the pick cadence was roughly weekly this was fine, because
+at most one trade closed between reviews. The cadence is now roughly one
+pick per day (Aug 3, 5, 7, 8, 10, 11, 12 all produced picks), several
+close between episodes, and every close except the newest was skipped
+**permanently** — the stamp on the newest one sent the next episode down
+the "no newly closed trade" branch.
+
+Five closes in the ten days before this review were never narrated: LNTH
+(Ep126), MU (Ep130, **+5.12%, the best result in weeks**), TBBK (Ep131),
+IPCO.TO (Ep133), AAPL (Ep134). Their P&L still counted in the running
+totals the segment reported — so the show was quoting an aggregate built
+from trades the audience never heard resolve. This is also the mechanical
+explanation for the July-24 finding of "no newly closed trade" in 9 of 10
+episodes, which that review attributed to the pick drought.
+
+**Fixed:** the review now drains the backlog oldest-first, one trade per
+episode, so every result is narrated exactly once. Bounded by
+`REVIEW_BACKLOG_MAX_DAYS = 14` so the 38-trade historical backlog is
+retired in place rather than replayed as fresh news — with the newest
+close never retired, however old, so a long pipeline outage cannot
+silence the segment.
+
+## P1 — "Weekly Hold" holds averaged 2.8 sessions, not five
+
+Every pick is labelled a Weekly Hold and written against a five-day thesis
+("+3% to +6% over the five-day window" — Ep135). The verified windows say
+the holds actually ran 0–6 calendar days, median 3:
+
+```
+Ep101 COST 0d · Ep102 DAL 6d · Ep117 EPD 3d · Ep126 LNTH 3d · Ep128 AMD 1d
+Ep130 MU  6d · Ep131 TBBK 3d · Ep133 IPCO.TO 3d · Ep134 AAPL 2d · Ep135 X.TO 1d
+```
+
+This is structural, not random. Exits are pinned to the Friday pre-market
+run, which prices **Thursday's** bar, so a Wednesday pick resolves after a
+single session. The July-18 minimum-hold guard measures calendar days
+since the pick (`today - pick_date >= 2`), which a Wed→Fri pick satisfies
+while still producing a one-bar window — the Ep101 zero-bar degenerate was
+fixed, the one-bar case was not.
+
+**Fixed (narration side):** the review block now states the span that
+actually happened — *"Actual hold: 1 calendar day of market data
+(Wednesday → Thursday)"* — with an explicit instruction never to call it a
+five-day hold unless the dates say so. **Not fixed (cadence side):**
+whether a "weekly" hold should run a fixed five bars from entry instead of
+to the next Friday is an editorial decision, deferred to the operator; the
+shadow executor's exit calendar would need to move with it.
+
+## P1 — the source-collapse alarm went quiet as the collapse got worse
+
+MIT's article fetch has fallen by roughly 78% and has been there for three
+weeks:
+
+| Episodes | Median articles |
+|---|---:|
+| Ep90–99 | 274 |
+| Ep100–109 | 268 |
+| Ep110–119 | 277 |
+| Ep120–129 | **50** |
+| Ep130–137 | **64** |
+
+The alarm shipped on 2026-07-24 fired three times (Ep121, 123, 124) and
+then stopped — because it compares today against the median of the **last
+10 episodes**, and the decayed counts became the baseline. Ep132's 32
+articles and Ep133's 28 passed silently. A watchdog whose reference point
+follows the thing it is watching only catches a cliff, never a slide.
+
+The cause is feed rot. Probed live with the production User-Agent:
+
+| Feed | Result |
+|---|---|
+| CNBC Investing | **403 Forbidden** |
+| CNBC Top Stories | **403 Forbidden** |
+| Benzinga | **403 Forbidden** |
+| r/stocks | 429 (Reddit rate-limits this egress; may differ in CI) |
+| CBC Business | 200 (the earlier timeout was transient) |
+
+**Fixed:** three dead feeds removed and replaced with live ones probed
+first — Yahoo Finance (49 entries), a Google News earnings query (100), a
+Google News Fed/BoC rates query (92). The alarm gained a **second, longer
+baseline**: it now also fires when the last 10 episodes are running under
+half the median of the 50 before them, which is the shape a slide makes.
+Both medians are recorded as metrics so the decay is visible rather than
+inferred. Reddit was left alone — a 429 from this egress is not evidence
+the feed is dead in production.
+
+This is also the upstream cause of the July-24 x.com-sourcing finding:
+when RSS thins out, the X-post block is what is left. It is still
+happening — 6 of the last 12 episodes cite more than two x.com sources on
+normal-fetch days (Ep128 was 6 of 7).
+
+## Learning loops — audited, mostly healthy
+
+- **`lessons_learned.json`**: 11 distinct actives, 54 correctly marked
+  `merged_duplicate`. The July-3 dedup held; no echo regrowth. ✅
+- **`taught_lessons.json`**: 25 lessons under cooldown, working. ✅
+- **Rule-effectiveness stamping**: 11 trades stamped with
+  `rules_in_effect`. Accruing; the scoreboard needs ~8 stamped closes per
+  rule before it can adjudicate. ✅
+- **YouTube title feedback**: 150 videos analysed, hints distinguish
+  long-form (median 9% retention) from Shorts (33%), and identify which
+  titles converted subscribers. Working as designed. ✅
+- **Show memory / narrative tracker**: present and updating. ✅
+- **Benchmark windows**: broken as described above. ❌
+- **Trade review**: broken as described above. ❌
+
+The pattern worth naming: the loops that operate on *text* are healthy,
+and the loops that operate on *numbers* are the ones that drifted. Text
+loops fail loudly (a repeated phrase shows up in a snapshot); number loops
+fail silently, because a wrong number looks exactly like a right one.
+
+## Model strategy — grok-4.6
+
+Grok 4.6 shipped 2026-08-12: a post-training upgrade over 4.5, 500K
+context, an added `xhigh` reasoning level, priced at $2/$6 per 1M
+(vs grok-4.3 at $1.25/$2.50).
+
+**The digest and fetch stages stay on grok-4.3, and this is not a close
+call.** The network's documented reason for holding facts-first stages
+there is that grok-4.5 regressed confident-hallucination from 25% to 54%.
+4.6 is built on 4.5's post-training, so that risk is *unmeasured for it,
+not disproven*, and MIT is the show where a hallucinated number is most
+expensive — it names real tickers, quotes real prices, and publishes a
+track record. Switching its digest model on a capability headline would
+be the exact trade the network already decided against.
+
+**Shipped instead:** `llm.podcast_model: grok-4.6` — the script stage
+only, following the dp_pod precedent. That stage introduces no facts; it
+rewrites an already-verified digest into a script. It is also where MIT's
+last unfixed chronic problem lives: 9 of the last 10 scripts came in under
+the 1800-word floor (median 1535w), and the digest-substrate lever shipped
+on July 24 moved that only from 1382w — which points at the script stage
+as the remaining ceiling. Registered as experiment `mit-script-model-46`,
+readout 2026-08-29, revert is deleting one line.
+
+Because the model id could not be validated against the API from this
+session (no key present), `engine/generator.py` now catches a failed
+script-stage override, falls back to `config.llm.model`, and prints a
+GitHub warning. A wrong id costs the experiment, never an episode.
+
+---
+
+## Scoring the 2026-07-24 predictions
+
+| Metric | Expected | Verdict |
+|---|---|---|
+| Suffixed/crypto picks recorded correctly | 0 lost or mangled | **hit** — IPCO.TO and X.TO recorded verbatim with `.TO`; no crypto pick in window |
+| Stop/reference ratio outside [1/3, 3] | 0 | **hit** — 0 across all non-voided trades |
+| Alpha mentions carrying the significance qualifier | ≥70% | **miss (3rd)** — 0 of 22 mentions across Ep126–137 |
+| Median script words | ≥1550w | **partial** — 1382w → 1535w; 9 of 10 still below the 1800 floor |
+| Episodes with >2 x.com citations on normal-fetch days | 0 | **miss** — 6 of 12; Ep128 6/7, all on 58–81-article days |
+
+**The significance-qualifier metric has now missed three times.** Per the
+playbook's two-miss escalation rule, a fourth mechanism is not the answer
+and none was written. Three have been tried: a separate instruction
+(dropped entirely), an em-dash inline form (1/6), and a data-shaped
+parenthetical fused into the value (0/22). Each was stripped during
+paraphrase. This goes to the operator as **accept-or-abandon**: either the
+qualifier is dropped as unachievable through prompt instruction, or the
+alpha figure stops being handed to the model as a number it can rephrase.
+The verified-window change above makes the second option more attractive —
+the sample size is now part of the sentence the model is given, so if it
+survives paraphrase at n=10 the mechanism works after all and this is
+re-scorable in two weeks.
+
+---
+
+## Operator items
+
+1. **Run `scripts/recompute_mit_benchmarks.py --apply`** (needs market-data
+   access). Open since 2026-07-03. It collapses the verified/legacy split
+   and takes the honest alpha sample from n=10 to n=45. Highest value.
+2. **Decide the significance-qualifier question** (accept or abandon) —
+   three mechanisms, three misses.
+3. **A/B-listen the first post-merge episodes** — prompt and script-model
+   changes both alter shipped audio (landmine #17).
+4. **Decide the weekly-hold cadence**: fixed five bars from entry, or keep
+   the Friday-close calendar and let the narration describe the real span
+   (which is what shipped).
+5. Carried: SnapTrade Phase-0 verification; the closing-price lesson
+   retirement.

--- a/engine/generator.py
+++ b/engine/generator.py
@@ -2217,15 +2217,43 @@ def generate_podcast_script(
     # Use podcast-specific max_tokens if configured, otherwise fall back to shared max_tokens
     podcast_tokens = getattr(config.llm, "podcast_max_tokens", 0) or config.llm.max_tokens
 
-    text, meta = _call_grok(
-        prompt,
-        model=script_model,
-        system_prompt=system_prompt,
-        temperature=config.llm.podcast_temperature,
-        max_tokens=podcast_tokens,
-        cache_key=_show_cache_key(config),
-        reasoning_effort=_llm_reasoning_effort(config),
-    )
+    def _script_call(model_id: str):
+        return _call_grok(
+            prompt,
+            model=model_id,
+            system_prompt=system_prompt,
+            temperature=config.llm.podcast_temperature,
+            max_tokens=podcast_tokens,
+            cache_key=_show_cache_key(config),
+            reasoning_effort=_llm_reasoning_effort(config),
+        )
+
+    try:
+        text, meta = _script_call(script_model)
+    except Exception as exc:
+        # A per-stage override names a model this account may not be able
+        # to reach — a new release the key is not enrolled for, a
+        # retired snapshot, a typo in one show's YAML. The override is an
+        # experiment; an experiment must not be able to cost a show its
+        # episode. Fall back to the configured default and record it, so
+        # a silently-unused override shows up as a metric instead of as
+        # an A/B result that never actually ran.
+        if script_model == config.llm.model:
+            raise
+        logger.warning(
+            "Script-stage model override '%s' failed (%s: %s) — falling back "
+            "to '%s' for this episode",
+            script_model, type(exc).__name__, exc, config.llm.model,
+        )
+        print(
+            f"::warning::{getattr(config, 'slug', '?')}: script-stage model "
+            f"override '{script_model}' unavailable — episode generated on "
+            f"'{config.llm.model}'. The A/B is NOT running; fix or remove "
+            f"llm.podcast_model.",
+            flush=True,
+        )
+        script_model = config.llm.model
+        text, meta = _script_call(script_model)
 
     # Retry once with 50% more tokens if the response was truncated
     if meta.get("finish_reason") == "length":

--- a/engine/tracking.py
+++ b/engine/tracking.py
@@ -86,6 +86,19 @@ GROK_PRICING = {
         "output_per_1m": 6.00,
         "cached_input_per_1m": 0.30,
     },
+    # Grok 4.6 (August 12 2026) — post-training upgrade over 4.5, not a
+    # larger base model: 500k context, an added `xhigh` reasoning level,
+    # tuned for long-running agents and coding. Same list price as 4.5.
+    # Wired for the modern_investing SCRIPT-stage A/B only. Do NOT promote
+    # it to any digest/fetch stage without measuring hallucination rate
+    # first: the network's reason for holding digests on 4.3 is that 4.5
+    # regressed confident-hallucination 25% -> 54%, and 4.6 is built on
+    # 4.5's post-training — there is no evidence either way yet.
+    "grok-4.6": {
+        "input_per_1m": 2.00,
+        "output_per_1m": 6.00,
+        "cached_input_per_1m": 0.30,
+    },
     # Grok 4 (legacy refusal fallback — retained because older
     # credit_usage JSONs still report it, and _estimate_grok_cost may be
     # re-run against them).

--- a/run_show.py
+++ b/run_show.py
@@ -151,6 +151,19 @@ def _alert_webhook(text: str) -> None:
 _NON_SHOW_YAMLS = {"pronunciation_map"}  # kept for backward compat in CLI help text only
 
 
+def _episode_num_from_metrics_path(path: Path) -> int:
+    """Sort key for ``metrics_epNNN.json`` paths, by episode number.
+
+    Filenames are zero-padded to three digits, so lexicographic order
+    happens to be correct today — and stops being correct the day a show
+    reaches episode 1000. The source-collapse alarm slices the tail of
+    this list to build its baselines, so a wrong order silently compares
+    the wrong episodes rather than failing.
+    """
+    match = re.search(r"ep(\d+)", path.stem)
+    return int(match.group(1)) if match else -1
+
+
 def _discover_shows() -> list[str]:
     """Find all show slugs.
 
@@ -1092,30 +1105,83 @@ def run(args: argparse.Namespace) -> None:
         # annotation) so a degraded-fetch day is visible the same morning.
         # Log-only — never blocks the episode.
         try:
-            _recent_counts = []
-            for _mf in sorted(Path(config.episode.output_dir).glob("metrics_ep*.json"))[-10:]:
-                try:
-                    _mc = json.loads(_mf.read_text(encoding="utf-8")).get(
-                        "counters", {}).get("article_count")
-                    if isinstance(_mc, (int, float)) and _mc > 0:
-                        _recent_counts.append(int(_mc))
-                except (json.JSONDecodeError, OSError, ValueError):
-                    continue
-            if len(_recent_counts) >= 5:
-                _median = sorted(_recent_counts)[len(_recent_counts) // 2]
-                if _median >= 40 and len(articles) < _median * 0.25:
-                    metrics.record("article_count_degraded", True)
-                    print(
-                        f"::warning::{config.slug}: article fetch collapsed — "
-                        f"{len(articles)} articles vs recent median {_median}. "
-                        f"Digest will lean on X/web-search sources; check feed "
-                        f"health.",
-                        flush=True,
-                    )
-                    logger.warning(
-                        "Article fetch collapsed: %d vs recent median %d",
-                        len(articles), _median,
-                    )
+            # Two baselines, because one is not enough (August 2026, MIT).
+            # The original alarm compared today against the median of the
+            # last 10 episodes only. That catches a cliff and is blind to a
+            # slide: MIT's fetch fell from a median of 274 articles
+            # (ep90-119) to 50-64 (ep120-137) and the alarm went quiet
+            # after three firings, because the decayed counts became the
+            # baseline the next comparison used. Three of its RSS sources
+            # had started returning 403/500 and nothing said so for
+            # eighteen episodes. The short window still catches a sudden
+            # cliff; a long window that reaches back BEFORE the slide
+            # catches the slide itself.
+            def _counts_from(paths) -> list[int]:
+                out: list[int] = []
+                for _mf in paths:
+                    try:
+                        _mc = json.loads(_mf.read_text(encoding="utf-8")).get(
+                            "counters", {}).get("article_count")
+                        if isinstance(_mc, (int, float)) and _mc > 0:
+                            out.append(int(_mc))
+                    except (json.JSONDecodeError, OSError, ValueError):
+                        continue
+                return out
+
+            _metric_files = sorted(
+                Path(config.episode.output_dir).glob("metrics_ep*.json"),
+                key=_episode_num_from_metrics_path,
+            )
+            _recent_counts = _counts_from(_metric_files[-10:])
+            _baseline_counts = _counts_from(_metric_files[-60:-10])
+
+            def _median_of(vals: list[int]) -> int | None:
+                return sorted(vals)[len(vals) // 2] if vals else None
+
+            _median = _median_of(_recent_counts)
+            _baseline = _median_of(_baseline_counts)
+            if _median is not None:
+                metrics.record("article_count_recent_median", _median)
+            if _baseline is not None:
+                metrics.record("article_count_baseline_median", _baseline)
+
+            _alarm = None
+            if (
+                len(_recent_counts) >= 5
+                and _median is not None
+                and _median >= 40
+                and len(articles) < _median * 0.25
+            ):
+                _alarm = (
+                    f"article fetch collapsed — {len(articles)} articles vs "
+                    f"recent median {_median}"
+                )
+            elif (
+                len(_baseline_counts) >= 10
+                and _baseline is not None
+                and _baseline >= 40
+                and _median is not None
+                and _median < _baseline * 0.5
+            ):
+                # Slow decay: the last 10 episodes are running at under half
+                # the volume of the 50 before them. Fires every episode until
+                # the feeds are repaired or the new level becomes the
+                # baseline — which is the point, since silence is what let
+                # the previous slide run for three weeks.
+                _alarm = (
+                    f"article fetch has DECAYED — recent median {_median} vs "
+                    f"longer-run baseline {_baseline} (sources may be "
+                    f"returning errors; probe the feed list)"
+                )
+
+            if _alarm:
+                metrics.record("article_count_degraded", True)
+                print(
+                    f"::warning::{config.slug}: {_alarm}. Digest will lean on "
+                    f"X/web-search sources; check feed health.",
+                    flush=True,
+                )
+                logger.warning("%s: %s", config.slug, _alarm)
         except (OSError, TypeError, ValueError, AttributeError) as exc:
             # Alarm must never break a run — degrade to a debug line.
             logger.debug("article-collapse check failed: %s", exc)

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -58,6 +58,14 @@ LESSONS_LEARNED_FILENAME = "lessons_learned.json"
 MONTHLY_EPISODES_FILENAME = "monthly_episodes.json"
 NASDAQ_SYMBOL = "^IXIC"
 
+# How stale a closed trade may be and still be narrated in the Trade
+# Review segment. Anything older is retired unreviewed rather than
+# presented as a fresh result (August 2026 review — see
+# ``_build_trade_review``). Two weeks covers a missed weekly hold plus
+# the weekend either side; the 43-trade historical backlog is far
+# outside it and drains on the first run without ever reaching air.
+REVIEW_BACKLOG_MAX_DAYS = 14
+
 # Multi-index benchmarking (July 2026 "beat all major indices" pass).
 # ^IXIC stays THE headline benchmark (the show's identity and every legacy
 # field); the other two majors are scored over the same matched windows so
@@ -1537,6 +1545,23 @@ def _recompute_summary(tracker: dict) -> None:
     comp_port = 1.0
     comp_ndq = 1.0
     n_matched = 0
+    # VERIFIED subset (August 2026 review): the same compounding restricted
+    # to trades whose benchmark window was built by the July-3 pick-date-
+    # aligned code path — identified by ``entry_bar_date`` (only that path
+    # writes it). Everything older carries a window the July-3 integrity
+    # pass itself declared untrustworthy ("old-window inflation", carried
+    # in the ledger as an unrun operator recompute since 2026-07-03), and
+    # blending the two produced a headline the show states on air EVERY
+    # episode: +9.28% across 45 trades, while the 10 honestly-measured
+    # trades were at -1.95%. A number that survives only because it is
+    # averaged with numbers we know are wrong is not a measurement.
+    # ``scripts/recompute_mit_benchmarks.py --apply`` backfills the legacy
+    # windows; when it runs, every trade gains ``entry_bar_date`` and the
+    # verified figure simply becomes the whole record.
+    comp_v_port = 1.0
+    comp_v_ndq = 1.0
+    n_verified = 0
+    verified_alphas: list[float] = []
     for t in closed:
         pnl = t.get("pnl_pct")
         ndq = t.get("nasdaq_return_pct")
@@ -1547,6 +1572,21 @@ def _recompute_summary(tracker: dict) -> None:
             comp_port *= 1 + pnl / 100
             comp_ndq *= 1 + ndq / 100
             n_matched += 1
+            if t.get("entry_bar_date"):
+                comp_v_port *= 1 + pnl / 100
+                comp_v_ndq *= 1 + ndq / 100
+                n_verified += 1
+                verified_alphas.append(pnl - ndq)
+
+    # Significance on the VERIFIED subset only — a t-stat computed over
+    # windows we do not trust answers a question nobody asked.
+    verified_t_stat = None
+    if len(verified_alphas) >= 2:
+        _mean = sum(verified_alphas) / len(verified_alphas)
+        _var = sum((a - _mean) ** 2 for a in verified_alphas) / (len(verified_alphas) - 1)
+        _std = _var ** 0.5
+        if _std > 0:
+            verified_t_stat = round(_mean / (_std / len(verified_alphas) ** 0.5), 2)
 
     # Per-index matched-window scores (July 2026 multi-index pass): the
     # same compounding, one score per major index, so the show can state
@@ -1612,6 +1652,20 @@ def _recompute_summary(tracker: dict) -> None:
         "compounded_nasdaq_matched_pct": round((comp_ndq - 1) * 100, 2),
         "matched_window_alpha_pct": round((comp_port - comp_ndq) * 100, 2),
         "matched_window_trades": n_matched,
+        # Verified-window figures (August 2026). These are what the show
+        # states on air; the blended pair above is retained for continuity
+        # with the performance page and the recompute script.
+        "verified_window_alpha_pct": round((comp_v_port - comp_v_ndq) * 100, 2)
+        if n_verified else None,
+        "verified_window_return_pct": round((comp_v_port - 1) * 100, 2)
+        if n_verified else None,
+        "verified_window_nasdaq_pct": round((comp_v_ndq - 1) * 100, 2)
+        if n_verified else None,
+        "verified_window_trades": n_verified,
+        "unverified_window_trades": n_matched - n_verified,
+        "verified_alpha_t_stat": verified_t_stat,
+        "verified_alpha_statistically_significant": bool(
+            verified_t_stat is not None and abs(verified_t_stat) >= 2.0),
         "benchmark_scores": benchmark_scores,
         "indices_beaten": indices_beaten,
         "indices_scored": len(benchmark_scores),
@@ -2160,7 +2214,55 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
         # Check for open weekly hold — provide mid-week update
         return void_note + _weekly_hold_update(open_trades)
 
-    last = closed[-1]
+    # Pick the OLDEST unreviewed close, not the newest (August 2026
+    # review). The guard shipped in July fixed over-reviewing (the MU
+    # flash trade narrated three times) by stamping the trade it
+    # narrated — but it only ever looked at ``closed[-1]``, the last
+    # trade APPENDED. Once the pick cadence went to roughly one a day,
+    # more than one trade routinely closed between reviews, and every
+    # close except the newest was silently skipped forever: 43 of 50
+    # closed trades had never been narrated, including five that closed
+    # in the ten days before this review (LNTH, MU, TBBK, IPCO.TO,
+    # AAPL). Those results still counted in the running totals, so the
+    # segment was reporting an aggregate built from trades the audience
+    # never heard resolve. Draining the backlog oldest-first keeps every
+    # result narrated exactly once and self-heals the existing gap at
+    # one trade per episode.
+    # Bounded by freshness: a result older than REVIEW_BACKLOG_MAX_DAYS is
+    # stale news, so the historical backlog is retired in place (stamped
+    # ``review_skipped_stale``) instead of being narrated as if it just
+    # happened. Only genuinely recent closes are drained.
+    def _closed_on(t: dict) -> datetime.date | None:
+        for key in ("exit_bar_date", "date"):
+            try:
+                return datetime.date.fromisoformat(t.get(key) or "")
+            except ValueError:
+                continue
+        return None
+
+    unreviewed = [t for t in closed if t.get("reviewed_in_episode") is None]
+
+    def _is_stale(t: dict) -> bool:
+        when = _closed_on(t)
+        return when is not None and (today - when).days > REVIEW_BACKLOG_MAX_DAYS
+
+    if unreviewed:
+        fresh = [t for t in unreviewed if not _is_stale(t)]
+        # The newest unreviewed close is never retired, however old it is.
+        # Staleness exists to stop a months-old backlog being narrated as
+        # today's news, not to make the segment go silent — if the
+        # pipeline has been down long enough that nothing is fresh, the
+        # most recent result is still the right thing to report.
+        last = fresh[0] if fresh else unreviewed[-1]
+        for t in unreviewed:
+            if t is not last and _is_stale(t):
+                # Retired in place: never claimed as a fresh result,
+                # never re-examined on a later run.
+                if episode_num is not None and not _hooks_readonly():
+                    t["review_skipped_stale"] = True
+                    t["reviewed_in_episode"] = 0
+    else:
+        last = closed[-1]
 
     # Double-review guard: don't re-narrate an already-reviewed result.
     already = last.get("reviewed_in_episode")
@@ -2218,6 +2320,30 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
             f"({summary.get('win_rate_pct', 0):.0f}%)\n"
         )
 
+    # State the hold length that actually happened (August 2026 review).
+    # "Weekly Hold" is the label the digest prompt assigns at pick time,
+    # but exits are pinned to the Friday pre-market run — which prices
+    # Thursday's bar — so a Wednesday pick resolves after a single
+    # session. Across the ten trades with verified windows the holds ran
+    # 0-6 calendar days (median 3), while the scripts kept describing a
+    # "five-day window" that the pick's own target range was written
+    # against. Handing the real span to the model stops the mismatch at
+    # the source instead of asking it to remember.
+    hold_note = ""
+    try:
+        if last.get("entry_bar_date") and last.get("exit_bar_date"):
+            _in = datetime.date.fromisoformat(last["entry_bar_date"])
+            _out = datetime.date.fromisoformat(last["exit_bar_date"])
+            _days = (_out - _in).days
+            hold_note = (
+                f"**Actual hold:** {_days} calendar day(s) of market data "
+                f"({_in.strftime('%A')} → {_out.strftime('%A')}). Describe "
+                f"the window you actually held — never call it a five-day "
+                f"or full-week hold unless the dates say so.\n"
+            )
+    except ValueError:
+        pass
+
     direction = "gained" if pnl_pct >= 0 else "lost"
     stop_note = ""
     if last.get("stopped_out"):
@@ -2229,6 +2355,7 @@ def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:
         )
     return void_note + (
         f"**Last {type_label}:** {symbol} — {strategy}\n"
+        f"{hold_note}"
         f"{stop_note}"
         f"**Entry:** ${entry:.2f} ({entry_label}) → **Exit:** ${exit_:.2f} ({exit_label})\n"
         f"**Result:** {direction} {abs(pnl_pct):.2f}% (${pnl_dollars:+.2f} on $1,000 position)\n"
@@ -2892,7 +3019,30 @@ def _build_portfolio_summary(tracker: dict) -> str:
     if trades_with_alpha:
         matched_alpha = summary.get("matched_window_alpha_pct")
         matched_n = summary.get("matched_window_trades", 0)
-        if matched_n and matched_alpha is not None:
+        verified_alpha = summary.get("verified_window_alpha_pct")
+        verified_n = summary.get("verified_window_trades", 0)
+        unverified_n = summary.get("unverified_window_trades", 0)
+        if verified_n and verified_alpha is not None:
+            # The headline is the verified subset only (August 2026). The
+            # qualifier is fused into the value the way mechanism 3 did it
+            # — the sample size is part of the number, not a separate
+            # instruction the model can paraphrase away.
+            alpha_line = (
+                f"- Matched-window alpha vs NASDAQ: "
+                f"{_finite(verified_alpha):+.1f}% across {verified_n} "
+                f"verified-window trades — THE headline number; state it on "
+                f"air every episode, always call it the 'matched-window' "
+                f"score, and always say the trade count in the same "
+                f"sentence so the sample size travels with the claim\n"
+            )
+            if unverified_n:
+                alpha_line += (
+                    f"- NOT for air: {unverified_n} older trades have "
+                    f"benchmark windows that predate the pick-date "
+                    f"alignment fix and are excluded from the headline. "
+                    f"Never quote a blended lifetime alpha figure.\n"
+                )
+        elif matched_n and matched_alpha is not None:
             alpha_line = (
                 f"- Matched-window alpha vs NASDAQ (compounded over each "
                 f"trade's own holding window): {_finite(matched_alpha):+.1f}% "

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -18,16 +18,21 @@ sources:
   label: Motley Fool Canada
 - url: https://www.fool.com/feeds/index.aspx
   label: Motley Fool
-- url: https://www.cnbc.com/id/100003114/device/rss/rss.html
-  label: CNBC Investing
-- url: https://www.cnbc.com/id/10001147/device/rss/rss.html
-  label: CNBC Top Stories
+# CNBC (both feeds) and Benzinga were REMOVED 2026-08-15: all three
+# returned hard 403s to the production fetcher, not rate limits, and had
+# been dead long enough to drag the show's article volume from a median
+# of 274 (ep90-119) to 50-64 (ep120-137). Replacements below were probed
+# live with the production User-Agent before being added.
+- url: https://finance.yahoo.com/news/rssindex
+  label: Yahoo Finance
+- url: https://news.google.com/rss/search?q=earnings+beat+OR+guidance+stock+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
+  label: Google News Earnings
+- url: https://news.google.com/rss/search?q=Federal+Reserve+OR+%22Bank+of+Canada%22+interest+rate+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
+  label: Google News Rates
 - url: https://feeds.bloomberg.com/markets/news.rss
   label: Bloomberg Markets
 - url: https://www.bankofcanada.ca/feed/
   label: Bank of Canada
-- url: https://www.benzinga.com/feed
-  label: Benzinga
 - url: https://www.marketwatch.com/rss/topstories
   label: MarketWatch
 - url: https://etfdb.com/feed/
@@ -125,6 +130,20 @@ llm:
   max_tokens: 4000
   podcast_max_tokens: 8000
   min_podcast_words: 1800
+  # SCRIPT-STAGE ONLY A/B (2026-08-15, experiment mit-script-model-46).
+  # The digest stays on grok-4.3: the network holds facts-first stages
+  # there because grok-4.5 regressed confident-hallucination 25% -> 54%,
+  # and 4.6 is a post-training upgrade over 4.5, so that risk is
+  # unmeasured, not disproven. MIT is the show where a hallucinated
+  # number is most expensive (real tickers, real prices, a published
+  # track record), which is exactly why the newer model is pointed at
+  # the one stage that introduces no facts — it rewrites an
+  # already-verified digest into a script. The problem it is aimed at is
+  # measurable: 9 of the last 10 scripts came in under the 1800-word
+  # floor (median ~1535w). Readout 2026-08-29. Revert = delete this line.
+  # An unreachable model id falls back to llm.model with a loud warning
+  # (engine/generator.py), so a bad id costs the A/B, never the episode.
+  podcast_model: grok-4.6
   # DISABLED July 29 2026 (cost + quality). Measured over 901 committed
   # episodes: 81% still shipped BELOW target WITH this retry running (Tesla
   # 96.7%, M&A 95.2%) — it fires on nearly every episode and almost never

--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -201,6 +201,12 @@ Write 6-8 sentences following this "Market Mechanics" framework:
 [Use format from above — skip for Episode 1]
 
 ━━━━━━━━━━━━━━━━━━━━
+### Portfolio Performance
+[REQUIRED in EVERY episode after Episode 1 — this is the show's signature segment and the reason a listener trusts the rest of it. Report the running simulated record using the exact figures from the PORTFOLIO PERFORMANCE block supplied above: total trades, win rate, cumulative P&L, and the matched-window alpha WITH its trade count in the same sentence. 2-4 sentences.
+
+The figures are always supplied. If this section is missing from your output the show tells listeners its performance feed is down — which is false and destroys the credibility the segment exists to build. NEVER write that portfolio data is unavailable, pending, not in today's feed, or will be reported once the tracker updates. If a specific number is genuinely absent from the block above, report the numbers that ARE there and say nothing about the missing one.]
+
+━━━━━━━━━━━━━━━━━━━━
 ### Tools & Techniques
 2-3 items about modern investing tools, AI platforms, or techniques. For each:
 **[Tool/Technique Name]**

--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -181,6 +181,8 @@ Patrick: Quick reminder — everything we discuss here is for education and ente
 - DO NOT repeat any specific trade narrative or P&L from Trade Review — just the cumulative numbers
 - Brief commentary: "our AI analysis is learning from [pattern] and adjusting..."
 - Frame it as a learning journey, not a track record to follow
+- When you state the matched-window alpha, say its trade count in the SAME sentence ("...across N verified-window trades"). The sample size is part of the number, not a footnote — a percentage with no n behind it is a claim, not a measurement.
+- **NEVER say the portfolio figures are unavailable, pending, missing from today's data feed, or that tracking will resume once the tracker updates.** The tracker is a committed file that is always present. If the briefing you were given does not contain a Portfolio Performance section, report whatever running figures the briefing DOES carry and move on in one sentence — do not narrate an outage, and do not invent one to explain a gap in your own briefing.
 
 11. [Investor Education — 90-120 seconds]
 If the digest has an "Investor Education" section, this is your "pro tip" moment. Expand it as if you're sharing insider knowledge with a friend over drinks:

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -1312,3 +1312,243 @@ class TestArticleCollapseAlarm:
         y = _yaml.safe_load((_ROOT / "shows/modern_investing.yaml").read_text())
         assert y["llm"]["digest_expand_below_target"] is True
         assert y["llm"]["min_digest_words"] == 1500
+
+
+# ---------------------------------------------------------------------------
+# August 15 2026 pass — data honesty, review coverage, alarm sensitivity
+# ---------------------------------------------------------------------------
+
+
+class TestVerifiedWindowAlpha:
+    """The spoken alpha must come only from windows we trust.
+
+    The July 3 pass rebuilt the benchmark window to align with the pick
+    date and recorded ``entry_bar_date`` on every trade it priced. It
+    also declared every OLDER window untrustworthy ("old-window
+    inflation") and left the backfill to an operator script that has
+    never been run. ``matched_window_alpha_pct`` compounded both sets
+    together, so the number the show stated on air every episode —
+    +9.28% across 45 trades — was carried by the 35 trades whose windows
+    the pass itself had disowned; the 10 honestly-measured trades were
+    at -1.95%.
+    """
+
+    @staticmethod
+    def _tracker():
+        return {
+            "metadata": {"position_size": 1000},
+            "trades": [
+                # Verified: carries entry_bar_date (only the aligned path
+                # writes it).
+                {"symbol": "AAA", "status": "closed", "pnl_pct": 1.0,
+                 "nasdaq_return_pct": 3.0, "alpha_pct": -2.0,
+                 "entry_bar_date": "2026-08-03",
+                 "exit_bar_date": "2026-08-06", "pnl_dollars": 10.0},
+                {"symbol": "BBB", "status": "closed", "pnl_pct": -1.0,
+                 "nasdaq_return_pct": 1.0, "alpha_pct": -2.0,
+                 "entry_bar_date": "2026-08-07",
+                 "exit_bar_date": "2026-08-10", "pnl_dollars": -10.0},
+                # Legacy: no entry_bar_date, wildly flattering window.
+                {"symbol": "CCC", "status": "closed", "pnl_pct": 20.0,
+                 "nasdaq_return_pct": 0.0, "alpha_pct": 20.0,
+                 "pnl_dollars": 200.0},
+            ],
+            "summary": {},
+        }
+
+    def test_verified_subset_excludes_legacy_windows(self):
+        tracker = self._tracker()
+        mi._recompute_summary(tracker)
+        s = tracker["summary"]
+        assert s["verified_window_trades"] == 2
+        assert s["unverified_window_trades"] == 1
+        # Verified alpha is negative; the blended figure is dragged
+        # positive by the legacy trade. They must not be the same number.
+        assert s["verified_window_alpha_pct"] < 0
+        assert s["matched_window_alpha_pct"] > s["verified_window_alpha_pct"]
+
+    def test_headline_block_states_verified_figure_and_its_n(self):
+        tracker = self._tracker()
+        mi._recompute_summary(tracker)
+        block = mi._build_portfolio_summary(tracker)
+        n = tracker["summary"]["verified_window_trades"]
+        # The sample size travels with the claim, in the same line.
+        headline = [ln for ln in block.splitlines()
+                    if "Matched-window alpha" in ln][0]
+        assert f"{n} verified-window trades" in headline
+        # The blended lifetime figure must never be offered as the number
+        # to say out loud.
+        assert "NOT for air" in block
+
+    def test_no_verified_trades_falls_back_to_legacy_wording(self):
+        tracker = {
+            "metadata": {"position_size": 1000},
+            "trades": [{"symbol": "CCC", "status": "closed", "pnl_pct": 5.0,
+                        "nasdaq_return_pct": 1.0, "alpha_pct": 4.0,
+                        "pnl_dollars": 50.0}],
+            "summary": {},
+        }
+        mi._recompute_summary(tracker)
+        assert tracker["summary"]["verified_window_trades"] == 0
+        assert tracker["summary"]["verified_window_alpha_pct"] is None
+        # Still produces a usable block rather than crashing or going silent.
+        assert "Matched-window alpha" in mi._build_portfolio_summary(tracker)
+
+    def test_significance_is_measured_on_the_verified_subset(self):
+        tracker = self._tracker()
+        mi._recompute_summary(tracker)
+        s = tracker["summary"]
+        assert "verified_alpha_t_stat" in s
+        assert s["verified_alpha_statistically_significant"] is False
+
+
+class TestReviewBacklogDrain:
+    """Every closed trade is narrated exactly once — including the ones
+    that closed while another trade was closing.
+
+    The July guard fixed over-reviewing by stamping the trade it
+    narrated, but only ever looked at ``closed[-1]``. Once the pick
+    cadence reached roughly one a day, several trades closed between
+    reviews and all but the newest were skipped permanently: 43 of 50
+    closed trades had never been narrated, five of them within the
+    preceding ten days, while their results still counted in the running
+    totals the segment reported.
+    """
+
+    @staticmethod
+    def _tracker(days_ago_list):
+        today = datetime.date.today()
+        return {
+            "metadata": {"position_size": 1000},
+            "trades": [
+                {"symbol": f"S{i}", "status": "closed", "trade_type": "weekly",
+                 "strategy": "test", "entry_price": 100.0, "exit_price": 101.0,
+                 "pnl_pct": 1.0, "pnl_dollars": 10.0,
+                 "date": (today - datetime.timedelta(days=d)).isoformat(),
+                 "exit_bar_date": (today - datetime.timedelta(days=d)).isoformat()}
+                for i, d in enumerate(days_ago_list)
+            ],
+            "summary": {"cumulative_pnl": 0.0, "total_trades": len(days_ago_list),
+                        "wins": 0, "win_rate_pct": 0.0, "current_streak": 0},
+        }
+
+    def test_oldest_fresh_close_is_reviewed_first(self):
+        tracker = self._tracker([5, 3, 1])
+        review = mi._build_trade_review(tracker, episode_num=200)
+        assert "S0" in review          # oldest fresh, not the newest
+        assert tracker["trades"][0]["reviewed_in_episode"] == 200
+        assert tracker["trades"][2].get("reviewed_in_episode") is None
+
+    def test_backlog_drains_one_per_episode(self):
+        tracker = self._tracker([5, 3, 1])
+        seen = []
+        for ep in (200, 201, 202):
+            review = mi._build_trade_review(tracker, episode_num=ep)
+            seen.append(next(s for s in ("S0", "S1", "S2") if s in review))
+        assert seen == ["S0", "S1", "S2"]
+
+    def test_stale_backlog_is_retired_not_narrated(self):
+        # Months-old closes must never be presented as a fresh result.
+        tracker = self._tracker([400, 380, 2])
+        review = mi._build_trade_review(tracker, episode_num=200)
+        assert "S2" in review
+        assert "S0" not in review and "S1" not in review
+        assert tracker["trades"][0]["review_skipped_stale"] is True
+        assert tracker["trades"][1]["review_skipped_stale"] is True
+        assert "review_skipped_stale" not in tracker["trades"][2]
+
+    def test_newest_close_is_never_retired_even_when_stale(self):
+        # A long pipeline outage must not silence the segment entirely.
+        tracker = self._tracker([400, 380])
+        review = mi._build_trade_review(tracker, episode_num=200)
+        assert "S1" in review
+        assert tracker["trades"][1].get("review_skipped_stale") is None
+
+    def test_readonly_runs_do_not_retire_the_backlog(self, monkeypatch):
+        monkeypatch.setenv("NERRA_HOOKS_READONLY", "1")
+        tracker = self._tracker([400, 380, 2])
+        mi._build_trade_review(tracker, episode_num=200)
+        assert all("review_skipped_stale" not in t for t in tracker["trades"])
+
+
+class TestHonestHoldLength:
+    """The review states the window actually held.
+
+    Exits are pinned to the Friday pre-market run, which prices
+    Thursday's bar, so a mid-week pick resolves after one or two
+    sessions. Across the ten verified-window trades the holds ran 0-6
+    days (median 3) while the scripts described a five-day window.
+    """
+
+    def test_review_states_actual_hold_span(self):
+        tracker = {
+            "metadata": {"position_size": 1000},
+            "trades": [{
+                "symbol": "X.TO", "status": "closed", "trade_type": "weekly",
+                "strategy": "catalyst entry", "entry_price": 53.03,
+                "exit_price": 54.06, "pnl_pct": 1.94, "pnl_dollars": 19.42,
+                "entry_bar_date": "2026-08-12", "exit_bar_date": "2026-08-13",
+            }],
+            "summary": {"cumulative_pnl": 0.0, "total_trades": 1, "wins": 1,
+                        "win_rate_pct": 100.0, "current_streak": 1},
+        }
+        review = mi._build_trade_review(tracker, episode_num=200)
+        assert "Actual hold:** 1 calendar day" in review
+        assert "never call it a five-day" in review
+
+
+class TestSourceDecayAlarm:
+    """The collapse alarm must catch a slide, not only a cliff.
+
+    Comparing today against the median of the last 10 episodes uses a
+    baseline that decays with the problem: MIT's fetch fell from a median
+    of 274 (ep90-119) to 50-64 (ep120-137) after three of its RSS sources
+    began returning 403/500, and the alarm went quiet after three
+    firings.
+    """
+
+    def test_long_baseline_comparison_present(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "article_count_baseline_median" in src
+        assert "article fetch has DECAYED" in src
+        # Still non-blocking.
+        block = src.split("Source-collapse alarm")[1].split("if not articles")[0]
+        assert "_skip_episode" not in block
+
+    def test_metrics_path_sorted_by_episode_number(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "_episode_num_from_metrics_path" in src
+
+    def test_dead_feeds_removed_from_mit(self):
+        import yaml as _yaml
+        y = _yaml.safe_load((_ROOT / "shows/modern_investing.yaml").read_text())
+        urls = " ".join(s["url"] for s in y["sources"])
+        # All three returned hard 403s to the production User-Agent.
+        assert "cnbc.com" not in urls
+        assert "benzinga.com" not in urls
+        # Live replacements probed before adding.
+        assert "finance.yahoo.com/news/rssindex" in urls
+
+
+class TestScriptStageModelOverride:
+    """MIT runs a script-stage-only model A/B; the digest stays on 4.3."""
+
+    def test_mit_overrides_only_the_script_stage(self):
+        import yaml as _yaml
+        y = _yaml.safe_load((_ROOT / "shows/modern_investing.yaml").read_text())
+        assert y["llm"]["podcast_model"] == "grok-4.6"
+        # The digest/fetch stage must NOT follow it — grok-4.6 is built on
+        # 4.5's post-training and 4.5 regressed confident-hallucination
+        # 25% -> 54%. This is the show where a hallucinated number costs
+        # the most.
+        assert "model" not in y["llm"] or y["llm"]["model"] != "grok-4.6"
+
+    def test_override_model_is_priced(self):
+        from engine.tracking import GROK_PRICING
+        assert "grok-4.6" in GROK_PRICING
+
+    def test_unavailable_override_falls_back_instead_of_failing(self):
+        src = (_ROOT / "engine/generator.py").read_text(encoding="utf-8")
+        block = src.split("Per-stage model override")[1][:3000]
+        assert "falling back" in block
+        assert "config.llm.model" in block


### PR DESCRIPTION
Operator-directed deep pass on Modern Investing's pipeline **data, analytics, recursive learning and goal adjustment**, plus a performance review of past episodes.

Full write-up: [`docs/reviews/modern_investing_review_2026_08_15.md`](docs/reviews/modern_investing_review_2026_08_15.md). Ledger entry + the five scored predictions: `docs/reviews/ledger/modern_investing.yaml`.

## ⚠️ A/B-listen required (landmine #17)

Three changes alter shipped audio: the on-air alpha figure, the digest/podcast prompt edits, and the `grok-4.6` script-stage model. Please listen to the first post-merge episode before trusting the output change.

## Verdict

The measurement machinery built between July 3–24 all still works. What this pass found is that **three of the loops built to keep the show honest had quietly stopped closing** — and in each case the mechanism was correct when it shipped and became wrong as the data around it moved, with nothing watching the seam. None were visible from the dashboard, the metrics, or the ledger.

## P0 — the spoken alpha was built from windows we already know are wrong

`matched_window_alpha_pct` compounded every trade with a `nasdaq_return_pct`. That's 45 trades — but only **10** were priced by the July-3 pick-date-aligned path. The other **35** carry the windows that pass itself called *"old-window inflation"* and handed to `scripts/recompute_mit_benchmarks.py --apply`, which **has never been run** (open in the ledger for six weeks).

| Subset | Trades | Portfolio | NASDAQ | Alpha |
|---|---:|---:|---:|---:|
| Verified windows (`entry_bar_date`) | 10 | +2.69% | +4.64% | **−1.95%** |
| Legacy windows (pre-July-3) | 35 | +23.55% | +12.38% | +11.17% |
| Blended — **what shipped on air** | 45 | — | — | **+9.28%** |

Ep137, verbatim: *"Matched window alpha versus the NASDAQ reaches nine point three percent across forty five benchmarked trades."*

A number that survives only because it's averaged with numbers we know are wrong isn't a measurement. Now computes `verified_window_alpha_pct` / `_trades` / `unverified_window_trades` and a t-stat over the verified subset alone; the on-air headline switches to it with the trade count fused into the sentence and an explicit "NOT for air" line on the blend. **The recompute is now the highest-value operator action** — it collapses the split and takes the honest sample from n=10 to n=45.

## P0 — the track-record segment vanished from 65% of episodes, and the script invented a reason

13 of the last 20 digests (Ep118–121, 124–127, 129, 133–136) contain **no Portfolio Performance section at all**. On those days the podcast stage filled the gap:

> *"Portfolio performance numbers … are not available in today's data feed, so we will resume that tracking once the next update arrives."* (Ep134)

The tracker is a committed file and was healthy on every one of those days. The model omitted the section, then explained its own omission as a data failure — on the show whose entire premise is a published track record.

**Root cause is one line:** the figures are supplied as input context and the prompt says "state every episode", but the `### FORMATTING (EXACT — USE MARKDOWN AS SHOWN)` block — the template the model actually follows — **never listed the section**. Every other segment is in there. Added, plus an explicit ban in both prompts on narrating the figures as unavailable/pending.

## P0 — 43 of 50 closed trades were never narrated

July's fix for over-reviewing (MU told three times) stamped each trade when narrated — but only ever examined `closed[-1]`. Once the pick cadence went to roughly one a day, several closed between episodes and **every close but the newest was skipped permanently**. Five in the ten days before this review: LNTH, MU (**+5.12%, best result in weeks**), TBBK, IPCO.TO, AAPL. Their P&L still counted in the totals the segment reported — an aggregate built from trades the audience never heard resolve. This is also the mechanical explanation for July-24's "no newly closed trade in 9/10 episodes", which that review attributed to the pick drought.

Now drains oldest-first, one per episode, bounded by `REVIEW_BACKLOG_MAX_DAYS = 14` so the 38-trade historical backlog is retired in place rather than replayed as fresh news — and the newest close is never retired, so a long outage can't silence the segment.

## P1 — "Weekly Hold" holds averaged 2.8 sessions, not five

```
Ep101 COST 0d · Ep102 DAL 6d · Ep117 EPD 3d · Ep126 LNTH 3d · Ep128 AMD 1d
Ep130 MU  6d · Ep131 TBBK 3d · Ep133 IPCO 3d · Ep134 AAPL 2d · Ep135 X.TO 1d
```

Structural: exits are pinned to the Friday pre-market run, which prices **Thursday's** bar, so a Wednesday pick resolves after one session. The July-18 min-hold guard counts calendar days since the pick, which a Wed→Fri pick satisfies while still producing a one-bar window. The review block now states the real span. **Deferred to you:** whether a weekly hold should run a fixed five bars from entry instead (the shadow executor's exit calendar would move with it).

## P1 — the collapse alarm went quiet as the collapse got worse

| Episodes | Median articles |
|---|---:|
| Ep90–119 | ~274 |
| Ep120–129 | **50** |
| Ep130–137 | **64** |

The July-24 alarm fired three times (Ep121/123/124) then stopped — it compares today against the median of the **last 10 episodes**, so the decayed counts became the baseline. Ep132's 32 and Ep133's 28 passed silently. A watchdog whose reference point follows the thing it watches only catches a cliff, never a slide.

Cause is feed rot, probed live with the production User-Agent: **CNBC Investing, CNBC Top Stories and Benzinga all return hard 403s.** Replaced with live-probed feeds (Yahoo Finance 49 entries, Google News earnings 100, Google News rates 92). The alarm gains a second, longer baseline (last 10 vs the 50 before) and records both medians as metrics. Reddit left alone — a 429 from this egress isn't evidence it's dead in CI.

This is also the upstream cause of July-24's x.com-sourcing finding: when RSS thins out, the X block is what's left.

## Learning loops — audited

Healthy ✅: `lessons_learned` (11 distinct actives, no echo regrowth), `taught_lessons` (25 under cooldown), rule stamping, YouTube title feedback (150 videos, long-form 9% vs Shorts 33% retention), show memory. Broken ❌: benchmark windows, trade review — both above.

The pattern worth naming: **loops that operate on text fail loudly** (a tic shows up in a snapshot); **loops that operate on numbers fail silently**, because a wrong number looks exactly like a right one.

## Model strategy — grok-4.6

**Digest and fetch stages stay on grok-4.3, and it isn't close.** The documented reason facts-first stages sit there is that grok-4.5 regressed confident-hallucination 25% → 54%. grok-4.6 (2026-08-12) is a *post-training upgrade over 4.5*, so that risk is **unmeasured for it, not disproven** — and MIT names real tickers, quotes real prices and publishes a track record. Switching its digest model on a capability headline is the exact trade the network already decided against.

Shipped instead: `llm.podcast_model: grok-4.6` — **script stage only**, following the dp_pod precedent. That stage introduces no facts, and it's where the last chronic problem lives: 9 of the last 10 scripts under the 1800-word floor (median 1535w), after the July-24 digest lever moved it only from 1382w and plateaued. Experiment `mit-script-model-46`, readout 2026-08-29, revert is deleting one line.

The model id couldn't be validated against the API from this session (no key present), so `generate_podcast_script` now catches a failed override, falls back to `config.llm.model`, and prints a GitHub warning — **a wrong id costs the experiment, never an episode.**

## Scoring the 2026-07-24 predictions

| Metric | Expected | Verdict |
|---|---|---|
| Suffixed/crypto picks recorded correctly | 0 lost/mangled | **hit** — IPCO.TO, X.TO verbatim; no crypto pick to test |
| Stop/reference ratio outside [1/3, 3] | 0 | **hit** — 0 of 50 |
| Alpha mentions carrying the significance qualifier | ≥70% | **miss (3rd)** — 0 of 22 |
| Median script words | ≥1550w | **partial** — 1382 → 1535w |
| >2 x.com citations on normal-fetch days | 0 | **miss** — 6 of 12 |

The significance qualifier has now **missed three times** across three mechanisms. Per the playbook's escalation rule no fourth was written — it goes to you as **accept-or-abandon**. One confound: the figure being quoted was the blended number, now replaced by one that carries its own sample size inside the sentence, so it's worth re-scoring in two weeks before abandoning.

## Testing

- `tests/test_mit_benchmark_integrity.py`: **126 pass** (16 new guards across 5 new classes).
- Full suite: **6589 pass**. The 28 failures / 38 errors are **identical on a clean tree** (verified via `git stash`) — pre-existing missing optional deps (`yfinance`, image libs) in this sandbox, unrelated to these changes.

## Operator items

1. **Run `scripts/recompute_mit_benchmarks.py --apply`** — open since 2026-07-03, now the highest-value action on the show.
2. **Decide the significance-qualifier question** — accept or abandon.
3. **A/B-listen** the first post-merge episodes.
4. **Decide the weekly-hold cadence** — fixed five bars vs the Friday-close calendar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_