### PR TITLE
Fix log failures (stale-feed false pages, blocked MIT source) + workflow hardening pass

### DIFF
--- a/.github/workflows/backfill-video-feeds.yml
+++ b/.github/workflows/backfill-video-feeds.yml
@@ -69,7 +69,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: main
-          fetch-depth: 0
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/build-broll-pool.yml
+++ b/.github/workflows/build-broll-pool.yml
@@ -60,6 +60,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/build-gallery-manifest.yml
+++ b/.github/workflows/build-gallery-manifest.yml
@@ -49,6 +49,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/buttondown-tag-subscriber.yml
+++ b/.github/workflows/buttondown-tag-subscriber.yml
@@ -67,12 +67,16 @@ jobs:
         id: run_tool
         env:
           BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+          # env-var indirection, not inline '${{ }}' interpolation into
+          # shell quotes — an input containing a single quote would break
+          # out of the string (same rationale documented in
+          # backfill-dub-playlists.yml).
+          MODE: ${{ github.event.inputs.mode }}
+          EMAIL: ${{ github.event.inputs.email }}
+          SHOWS: ${{ github.event.inputs.shows }}
+          CSV: ${{ github.event.inputs.csv }}
         run: |
           set -e
-          MODE='${{ github.event.inputs.mode }}'
-          EMAIL='${{ github.event.inputs.email }}'
-          SHOWS='${{ github.event.inputs.shows }}'
-          CSV='${{ github.event.inputs.csv }}'
           ARGS=()
           OUTPUT_FILE=""
 

--- a/.github/workflows/check-youtube-caption-scope.yml
+++ b/.github/workflows/check-youtube-caption-scope.yml
@@ -17,6 +17,13 @@ name: Check YouTube Caption Scope
 # replacing that channel's YOUTUBE_REFRESH_TOKEN_* secret.
 
 on:
+  # Monthly cron (Aug 15 2026): token scope decays silently — a refresh
+  # token can lose force-ssl and every episode ships captionless while
+  # uploads stay green. Dispatch-only meant someone had to remember to
+  # check; a cheap read-only monthly run makes decay a monitored signal
+  # (same reasoning as check_apple_reporter_freshness in the nightly).
+  schedule:
+    - cron: '7 5 3 * *'  # 3rd of each month, 05:07 UTC (off-peak)
   workflow_dispatch:
     inputs:
       channel:

--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -83,6 +83,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -136,6 +139,11 @@ jobs:
           fi
 
       - name: RSS Feed Freshness Health Check
+        # always(): without it, a missed-episode failure in the audit step
+        # above skips this step entirely — so on the day a show is broken
+        # enough to miss an episode AND its feed is stale, only the first
+        # signal surfaces. The two checks are independent; run both.
+        if: always()
         shell: python3 {0}
         run: |
           import os
@@ -170,6 +178,13 @@ jobs:
               # Monday-only — a full week between episodes, so the limit
               # matches the dashboard's Monday cadence band, not the daily 96.
               "offshore_north_podcast.rss": ("Offshore North", 240),
+              # DELIBERATELY EXCLUDED: age_of_ai_podcast.rss — episodes
+              # publish only when an interview clears both human gates
+              # (Nerra Voices pipeline, not run_show), so there is no
+              # cadence to hold it to; any threshold would either page
+              # constantly or never. Guarded by the cadence test in
+              # tests/test_scheduling_punctuality.py, which requires an
+              # entry only for CRON_MAP-scheduled shows.
           }
 
           now = datetime.now(timezone.utc)

--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -149,11 +149,17 @@ jobs:
               "omni_view_podcast.rss": ("Omni View", 96),
               "fascinating_frontiers_podcast.rss": ("Fascinating Frontiers", 96),
               "planetterrian_podcast.rss": ("Planetterrian Daily", 96),
-              "env_intel_podcast.rss": ("Environmental Intelligence", 120),
+              # Monday-only since the Aug 2026 cadence alignment (CRON_MAP
+              # "7 8 * * 1") — a full week between episodes, so the daily/
+              # alt-cadence limits below would page every Saturday. 240h =
+              # one missed Monday + slack, same band as Offshore North.
+              "env_intel_podcast.rss": ("Environmental Intelligence", 240),
               "models_agents_podcast.rss": ("Models & Agents", 96),
               "models_agents_beginners_podcast.rss": ("Models & Agents for Beginners", 96),
-              "finansy_prosto_podcast.rss": ("Finansy Prosto", 96),
-              "privet_russian_podcast.rss": ("Privet Russian", 96),
+              # Monday-only (CRON_MAP "37 9 * * 1" / "7 6 * * 1") — see
+              # Environmental Intelligence note above.
+              "finansy_prosto_podcast.rss": ("Finansy Prosto", 240),
+              "privet_russian_podcast.rss": ("Privet Russian", 240),
               "modern_investing_podcast.rss": ("Modern Investing", 120),
               "unintended_consequences_podcast.rss": ("Unintended Consequences", 120),
               "first_principles_podcast.rss": ("First Principles Daily", 96),

--- a/.github/workflows/data-retention.yml
+++ b/.github/workflows/data-retention.yml
@@ -26,12 +26,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1). NOTE: the composite's
+          # own fetch-depth input is ignored under skip-checkout — the
+          # depth must be set on THIS checkout.
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
           requirements-file: 'requirements.txt'
-          fetch-depth: "1"
           skip-checkout: 'true'
 
       - name: Archive old data files
@@ -39,20 +43,14 @@ jobs:
           KEEP_DAYS="${{ inputs.keep_days || '180' }}"
           python scripts/archive_old_data.py --keep-days "$KEEP_DAYS"
 
+      # Aug 15 2026: replaced a naive push loop (no `rebase --abort`
+      # between attempts, so one conflict poisoned all four retries) with
+      # the shared composite. The archive move is re-runnable next month,
+      # so no recovery PR is needed — a failed push stays visible.
       - name: Commit archives + pruned files
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A data/archives/ digests/
-          if git diff --cached --quiet; then
-            echo "No files to archive this month"
-            exit 0
-          fi
-          git commit -m "Monthly data retention: archive files older than ${{ inputs.keep_days || '180' }}d"
-          for attempt in 1 2 3 4; do
-            git pull --rebase origin main && git push origin main && exit 0
-            echo "Push failed (attempt $attempt), retrying in $((attempt * 2))s..."
-            sleep $((attempt * 2))
-          done
-          echo "All push attempts failed"
-          exit 1
+        uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: |
+            data/archives/
+            digests/
+          commit-message: "Monthly data retention: archive files older than ${{ inputs.keep_days || '180' }}d"

--- a/.github/workflows/feed-audit.yml
+++ b/.github/workflows/feed-audit.yml
@@ -5,15 +5,25 @@ on:
     - cron: '0 12 * * 0'  # Sunday 12:00 UTC
   workflow_dispatch:
 
+# This job pushes to main; a dispatch overlapping the Sunday cron would
+# race its own commit step.
+concurrency:
+  group: feed-audit
+  cancel-in-progress: false
+
 jobs:
   audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -27,7 +37,11 @@ jobs:
         run: |
           set +e
           python scripts/audit_feeds.py 2>&1 | tee audit_output.txt
-          EXIT_CODE=$?
+          # PIPESTATUS[0], not $?: after a pipeline $? is tee's status
+          # (always 0), so the unhealthy-feeds warning below had never
+          # fired since this workflow shipped (Aug 15 2026 audit). Same
+          # fix daily-audit.yml and retitle-youtube-videos.yml carry.
+          EXIT_CODE=${PIPESTATUS[0]}
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
           exit 0
 

--- a/.github/workflows/mit-live-executor.yml
+++ b/.github/workflows/mit-live-executor.yml
@@ -29,7 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: actions/setup-python@v7
         with:
@@ -73,3 +74,9 @@ jobs:
         with:
           add-paths: digests/modern_investing/live_execution_state.json
           commit-message: "MIT live executor state: ${{ github.run_id }}"
+          # ARM-BLOCKER hardening (Aug 15 2026 audit): this file holds the
+          # halt flag and the open-position index. A dropped push resets
+          # the halt flag and orphans open positions from the --exits
+          # slot. Must be in place BEFORE live trading is ever armed.
+          recovery-on-failure: "true"
+          recovery-show: "mit-live-executor"

--- a/.github/workflows/mit-shadow-executor.yml
+++ b/.github/workflows/mit-shadow-executor.yml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: actions/setup-python@v7
         with:
@@ -43,3 +44,7 @@ jobs:
         with:
           add-paths: digests/modern_investing/shadow_ledger.json
           commit-message: "MIT shadow executor: ${{ github.run_id }}"
+          # The shadow ledger is an append-only dataset — a dropped push
+          # silently loses that day's fills (Aug 15 2026 audit).
+          recovery-on-failure: "true"
+          recovery-show: "mit-shadow-executor"

--- a/.github/workflows/monthly-report.yml
+++ b/.github/workflows/monthly-report.yml
@@ -63,6 +63,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -78,17 +81,22 @@ jobs:
           INPUT_MONTH: ${{ github.event.inputs.month || '' }}
           INPUT_YEAR: ${{ github.event.inputs.year || '' }}
         run: |
-          ARGS=""
+          # Bash array, not a quoted string: `"$ARGS"` passed every flag
+          # as ONE argv entry (argparse saw `--show tesla --month 7` as a
+          # single unknown argument), and the scheduled path passed a
+          # literal empty-string arg. Same pattern as
+          # backfill-dub-playlists.yml.
+          ARGS=()
           if [ "$INPUT_SHOW" != "" ] && [ "$INPUT_SHOW" != "all" ]; then
-            ARGS="--show $INPUT_SHOW"
+            ARGS+=(--show "$INPUT_SHOW")
           fi
           if [ "$INPUT_MONTH" != "" ]; then
-            ARGS="$ARGS --month $INPUT_MONTH"
+            ARGS+=(--month "$INPUT_MONTH")
           fi
           if [ "$INPUT_YEAR" != "" ]; then
-            ARGS="$ARGS --year $INPUT_YEAR"
+            ARGS+=(--year "$INPUT_YEAR")
           fi
-          python scripts/run_monthly_report.py "$ARGS"
+          python scripts/run_monthly_report.py "${ARGS[@]}"
 
       - name: Generate cross-show briefing
         env:
@@ -106,6 +114,8 @@ jobs:
     # the last trading day of the calendar month. Manual dispatch can
     # force a run via the mit_monthly input.
     runs-on: ubuntu-latest
+    # Full TTS + mix pipeline; cap well below the 6h GitHub default.
+    timeout-minutes: 60
     if: >-
       ${{
         (github.event_name == 'schedule' && github.event.schedule == '0 22 * * 1-5')
@@ -115,6 +125,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -141,7 +154,12 @@ jobs:
           fi
           python scripts/run_monthly_mit_episode.py $ARGS
 
+      # A full generated episode (TTS spend + R2 upload already done) —
+      # exactly the class the recovery-PR hatch exists for. Without it a
+      # push-retry exhaustion drops the episode's RSS entry + digest.
       - uses: ./.github/actions/safe-commit-push
         with:
           add-paths: "digests/modern_investing/ modern_investing_podcast.rss"
           commit-message: "MIT monthly recap — $(date -u +%Y-%m)"
+          recovery-on-failure: "true"
+          recovery-show: "mit-monthly"

--- a/.github/workflows/nerra_voices_fire_interview.yml
+++ b/.github/workflows/nerra_voices_fire_interview.yml
@@ -26,12 +26,20 @@ concurrency:
 jobs:
   fire:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
+      # Shallow checkout + cached pip. This job runs ~288×/day on the */5
+      # cron; the previous bare checkout full-cloned the repo (~2.5 GB of
+      # MP3 history, landmine #1) and reinstalled pip deps from scratch
+      # on every tick.
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+        with:
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
-      - run: pip install -r pipelines/requirements.txt
+          requirements-file: 'pipelines/requirements.txt'
+          skip-checkout: 'true'
       - run: python pipelines/voices/fire_interviews.py
         env:
           SUPABASE_URL: ${{ secrets.VOICES_SUPABASE_URL }}

--- a/.github/workflows/nerra_voices_post_interview.yml
+++ b/.github/workflows/nerra_voices_post_interview.yml
@@ -10,16 +10,29 @@ on:
 permissions:
   contents: read
 
+# Duplicate webhook deliveries for the same interview must not run the
+# full mix + STT + editorial pipeline twice concurrently.
+concurrency:
+  group: nerra-voices-post-${{ github.event.client_payload.interview_id || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   process:
     runs-on: ubuntu-latest
+    # ffmpeg mix + per-channel Whisper STT + 8 editorial passes; cap well
+    # below the 6h GitHub default so a hung API call can't strand it.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
+          requirements-file: 'pipelines/requirements.txt'
+          skip-checkout: 'true'
       - uses: FedericoCarboni/setup-ffmpeg@v3
-      - run: pip install -r pipelines/requirements.txt
       - run: python pipelines/voices/post_interview.py
         env:
           INTERVIEW_RUN_ID: ${{ github.event.client_payload.run_id }}

--- a/.github/workflows/nerra_voices_prep_briefs.yml
+++ b/.github/workflows/nerra_voices_prep_briefs.yml
@@ -13,12 +13,17 @@ permissions:
 jobs:
   prep_briefs:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
-      - run: pip install -r pipelines/requirements.txt
+          requirements-file: 'pipelines/requirements.txt'
+          skip-checkout: 'true'
       - run: python pipelines/voices/generate_briefs.py
         env:
           SUPABASE_URL: ${{ secrets.VOICES_SUPABASE_URL }}

--- a/.github/workflows/nerra_voices_produce_episode.yml
+++ b/.github/workflows/nerra_voices_produce_episode.yml
@@ -9,16 +9,29 @@ on:
 permissions:
   contents: read
 
+# Duplicate webhook deliveries for the same interview must not assemble
+# the episode twice concurrently.
+concurrency:
+  group: nerra-voices-produce-${{ github.event.client_payload.interview_id || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   produce:
     runs-on: ubuntu-latest
+    # Narration TTS + ffmpeg assembly + waveform render; cap well below
+    # the 6h GitHub default.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
+          requirements-file: 'pipelines/requirements.txt'
+          skip-checkout: 'true'
       - uses: FedericoCarboni/setup-ffmpeg@v3
-      - run: pip install -r pipelines/requirements.txt
       - run: python pipelines/voices/produce_episode.py
         env:
           INTERVIEW_ID: ${{ github.event.client_payload.interview_id }}

--- a/.github/workflows/nerra_voices_publish.yml
+++ b/.github/workflows/nerra_voices_publish.yml
@@ -37,15 +37,20 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # ffmpeg + network calls; the 6h GitHub default is not a real guard.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v7
+          # Publish only reads working-tree files and pushes; no history
+          # needed (landmine #1: full clones of this repo are ~2.5 GB).
+          fetch-depth: 1
+      - uses: ./.github/actions/setup-python
         with:
           python-version: '3.12'
+          requirements-file: 'pipelines/requirements.txt'
+          skip-checkout: 'true'
       - uses: FedericoCarboni/setup-ffmpeg@v3
-      - run: pip install -r pipelines/requirements.txt
       - run: python pipelines/voices/publish_episode.py
         env:
           INTERVIEW_ID: ${{ github.event.inputs.interview_id || github.event.client_payload.interview_id }}
@@ -53,16 +58,22 @@ jobs:
           SUPABASE_SERVICE_KEY: ${{ secrets.VOICES_SUPABASE_SERVICE_KEY }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           NOTIFICATION_WEBHOOK_URL: ${{ secrets.NOTIFICATION_WEBHOOK_URL }}
+      # Aug 15 2026: replaced a naive 4-attempt push loop. By this point
+      # the Supabase row already reads `published` and the audio is on R2,
+      # so a lost push silently strands the RSS entry / digest / site
+      # pages with no retry path (the sweep skips published rows). The
+      # composite adds rebase-conflict cleanup between attempts and, on
+      # exhaustion, opens a draft recovery PR instead of dropping the
+      # episode.
       - name: Commit RSS + summaries + pages
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add age_of_ai_podcast.rss digests/age_of_ai/ age-of-ai.html age-of-ai-summaries.html blog/age_of_ai/ 2>/dev/null || true
-          git diff --cached --quiet && echo "Nothing to commit" && exit 0
-          git commit -m "Publish: Age of AI episode ($(date -u +%F))"
-          for i in 1 2 3 4; do
-            git pull --rebase origin main && git push origin main && exit 0
-            sleep $((2**i))
-          done
-          echo "::error::Publish push failed after retries"
-          exit 1
+        uses: ./.github/actions/safe-commit-push
+        with:
+          add-paths: |
+            age_of_ai_podcast.rss
+            digests/age_of_ai/
+            age-of-ai.html
+            age-of-ai-summaries.html
+            blog/age_of_ai/
+          commit-message: "Publish: Age of AI episode"
+          recovery-on-failure: "true"
+          recovery-show: "age_of_ai"

--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -43,6 +43,9 @@ concurrency:
 jobs:
   generate-artifacts:
     runs-on: ubuntu-latest
+    # 6 external API fetches + site regen; the connector budget bounds
+    # the fetchers (docs/analytics.md) but nothing bounded the job.
+    timeout-minutes: 120
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/restock-topic-queues.yml
+++ b/.github/workflows/restock-topic-queues.yml
@@ -33,11 +33,16 @@ concurrency:
 jobs:
   restock:
     runs-on: ubuntu-latest
+    # Grok generation can hang; cap well below the 6h GitHub default.
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write  # recovery PR if push to main exhausts
     steps:
       - uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -64,9 +69,13 @@ jobs:
 
       - uses: ./.github/actions/safe-commit-push
         with:
+          # Glob, not per-show hardcoding: with the two files listed
+          # explicitly, a third narrative show's restocked queue would be
+          # generated and then silently never committed (Aug 15 2026
+          # audit). Age of AI's deliberately-empty queue is not in the
+          # restock registry, so it can never be restocked or staged.
           add-paths: |
-            shows/topic_queues/first_principles.yaml
-            shows/topic_queues/unintended_consequences.yaml
+            shows/topic_queues/*.yaml
           commit-message: "Auto-restock: narrative topic queues (trigger-gated)"
           recovery-on-failure: "true"
           recovery-show: "topic-queues"

--- a/.github/workflows/ru-spacex-weekly.yml
+++ b/.github/workflows/ru-spacex-weekly.yml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -56,10 +59,15 @@ jobs:
             ${{ inputs.force && '--force' || '' }}
 
       # The send marker is what stops a retried run from mailing the list
-      # twice, so it has to survive the runner.
+      # twice, so it has to survive the runner — including when the push
+      # retry loop exhausts. Without recovery-on-failure the composite
+      # exits 1 and DROPS the marker, and the next run double-mails real
+      # subscribers (Aug 15 2026 audit).
       - uses: ./.github/actions/safe-commit-push
         if: ${{ !inputs.dry_run }}
         with:
           add-paths: |
             digests/spacex/_ru_weekly_lastsend.txt
           commit-message: 'RU SpaceX weekly letter sent'
+          recovery-on-failure: "true"
+          recovery-show: "ru-spacex-weekly"

--- a/.github/workflows/source-discovery.yml
+++ b/.github/workflows/source-discovery.yml
@@ -65,17 +65,21 @@ jobs:
           INPUT_MIN_SCORE: ${{ github.event.inputs.min_score || '' }}
           INPUT_AUTO_APPLY: ${{ github.event.inputs.auto_apply || '' }}
         run: |
-          ARGS="--report"
+          # Bash array, not a quoted string: `"$ARGS"` passed every flag
+          # as ONE argv entry, so any dispatch with a show or min-score
+          # misparsed (Aug 15 2026 audit). Same pattern as
+          # backfill-dub-playlists.yml.
+          ARGS=(--report)
           if [ "$INPUT_SHOW" != "" ] && [ "$INPUT_SHOW" != "all" ]; then
-            ARGS="$ARGS $INPUT_SHOW"
+            ARGS+=("$INPUT_SHOW")
           fi
           if [ "$INPUT_MIN_SCORE" != "" ]; then
-            ARGS="$ARGS --min-score $INPUT_MIN_SCORE"
+            ARGS+=(--min-score "$INPUT_MIN_SCORE")
           fi
           if [ "$INPUT_AUTO_APPLY" = "true" ]; then
-            ARGS="$ARGS --apply"
+            ARGS+=(--apply)
           fi
-          python discover_sources.py "$ARGS"
+          python discover_sources.py "${ARGS[@]}"
 
       - uses: ./.github/actions/safe-commit-push
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,22 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on the same PR; on main every push gets its own
+# group (run_id) so nothing is cancelled there.
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:

--- a/.github/workflows/weekly-newsletter.yml
+++ b/.github/workflows/weekly-newsletter.yml
@@ -39,10 +39,15 @@ concurrency:
 jobs:
   generate:
     runs-on: ubuntu-latest
+    # Grok synthesis + Buttondown sends can hang; cap below the 6h default.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # No git history needed (landmine #1: full clone is ~2.5 GB).
+          fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
         with:
@@ -77,7 +82,8 @@ jobs:
           python scripts/run_weekly_newsletters.py "${ARGS[@]}"
 
       - name: Generate cross-network intelligence briefing
-        # Editorial synthesis across all 11 shows for the past 7 days.
+        # Editorial synthesis across the network's shows for the past 7
+        # days (count drifts as shows launch — don't hardcode it here).
         # Output: outputs/cross_network/cross_network_briefing_<YYYY-WW>.md.
         # The synthesizer skips when fewer than 10 episodes are in
         # window, so the script is no-op friendly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1828,8 +1828,11 @@ decision); everything else has a live status card.
     the repo for the operator to merge. This is the hardened path for the
     "Commit and push output" step (the finalize shared-pages push has a 5-attempt
     loop + warning but no recovery PR because those pages are fully regenerable).
-    The `safe-commit-push` composite used by nightly + 8 other workflows does not
-    yet have the recovery escape hatch (lower risk callers). The multilingual
+    The `safe-commit-push` composite now has an opt-in `recovery-on-failure`
+    input wired for the two callers whose commits are expensive to regenerate
+    (nightly maintenance, topic-queue restock); the other composite callers
+    deliberately stay fail-visible because their artifacts are regenerable
+    (stale note corrected 2026-08-15). The multilingual
     sweep's commit step (`.github/workflows/multilingual.yml`) also uses the
     recovery-PR escape hatch now, since it commits large translation-track +
     per-language-feed diffs on the same push-contended `main`. Drift guard:

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -23,8 +23,10 @@ sources:
 # been dead long enough to drag the show's article volume from a median
 # of 274 (ep90-119) to 50-64 (ep120-137). Replacements below were probed
 # live with the production User-Agent before being added.
-- url: https://finance.yahoo.com/news/rssindex
-  label: Yahoo Finance
+# NOTE: Yahoo Finance was briefly among those replacements but is on
+# shows/_blocked_sources.yaml (blocked 2026-03-16 for editorial quality,
+# not reachability) — the live probe checks the wrong axis for it. It
+# failed check_sources --check-blocked and was removed 2026-08-15.
 - url: https://news.google.com/rss/search?q=earnings+beat+OR+guidance+stock+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en
   label: Google News Earnings
 - url: https://news.google.com/rss/search?q=Federal+Reserve+OR+%22Bank+of+Canada%22+interest+rate+when%3A1d&hl=en-CA&gl=CA&ceid=CA:en

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -1526,8 +1526,41 @@ class TestSourceDecayAlarm:
         # All three returned hard 403s to the production User-Agent.
         assert "cnbc.com" not in urls
         assert "benzinga.com" not in urls
-        # Live replacements probed before adding.
-        assert "finance.yahoo.com/news/rssindex" in urls
+        # Yahoo Finance was briefly among the Aug-15 replacements but is
+        # on shows/_blocked_sources.yaml (blocked 2026-03-16 for editorial
+        # quality) — the live probe checked reachability, the wrong axis.
+        # Removed same day; the volume floor rests on the remaining
+        # replacements.
+        assert "finance.yahoo.com" not in urls
+        assert "feeds.bloomberg.com/markets" in urls
+        assert "marketwatch.com/rss" in urls
+
+    def test_no_show_uses_a_blocked_source(self):
+        """Network-wide mirror of `check_sources.py --check-blocked`.
+
+        That check runs in the weekly source-discovery workflow, so a
+        blocked source re-added to a show YAML sails through CI and only
+        fails days later on the cron (exactly how Yahoo Finance shipped
+        on 2026-08-15). This makes the blocklist a merge gate.
+        """
+        import yaml as _yaml
+        blocked_file = _ROOT / "shows/_blocked_sources.yaml"
+        blocked = _yaml.safe_load(blocked_file.read_text()) or {}
+        patterns = [b["url"] for b in blocked.get("blocked", [])
+                    if isinstance(b, dict) and b.get("url")]
+        assert patterns, "blocklist parse drift — no patterns found"
+        for cfg in sorted((_ROOT / "shows").glob("*.yaml")):
+            if cfg.name.startswith("_"):
+                continue
+            y = _yaml.safe_load(cfg.read_text()) or {}
+            for src in y.get("sources") or []:
+                url = src.get("url", "") if isinstance(src, dict) else ""
+                for pat in patterns:
+                    assert pat not in url, (
+                        f"{cfg.name}: source {url!r} matches blocked "
+                        f"pattern {pat!r} (see shows/_blocked_sources.yaml "
+                        "for the reason and date)"
+                    )
 
 
 class TestScriptStageModelOverride:

--- a/tests/test_queue_restock.py
+++ b/tests/test_queue_restock.py
@@ -141,9 +141,13 @@ class TestWorkflowWiring:
         assert "GROK_API_KEY" in wf
         # Post-restock validation must run BEFORE the commit step.
         assert wf.find("TestNarrativeQueueRunway") < wf.find("safe-commit-push")
-        # Both queue files whitelisted for commit (the history-file landmine).
-        assert "shows/topic_queues/first_principles.yaml" in wf
-        assert "shows/topic_queues/unintended_consequences.yaml" in wf
+        # The commit whitelist is a glob, not per-show hardcoding: with
+        # explicit files listed, a third narrative show's restocked queue
+        # would be generated and then silently never committed (Aug 15
+        # 2026 audit — same silent-drop class as youtube_channel_history).
+        # Age of AI's deliberately-empty queue is not in the restock
+        # registry, so the glob can never stage a restock for it.
+        assert "shows/topic_queues/*.yaml" in wf
 
     def test_runway_alarm_comment_updated(self):
         src = (ROOT / "tests/test_network_quality_pass.py").read_text()

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -111,3 +111,45 @@ def test_review_schedules_match_cron_day_filters():
                 f"{show}: review_episodes says Monday-only but the cron "
                 "has no Monday day-filter"
             )
+
+
+def _audit_rss_limits() -> dict:
+    """Parse the daily-audit RSS-freshness FEEDS dict: feed file -> limit."""
+    audit = (_ROOT / ".github" / "workflows" / "daily-audit.yml").read_text(
+        encoding="utf-8"
+    )
+    entries = {}
+    for m in re.finditer(r'"([\w.]+\.rss)":\s*\("[^"]+",\s*(\d+)\)', audit):
+        entries[m.group(1)] = int(m.group(2))
+    return entries
+
+
+def test_audit_rss_limits_match_cron_cadence():
+    """Aug 15 2026: env_intel/finansy_prosto/privet_russian moved to
+    Monday-only cadence but the daily audit's RSS staleness limits kept
+    their old daily/alt-cadence values (96-120h), so the audit paged the
+    operator every Saturday for feeds that were exactly on schedule. The
+    limit must follow the cadence CRON_MAP declares: a Monday-only show
+    needs headroom past one full week (>=192h), and a daily show must
+    stay tight enough (<=120h) that a real outage still pages within a
+    few missed cycles."""
+    cron_map = _cron_map()
+    limits = _audit_rss_limits()
+    assert limits, "no FEEDS limits parsed from daily-audit.yml"
+    for show, (_h, _m, day_filter) in cron_map.items():
+        feed = "podcast.rss" if show == "tesla" else f"{show}_podcast.rss"
+        assert feed in limits, (
+            f"{show}: scheduled in CRON_MAP but missing from the daily "
+            "audit's RSS freshness FEEDS — a dead feed would never page"
+        )
+        limit = limits[feed]
+        if day_filter == "monday":
+            assert limit >= 192, (
+                f"{show}: Monday-only cadence but audit limit is {limit}h "
+                "(<192h) — pages every week for an on-schedule feed"
+            )
+        else:
+            assert limit <= 120, (
+                f"{show}: daily cadence but audit limit is {limit}h "
+                "(>120h) — a real outage would go unnoticed for days"
+            )

--- a/tests/test_youtube_policy.py
+++ b/tests/test_youtube_policy.py
@@ -798,7 +798,14 @@ class TestShortsSupplyLadder:
         assert f"-> {entry['shorts_per_episode']} Short(s)" in entry["reason"]
 
     def test_committed_policy_agrees_with_the_ladder(self):
-        """api/youtube_policy.json is regenerated, not hand-edited."""
+        """api/youtube_policy.json is regenerated, not hand-edited.
+
+        Since the shorts-count hysteresis (commit defdef51), the ACTIVE
+        count may lawfully lag the ladder while a change is confirmed
+        over consecutive runs — but then the entry must carry the ladder
+        value as ``shorts_pending``. An active count that disagrees with
+        the ladder with no pending record is a hand-edit or a script bug.
+        """
         mod = _load_script()
         policy = json.loads(
             (_ROOT / "api" / "youtube_policy.json").read_text(encoding="utf-8"))
@@ -807,9 +814,14 @@ class TestShortsSupplyLadder:
                 vpd = entry.get("short_vpd")
                 if vpd is None:
                     continue    # held — the count follows the active tier
-                assert entry["shorts_per_episode"] == mod.shorts_for_vpd(vpd), (
-                    f"{channel}/{slug}: {vpd} vpd recorded as "
-                    f"{entry['shorts_per_episode']} Short(s)"
+                ladder = mod.shorts_for_vpd(vpd)
+                if entry["shorts_per_episode"] == ladder:
+                    continue
+                assert entry.get("shorts_pending") == ladder, (
+                    f"{channel}/{slug}: {vpd} vpd -> ladder {ladder} but "
+                    f"active {entry['shorts_per_episode']} Short(s) with "
+                    f"pending {entry.get('shorts_pending')!r} — neither "
+                    "current nor mid-hysteresis"
                 )
 
 


### PR DESCRIPTION
## The two logged failures — root causes

**Daily-audit "STALE RSS FEEDS" (env_intel 128.7h, finansy_prosto 128.7h, privet_russian 128.7h)** — all three feeds published Monday Aug 10 at 08:00 UTC, exactly on schedule. They are Monday-only shows per `CRON_MAP`, but the audit kept their old daily/alt-cadence limits (120/96/96h), so it pages every Saturday for healthy feeds. Limits moved to 240h (one missed Monday + slack, same band as Offshore North), and a new drift guard `test_audit_rss_limits_match_cron_cadence` ties every CRON_MAP show's audit limit to its declared cadence so this class can't recur.

**`check_sources.py --check-blocked` (Yahoo Finance in modern_investing)** — `finance.yahoo.com` has been on `shows/_blocked_sources.yaml` since 2026-03-16 for editorial quality, but was re-added on Aug 15 as a replacement for the dead CNBC/Benzinga feeds because the live probe checked reachability, not the blocklist. Removed; MIT keeps its other replacements (Bloomberg Markets, MarketWatch, Google News queries). A new network-wide test makes the blocklist a **merge gate** instead of a weekly-cron surprise.

## Workflow review — implemented

Reliability (recovery-PR hatches on non-regenerable commits):
- **nerra_voices_publish** — worst gap found: by push time the Supabase row reads `published` and the audio is on R2, so a lost push silently stranded the episode's RSS/digest/site pages forever (the sweep skips published rows). Naive 4-attempt loop (no rebase cleanup between attempts) replaced with `safe-commit-push` + recovery PR.
- **ru-spacex-weekly** — the anti-double-send marker now survives push exhaustion; losing it double-mails real subscribers.
- **monthly-report (MIT monthly)** — full generated episode (TTS spend + R2 upload already done) now recovers instead of dropping; `timeout-minutes: 60`.
- **mit-live-executor** (arm-blocker: the state file holds the halt flag + open-position index) and **mit-shadow-executor** (append-only ledger) gain recovery.
- **data-retention** — naive push loop replaced with the composite (no recovery: re-runnable).

Correctness:
- **daily-audit** RSS freshness step gets `if: always()` — a missed-episode failure was skipping the staleness check on exactly the day both signals matter.
- **feed-audit** — `EXIT_CODE=$?` after a `tee` pipeline is always 0, so the unhealthy-feeds warning has *never fired* since the workflow shipped; now `${PIPESTATUS[0]}`.
- **source-discovery / monthly-report** — `"$ARGS"` passed every flag as one argv entry, breaking any dispatch with inputs; now bash arrays.
- **restock-topic-queues** — `add-paths` is now a glob so a third narrative show's restocked queue can't be generated then silently never committed.
- **buttondown-tag-subscriber** — inputs via `env:` instead of inline `${{ }}` in shell quotes.

Efficiency:
- Depth-1 checkouts on 15 workflows that never read history. Biggest win: `nerra_voices_fire_interview` was full-cloning the repo (~2.5 GB with MP3 history) **every 5 minutes, ~288×/day**; all five voices workflows also get cached pip via the setup-python composite.
- `timeout-minutes` on every hangable job (nightly, newsletter, restock, voices pipelines, MIT monthly, test).
- Concurrency groups: feed-audit (pushes to main), per-interview groups on the voices post/produce webhooks (duplicate webhook deliveries can no longer run the mix+STT pipeline twice), cancel-superseded test runs on PRs.

Recursively-improving pieces (guards that watch the automation itself):
- `test_audit_rss_limits_match_cron_cadence` — audit thresholds must track CRON_MAP cadence.
- `test_no_show_uses_a_blocked_source` — blocklist enforced in CI, not just the weekly cron.
- `test_committed_policy_agrees_with_the_ladder` fixed to understand the shorts-count hysteresis (`shorts_pending`) — **this test was failing on every push to main since `defdef51`**, which is also why the Aug-11 dependabot PRs showed red CI.
- `check-youtube-caption-scope` gains a monthly cron — OAuth scope decay was a "someone remembers to check" path.
- CLAUDE.md landmine #23 stale note corrected (the composite has had the recovery hatch since nightly/restock adopted it).

## Also done in this session (not in this diff)
- Merged all 10 open PRs: 5 dependabot bumps (their red CI was the pre-existing main test failure above, not the bumps) and 5 show-review drafts (verified docs/ledger-only — no prompt/audio edits applied, so landmine #17 untouched). Merged branches auto-deleted; remote is clean.

## Deliberately NOT done (needs operator judgment)
- `run-show.yml` smoke-suite trim, `multilingual.yml` `git add -A` tightening, cron restagger of the 13:37/16:xx push-contention bands, and demoting the fire-interview cron to */15 — all listed in the audit as propose-only; each interacts with publish surfaces or the Worker SLOTS table.
- Show lists in weekly-newsletter/monthly-report/source-discovery are 10-show lists in a 16-show network — likely intentional subsets, flagged for review rather than "fixed".

Validation: actionlint clean, all workflow YAML parses, full pytest suite green locally (6,522 passed; only the 21 `feedgen`-import tests fail in this sandbox because the wheel can't build here — CI installs it from requirements normally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j6gYHJ5tEgpwX4mdvGbgU

---
_Generated by [Claude Code](https://claude.ai/code/session_015j6gYHJ5tEgpwX4mdvGbgU)_