### PR TITLE
Story-recurrence memory + narrative memory for env_intel and omni_view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1435,7 +1435,33 @@ become longitudinal chronicles, not disposable daily recaps.
   `SHOW_MEMORY_CONFIGS` registers **Models & Agents, Fascinating Frontiers,
   Planetterrian** (MIT already has its own `investment_tracker`; Tesla keeps
   its bespoke `engine/tesla_memory.py` — a future cleanup could fold Tesla into
-  this engine).
+  this engine). **Aug 16 2026 expansion: env_intel (regulatory arcs — a
+  consultation today is a gazetted rule next year) and omni_view
+  (world-news arcs feeding the Steel Man format) joined the registry** —
+  the last two news-driven shows without memory; seeded conservatively,
+  injection is A/B-gated per landmine #17.
+
+- **Story-recurrence memory (Aug 16 2026, `engine/story_recurrence.py`;
+  drift guards `tests/test_story_recurrence.py`).** The Fort Bend
+  solar-factory story ran on 11 distinct days of Tesla's tracker window
+  (5 of 10 episodes re-told from scratch, 4× inside Ep573) past THREE
+  existing dedup layers — the 0.72 title-similarity/2-day
+  `content_freshness` check misses re-headlined multi-day recurrence,
+  the ContentTracker's flat DO-NOT-REPEAT block is ignored, and
+  banning is editorially wrong anyway (a new filing deserves coverage
+  as an UPDATE). The fix is the DP Pod lever-memory pattern applied to
+  news: salient-token matching (auto common-token filter, so the brand
+  name can't manufacture a match) over the dated headline window the
+  ContentTracker already persists, delivered as INLINE
+  `[ALREADY-COVERED NOTE …]` annotations under the exact matched
+  articles in the digest prompt, framed update-don't-retell. Data-side,
+  deterministic, no LLM calls, no new storage. Enabled via
+  `story_recurrence: true` on the 9 daily news shows (lesson shows'
+  recurrence is curriculum, narrative-queue shows have their own
+  history; dp_pod/offshore_north lack tracker section patterns so it
+  would no-op). Outcome metric: `story_recurrence_in_digest` per
+  episode, scored against the Fort Bend baseline; the sanitizer strips
+  any echoed annotation.
 - **Flag-gated, single placeholder.** Prompts carry one
   `{narrative_memory_section}` placeholder; the show's thin hook
   (`shows/hooks/<slug>.py` → `show_memory.memory_pre_fetch/`

--- a/docs/reviews/ledger/network.yaml
+++ b/docs/reviews/ledger/network.yaml
@@ -225,6 +225,45 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: '2026-08-16'
+    pr: null
+    doc: null
+    generated_by: claude-code-session
+    summary: 'Operator-directed build: story-recurrence memory (engine/story_recurrence.py) — inline update-don''t-retell notes on fetched articles matching the ContentTracker''s dated headline window, enabled on the 9 daily news shows; narrative show_memory expanded to env_intel (regulatory arcs) and omni_view (world-news arcs), the last two news-driven shows without it. Built after the Fort Bend story ran on 11 distinct days of Tesla''s current 15-episode window past three existing dedup layers.'
+    scored_prior_predictions: []
+    shipped:
+    - file: engine/story_recurrence.py
+      kind: code
+      ab_listen_required: false
+      rationale: 'Data-side, deterministic, no LLM calls, no new storage (reads the tracker''s window). Salient-token matching with an automatic common-token filter catches re-headlined variants the 0.72 title-similarity dedup missed; verified against the real Tesla tracker (all 5 shipped Fort Bend variants match, unrelated stories do not). Inline annotation in the article listing — the ContentTracker''s separate DO-NOT-REPEAT block demonstrably failed; the annotation instructs update-don''t-retell instead of banning (a real new development deserves coverage as an update).'
+    - file: run_show.py
+      kind: code
+      ab_listen_required: false
+      rationale: 'Annotation gated on the new story_recurrence YAML flag (9 news shows opted in; lesson/narrative shows deliberately off). Outcome metric story_recurrence_in_digest recorded per episode against a window that excludes today (FF Ep128 self-match class). Best-effort: any failure renders the legacy listing.'
+    - file: engine/show_memory.py
+      kind: code
+      ab_listen_required: true
+      rationale: 'env_intel + omni_view MemoryConfig entries seeded conservatively (arc descriptions + open questions, no speculative status claims). Memory-section injection changes prompt context for both shows -> A/B-listen per landmine #17 (same note as the July 24 MIT/DP Pod expansion).'
+    deferred:
+    - dp_pod + offshore_north have no ContentTracker section patterns, so story_recurrence would be a silent no-op there — give them tracker patterns first if their repetition ever bites.
+    - The recurrence annotation is digest-side only; if a recurring story still gets RE-TOLD (not updated) in scripts after 2 weeks, the next lever is podcast-prompt-side framing (A/B) — not a data change.
+    predictions:
+    - metric: 'tesla: same-story full re-telling across >=3 episodes of a 10-episode review window (Fort Bend class)'
+      baseline: Fort Bend ran 5 of 10 episodes (Ep565-573) re-told from scratch each time, and on 11 distinct days of the tracker window
+      expected: 0 stories re-told from scratch across >=3 episodes in the next tesla review window; legitimate developments framed as updates are a PASS, verbatim re-telling is the fail condition
+      verdict: pending
+      evidence: null
+    - metric: mean story_recurrence_annotated per episode on tesla+spacex (metrics_ep*.json)
+      baseline: 'unmeasured (new metric); real-window probe: ~1-3 articles/episode expected to match'
+      expected: metric present and nonzero within 3 post-merge episodes on both shows (proves the wiring fired); if 0 across 5 episodes, the flag or tracker wiring silently broke
+      verdict: pending
+      evidence: null
+    - metric: env_intel + omni_view narrative trackers exist and auto-freshness advances
+      baseline: no tracker files exist for either show
+      expected: digests/<dir>/<slug>_narrative_tracker.json committed within 3 episodes of merge, last_mentioned_episode advancing; narrative pages render
+      verdict: pending
+      evidence: null
+    agent_cost_usd: null
 do_not_retry:
   - idea: podcast-side length levers (word floors, expand-retries, prompt
       pressure on the podcast stage) for ANY show

--- a/engine/config.py
+++ b/engine/config.py
@@ -981,6 +981,14 @@ class ShowConfig:
     # content (moon calendars, planet-visibility roundups, "this day in
     # history") — see engine.utils.drop_excluded_titles.
     exclude_title_patterns: List[str] = field(default_factory=list)
+    # Story-recurrence memory (Aug 2026): annotate fetched articles that
+    # match the ContentTracker's recent-headline window with an inline
+    # "already covered — update, don't re-tell" note in the digest
+    # prompt's article listing. Data-side, deterministic, no LLM calls
+    # (engine/story_recurrence.py). Built after the Fort Bend story ran
+    # in 5 of 10 Tesla episodes past three existing dedup layers.
+    # Default False; the daily news shows opt in per-YAML.
+    story_recurrence: bool = False
     web_search_queries: List[str] = field(default_factory=list)
     # Run web_search_queries on EVERY episode, not only when the on-topic
     # article count falls below min_articles. For shows whose key sources
@@ -1214,6 +1222,7 @@ def load_config(yaml_path: str | Path) -> ShowConfig:
         x_fetch_enabled=data.get("x_fetch_enabled"),
         keywords=data.get("keywords", []),
         exclude_title_patterns=data.get("exclude_title_patterns", []),
+        story_recurrence=bool(data.get("story_recurrence", False)),
         web_search_queries=data.get("web_search_queries", []),
         web_search_always=bool(data.get("web_search_always", False)),
         min_articles=data.get("min_articles", 3),

--- a/engine/newsletter_sanitizer.py
+++ b/engine/newsletter_sanitizer.py
@@ -184,6 +184,12 @@ _RAW_RULES: List[Tuple[str, str, str]] = [
     # repaired here; that's the prompt-side fix.)
     (r"(?im)^(\s*(?:\d+\.|[-*•])?\s*\*\*)\s*Title\s*[:\-—]\s*", r"\1",
      "'**Title:' heading label"),
+    # Story-recurrence annotations (Aug 2026, engine/story_recurrence.py)
+    # are instruction text injected into the digest prompt's article
+    # listing — if the model ever echoes one into the digest body, strip
+    # the whole line before any reader surface sees it.
+    (r"(?im)^\s*\[?ALREADY-COVERED NOTE\b.*(?:\n|$)", "",
+     "'[ALREADY-COVERED NOTE' echo"),
     # NOTE: box-drawing horizontal rules (━━━ / ─── / ═══) are NOT
     # scrubbed here — they're converted to proper ``<hr>`` separators
     # by ``engine.newsletter_body.replace_box_rules_with_hr`` in the

--- a/engine/show_memory.py
+++ b/engine/show_memory.py
@@ -1054,6 +1054,111 @@ SHOW_MEMORY_CONFIGS: Dict[str, MemoryConfig] = {
             "rewilding", "clean energy", "carbon", "biodiversity",
         ],
     ),
+    # Aug 2026 expansion (operator-directed): env_intel and omni_view were
+    # the two remaining news-driven shows without narrative memory — and
+    # both are longitudinal by nature. EI's compliance beats ARE multi-year
+    # regulatory arcs (a consultation today is a gazetted rule next year);
+    # OV's world-news stories run for months and its Steel Man format
+    # benefits most from knowing where each arc stood last time. Seeded
+    # conservatively: arc descriptions + open questions, no speculative
+    # status claims — statuses accrue from coverage via
+    # auto_update_narrative_from_digest.
+    "env_intel": MemoryConfig(
+        slug="env_intel",
+        label="ENVIRONMENTAL INTELLIGENCE",
+        file_prefix="env_intel",
+        default_programs={
+            "federal_assessment_reform": _prog(
+                "Federal Impact Assessment & Permitting",
+                "The IAA-era assessment and permitting regime for major "
+                "projects — timelines, jurisdictional friction, and how "
+                "approvals actually move.",
+                ["How assessment timelines change for major projects",
+                 "Where federal-provincial jurisdiction friction lands"],
+            ),
+            "pfas_contaminants": _prog(
+                "PFAS & Emerging Contaminants",
+                "The regulatory arc for PFAS and other emerging "
+                "contaminants under CEPA — reporting, listing, and "
+                "remediation practice.",
+                ["Scope and timing of class-based PFAS requirements",
+                 "What reporting obligations reach practitioners first"],
+            ),
+            "carbon_pricing": _prog(
+                "Carbon Pricing & Industrial Emissions",
+                "Federal and provincial carbon-pricing systems and "
+                "industrial emissions rules as they bind operators.",
+                ["How output-based systems evolve per province",
+                 "Which compliance deadlines bind operators next"],
+            ),
+            "species_habitat": _prog(
+                "Species at Risk & Habitat Protection",
+                "SARA listings, habitat orders, and the project-level "
+                "practice they drive.",
+                ["Which listings change project screening practice",
+                 "How habitat protection orders are enforced"],
+            ),
+            "water_effluent": _prog(
+                "Water & Effluent Regulation",
+                "Effluent regulations, groundwater permitting, and "
+                "monitoring practice across provinces.",
+                ["Where effluent limits tighten next",
+                 "How monitoring expectations shift for practitioners"],
+            ),
+        },
+        theme_keywords=[
+            "cepa", "pfas", "carbon", "emission", "assessment", "permit",
+            "effluent", "groundwater", "remediation", "contamin", "habitat",
+            "species", "consultation", "gazette", "compliance",
+        ],
+    ),
+    "omni_view": MemoryConfig(
+        slug="omni_view",
+        label="OMNI VIEW",
+        file_prefix="omni_view",
+        default_programs={
+            "us_china": _prog(
+                "US-China Relations",
+                "The trade, technology, and security relationship between "
+                "the US and China — the axis many other stories bend "
+                "around.",
+                ["Where trade and export-control policy moves next",
+                 "How the technology decoupling actually plays out"],
+            ),
+            "russia_ukraine": _prog(
+                "Russia-Ukraine War",
+                "The war and the diplomacy around it — battlefield, "
+                "sanctions, and negotiation tracks.",
+                ["What shifts the battlefield or negotiation calculus",
+                 "How sanctions regimes evolve and leak"],
+            ),
+            "middle_east": _prog(
+                "Middle East Realignment",
+                "Regional conflicts and diplomatic realignment across the "
+                "Middle East.",
+                ["Which ceasefire and normalization tracks hold",
+                 "How regional powers reposition"],
+            ),
+            "global_trade": _prog(
+                "Global Trade & Tariffs",
+                "Tariff regimes, supply-chain shifts, and the trade "
+                "architecture underneath them.",
+                ["Where tariff escalation lands next",
+                 "Which supply chains actually move"],
+            ),
+            "ai_governance": _prog(
+                "AI Governance",
+                "How governments regulate, adopt, and compete over AI.",
+                ["Which jurisdictions' rules bind first",
+                 "How compute and model access get governed"],
+            ),
+        },
+        theme_keywords=[
+            "china", "russia", "ukraine", "tariff", "sanction", "election",
+            "ceasefire", "diplomac", "trade", "nato", "regulation",
+            "parliament", "treaty", "summit",
+        ],
+    ),
     # Age of AI does NOT run through run_show (Nerra Voices pipeline), so the
     # digest-driven hooks never fire — its memory feeds the interview
     # pipeline instead (pipelines/voices/common.py:episode_memory_block reads

--- a/engine/story_recurrence.py
+++ b/engine/story_recurrence.py
@@ -1,0 +1,197 @@
+"""Story-recurrence memory — inline "already covered" annotations.
+
+The problem (Aug 15 2026 Tesla review): the Fort Bend solar-factory story
+ran in 5 of 10 episodes and four times inside Ep573 alone, each time
+re-told from scratch as if new. Three defenses already existed and all
+three missed it:
+
+* ``content_freshness`` title-similarity dedup (0.72 threshold, 2-day
+  lookback) — re-headlined versions ("Tesla plans $10B solar cell
+  factory" vs "Tesla seeks Texas tax incentive for USD-10bn solar cell
+  factory") score below the threshold, and day-4/6/9 recurrences are
+  outside the window entirely.
+* ``ContentTracker.get_summary_for_prompt`` — a flat "DO NOT repeat
+  these" headline list, 3-day window, placed in a block far from the
+  article listing. Blanket-banning is also editorially WRONG for a
+  developing story: the new filing deserves coverage — as an UPDATE,
+  not a re-telling.
+* The within-episode duplicate-headline strip — exact/near matches only.
+
+This module is the DP Pod lever-memory pattern applied to news: the
+recurrence signal is computed DATA-side (no LLM calls, no new storage —
+it reads the dated headline window ``ContentTracker`` already persists)
+and delivered INLINE, attached to the exact article the model is
+deciding about, with update-don't-retell framing instead of a ban.
+
+Matching is salient-token overlap with an automatic per-show common-token
+filter: tokens appearing in a large share of the window's headlines
+("tesla", "spacex", "launch"…) carry no signal and are excluded, so the
+brand name can never manufacture a match. Deterministic, cheap, and the
+same doc-frequency idea the gallery-retention style miner uses.
+
+Wired in ``run_show.py``: annotations render into the news_section under
+each matched article; after the digest ships, the recurrence count of
+the SHIPPED stories is recorded as a metric so reviews can score the
+lever mechanically (``story_recurrence_in_digest``).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Generic English stopwords + article-title furniture. Deliberately small:
+# the doc-frequency filter below handles show-specific noise ("tesla",
+# "spacex", "starship") without hand-curation.
+_STOPWORDS = frozenset("""
+a an and are as at be but by for from has have how in into is it its new
+of on or over says say said that the their this to today up was were what
+when who will with after amid announces announced report reports reveals
+revealed here why you your
+""".split())
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+(?:['’][a-z0-9]+)*")
+
+# A window headline shares this many salient tokens with an article title
+# (or covers this fraction of the smaller token set) => same story.
+_MIN_OVERLAP = 3
+_MIN_FRACTION = 0.6
+
+# Tokens present in at least this share of window headlines are "common"
+# for the show and never count toward an overlap.
+_COMMON_DF = 0.30
+
+
+def salient_tokens(title: str) -> frozenset:
+    """Normalized salient tokens of a headline (pre common-token filter)."""
+    tokens = _TOKEN_RE.findall((title or "").lower())
+    return frozenset(
+        t for t in tokens
+        if t not in _STOPWORDS and (len(t) >= 3 or t.isdigit())
+    )
+
+
+class RecurrenceIndex:
+    """Token index over the tracker's recent-episode headline window."""
+
+    def __init__(self, episodes: List[dict], *, exclude_date: str = ""):
+        """*episodes* is ``ContentTracker.data["episodes"]`` (dicts with
+        ``date`` + ``headlines``). ``exclude_date`` drops that calendar
+        day's record — required when scoring today's own digest against
+        the window (the FF Ep128 self-match lesson)."""
+        self._entries: List[Tuple[str, str, frozenset]] = []
+        df: Dict[str, int] = {}
+        for ep in episodes or []:
+            date = ep.get("date", "")
+            if exclude_date and date == exclude_date:
+                continue
+            for headline in ep.get("headlines", []) or []:
+                toks = salient_tokens(headline)
+                if not toks:
+                    continue
+                self._entries.append((date, headline, toks))
+                for t in toks:
+                    df[t] = df.get(t, 0) + 1
+        n = len(self._entries)
+        self.common: frozenset = frozenset(
+            t for t, c in df.items() if n >= 5 and c / n >= _COMMON_DF
+        )
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def match(self, title: str) -> Optional[dict]:
+        """Best window match for *title*, or None.
+
+        Returns ``{"date", "headline", "times"}`` — ``times`` is how many
+        DISTINCT DAYS in the window covered the story (a story that ran
+        4 days reads differently than one that ran once; counting raw
+        headline matches would inflate multi-section coverage).
+        """
+        probe = salient_tokens(title) - self.common
+        if len(probe) < 2:
+            return None
+        matches: List[Tuple[str, str, int]] = []
+        for date, headline, toks in self._entries:
+            cand = toks - self.common
+            if not cand:
+                continue
+            overlap = len(probe & cand)
+            smaller = min(len(probe), len(cand))
+            if overlap >= _MIN_OVERLAP or (
+                smaller >= 2 and overlap / smaller >= _MIN_FRACTION
+                and overlap >= 2
+            ):
+                matches.append((date, headline, overlap))
+        if not matches:
+            return None
+        # Cite the MOST RECENT day the story ran ("most recently on …"
+        # must not point at an older copy), quoting that day's
+        # highest-overlap headline.
+        latest = max(d for d, _h, _o in matches)
+        quote = max((m for m in matches if m[0] == latest),
+                    key=lambda m: m[2])[1]
+        return {"date": latest, "headline": quote,
+                "times": len({d for d, _h, _o in matches})}
+
+
+def annotation_for(match: dict) -> str:
+    """The inline note rendered under a matched article in news_section.
+
+    Instruction-shaped, not content-shaped: nothing here should be
+    quotable as digest prose (de-seed rule), and a scrub guard in
+    ``engine.newsletter_sanitizer`` removes the marker if the model ever
+    echoes it.
+    """
+    times = match.get("times", 1)
+    seen = (f"covered on {times} recent days, most recently "
+            if times > 1 else "covered ")
+    return (
+        f"   [ALREADY-COVERED NOTE — instruction, not content: this story was "
+        f"{seen}on {match['date']} "
+        f"(“{match['headline'][:90]}”). Include it ONLY if today's "
+        f"item adds a genuinely NEW development beyond that coverage; if so, "
+        f"cover it as a short UPDATE — one clause of recap at most, lead with "
+        f"what changed — never re-tell the story from scratch, and do not "
+        f"make it the hook again. If nothing is new, pick a different story.]"
+    )
+
+
+def annotate_articles(articles: List[dict],
+                      index: "RecurrenceIndex") -> Dict[int, str]:
+    """Map article-list index -> annotation line for matched articles."""
+    notes: Dict[int, str] = {}
+    if not len(index):
+        return notes
+    for i, art in enumerate(articles):
+        title = art.get("title") or ""
+        if not title:
+            continue
+        m = index.match(title)
+        if m:
+            notes[i] = annotation_for(m)
+    return notes
+
+
+def recurrence_in_digest(digest_text: str,
+                         index: "RecurrenceIndex") -> int:
+    """How many of the shipped digest's story headlines match the window.
+
+    THE scoreable metric for this lever: the annotations aim to convert
+    re-tellings into brief updates and drop no-news repeats, so this
+    count (recorded as ``story_recurrence_in_digest``) should fall
+    relative to the Aug-2026 baseline (Fort Bend class: same story in
+    5 of 10 Tesla episodes).
+    """
+    if not digest_text or not len(index):
+        return 0
+    from engine.grok_imagine import extract_story_headlines
+
+    count = 0
+    for headline in extract_story_headlines(digest_text, max_count=24):
+        if index.match(headline):
+            count += 1
+    return count

--- a/run_show.py
+++ b/run_show.py
@@ -1351,6 +1351,39 @@ def run(args: argparse.Namespace) -> None:
 
         from engine.utils import prompt_pub_date
 
+        # Story-recurrence memory (Aug 2026): inline "already covered —
+        # update, don't re-tell" notes attached to the exact articles the
+        # model is deciding about. Reads the dated headline window the
+        # ContentTracker already persists; matching is salient-token
+        # overlap with an automatic common-token filter so re-headlined
+        # versions of a story are caught (the class the 0.72 title-
+        # similarity dedup and the flat DO-NOT-REPEAT list both missed —
+        # Fort Bend ran 5 of 10 Tesla episodes). Best-effort: any failure
+        # renders the legacy listing.
+        _recurrence_notes: dict = {}
+        _recurrence_index = None
+        if getattr(config, "story_recurrence", False):
+            try:
+                from engine.story_recurrence import (
+                    RecurrenceIndex, annotate_articles)
+                _recurrence_index = RecurrenceIndex(
+                    content_tracker.data.get("episodes", []),
+                    exclude_date=datetime.date.today().isoformat(),
+                )
+                _recurrence_notes = annotate_articles(
+                    articles, _recurrence_index)
+                if _recurrence_notes:
+                    logger.info(
+                        "Story recurrence: %d of %d articles matched the "
+                        "recent-coverage window and carry update-don't-"
+                        "retell notes", len(_recurrence_notes), len(articles))
+                metrics.record("story_recurrence_annotated",
+                               len(_recurrence_notes))
+            except Exception as _rec_exc:  # noqa: BLE001 — never block a run
+                logger.warning("Story recurrence annotation failed "
+                               "(non-fatal): %s", _rec_exc)
+                _recurrence_notes = {}
+
         news_lines = []
         for i, art in enumerate(articles, 1):
             title = art.get("title", "Untitled")
@@ -1363,6 +1396,8 @@ def run(args: argparse.Namespace) -> None:
                 f"{i}. **{title}** — {source}"
                 + (f" ({pub})" if pub else "")
                 + f"\n   {desc}\n   URL: {url}"
+                + ("\n" + _recurrence_notes[i - 1]
+                   if (i - 1) in _recurrence_notes else "")
             )
         news_section = "\n\n".join(news_lines)
 
@@ -1536,6 +1571,22 @@ def run(args: argparse.Namespace) -> None:
             )
             save_usage(tracker, digests_dir)
             sys.exit(1)
+
+        # Story-recurrence outcome metric (Aug 2026): how many of the
+        # SHIPPED digest's stories match the recent-coverage window. THE
+        # scoreable number for the recurrence lever — computed against
+        # the pre-record index (excludes today, so the digest never
+        # matches itself; the FF Ep128 lesson). Reviews score this
+        # against the Fort Bend baseline (same story 5 of 10 episodes).
+        if _recurrence_index is not None:
+            try:
+                from engine.story_recurrence import recurrence_in_digest
+                metrics.record(
+                    "story_recurrence_in_digest",
+                    recurrence_in_digest(x_thread, _recurrence_index))
+            except Exception as _rec_exc:  # noqa: BLE001
+                logger.warning("Story recurrence metric failed "
+                               "(non-fatal): %s", _rec_exc)
 
         # Record episode content in the cross-episode tracker
         if section_patterns:

--- a/shows/env_intel.yaml
+++ b/shows/env_intel.yaml
@@ -1,5 +1,6 @@
 name: Environmental Intelligence
 slug: env_intel
+memory_enabled: true   # Aug 2026 expansion: narrative memory (regulatory arcs / world-news arcs) — see engine/show_memory.py.
 description: Daily environmental regulatory, science, and compliance briefing for Canadian environmental professionals covering all provinces, territories, and federal jurisdictions.
 
 sources:
@@ -173,6 +174,14 @@ keywords:
 
 min_articles: 5
 min_articles_skip: 2
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 
 # Per-show translation set (June 2026 "Spanish dropped network-wide" decision).
 # Env Intel is a lighter daily show like Models & Agents / First Principles —

--- a/shows/fascinating_frontiers.yaml
+++ b/shows/fascinating_frontiers.yaml
@@ -84,6 +84,14 @@ x_accounts:
   label: NASA Webb Telescope
   max_posts: 3
 min_articles_skip: 4
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 exclude_title_patterns:
 - full moon calendar
 - (moon|lunar) calendar

--- a/shows/hooks/env_intel.py
+++ b/shows/hooks/env_intel.py
@@ -12,6 +12,23 @@ as smooth letter sequences without explicit spelling.
 
 from __future__ import annotations
 
+from engine import show_memory
+
+_SLUG = "env_intel"
+
+
+def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
+    """Narrative memory (Aug 2026 expansion) — thin wrapper over
+    engine.show_memory, same shape as shows/hooks/fascinating_frontiers.py.
+    EI's compliance beats are multi-year regulatory arcs, the best fit for
+    longitudinal memory in the network."""
+    return show_memory.memory_pre_fetch(config, _SLUG)
+
+
+def post_generate(config, *, digest_text="", episode_num=None) -> None:
+    show_memory.memory_post_generate(
+        config, _SLUG, digest_text or "", episode_num or 0)
+
 
 def pronunciation_overrides() -> dict:
     """Return EI-specific pronunciation overrides."""

--- a/shows/hooks/omni_view.py
+++ b/shows/hooks/omni_view.py
@@ -1,0 +1,21 @@
+"""Omni View hooks — recursive narrative memory (Aug 2026 expansion).
+
+Thin wrapper over engine.show_memory; see shows/hooks/models_agents.py.
+World-news arcs run for months, and the Steel Man format benefits most
+from knowing where each arc stood last time it aired.
+"""
+
+from __future__ import annotations
+
+from engine import show_memory
+
+_SLUG = "omni_view"
+
+
+def pre_fetch(config, *, episode_num=None, today_str=None) -> dict:
+    return show_memory.memory_pre_fetch(config, _SLUG)
+
+
+def post_generate(config, *, digest_text="", episode_num=None) -> None:
+    show_memory.memory_post_generate(
+        config, _SLUG, digest_text or "", episode_num or 0)

--- a/shows/models_agents.yaml
+++ b/shows/models_agents.yaml
@@ -79,6 +79,14 @@ x_accounts:
   label: Simon Willison (AI builder)
   max_posts: 3
 min_articles_skip: 4
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 keywords:
 - ai model
 - language model

--- a/shows/models_agents_beginners.yaml
+++ b/shows/models_agents_beginners.yaml
@@ -118,6 +118,14 @@ keywords:
 - Google AI
 - Meta AI
 min_articles_skip: 2
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 multilingual:
   enabled: false
 llm:

--- a/shows/modern_investing.yaml
+++ b/shows/modern_investing.yaml
@@ -83,6 +83,14 @@ x_accounts:
   max_posts: 3
 min_articles: 6
 min_articles_skip: 3
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 keywords:
 - AI investing
 - algorithmic trading

--- a/shows/omni_view.yaml
+++ b/shows/omni_view.yaml
@@ -1,5 +1,6 @@
 name: Omni View
 slug: omni_view
+memory_enabled: true   # Aug 2026 expansion: narrative memory (regulatory arcs / world-news arcs) — see engine/show_memory.py.
 weekly_summary_segment: true   # July 2026: daily cadence; Sunday episode includes a short "week in review" segment (content lake).
 description: The day's most important stories from around the world — explained calmly,
   from every side, in plain language for everyone from teens to seniors.
@@ -125,6 +126,14 @@ x_accounts:
   label: Semafor
   max_posts: 3
 min_articles_skip: 4
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 keywords:
 - election
 - president

--- a/shows/planetterrian.yaml
+++ b/shows/planetterrian.yaml
@@ -93,6 +93,14 @@ x_accounts:
 
 min_articles_skip: 2
 
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
+
 # July 2 2026 scope-drift backstop: Planetterrian is a life-science show
 # (longevity / neuroscience / microbiome / cellular biology), but the
 # shared science RSS feeds (Phys.org, ScienceDaily, Science Magazine)

--- a/shows/prompts/env_intel_digest.txt
+++ b/shows/prompts/env_intel_digest.txt
@@ -9,6 +9,8 @@ ABSOLUTE RULE — ZERO STORY OVERLAP: Each article, event, announcement, or deve
 
 {news_section}
 
+{narrative_memory_section}
+
 You are an expert environmental science journalist with deep knowledge of Canadian environmental regulation across all provinces, territories, and the federal government. You are writing the daily "Environmental Intelligence" briefing. Your readers are Canadian environmental professionals — contaminated-sites consultants, remediation engineers, environmental lawyers, government regulators, and laboratory scientists working across multiple jurisdictions. They are experts. They do not need hand-holding. They need intelligence they can act on.
 
 **EXPERTISE (demonstrate this in every sentence):**

--- a/shows/prompts/omni_view_digest.txt
+++ b/shows/prompts/omni_view_digest.txt
@@ -115,3 +115,5 @@ Then end with:
 Here are the sections, stories, and allowed sources (JSON). Again: ONLY use these URLs in the Read more section:
 
 {sections_json}
+
+{narrative_memory_section}

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -125,6 +125,14 @@ x_accounts:
 min_articles: 8
 min_articles_skip: 5
 
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
+
 # July 2 2026: a pirate soccer-stream SEO title — "SpaceX Falcon 9
 # Launches Starlink 6-103 Fiorentina Vs Genoa (RvpT3PF26j)" — was
 # laundered into an on-air "fact" (Ep18 spoke "designated Fiorentina

--- a/shows/tesla.yaml
+++ b/shows/tesla.yaml
@@ -84,6 +84,14 @@ x_accounts:
 
 min_articles: 10
 min_articles_skip: 6
+
+# Story-recurrence memory (Aug 2026): inline "already covered — update,
+# don't re-tell" notes on fetched articles matching the ContentTracker's
+# recent-headline window. Built after the Fort Bend story ran in 5 of 10
+# Tesla episodes past three existing dedup layers. Data-side and
+# deterministic (engine/story_recurrence.py).
+story_recurrence: true
+
 min_audio_duration: 300
 
 # June 20 2026 review: MarketBeat/Defense-World-style 13F institutional-

--- a/tests/test_phase3_memory.py
+++ b/tests/test_phase3_memory.py
@@ -141,9 +141,25 @@ class TestRegistryAndConfig:
         assert cfg.memory_enabled is True
 
     def test_non_memory_show_defaults_false(self):
+        # omni_view joined the memory registry in the Aug 2026 expansion,
+        # so the no-memory example is now a lesson show that will never
+        # carry narrative memory (vocab_tracker owns its continuity).
         from engine.config import load_config
-        cfg = load_config(PROJECT_ROOT / "shows" / "omni_view.yaml")
+        cfg = load_config(PROJECT_ROOT / "shows" / "privet_russian.yaml")
         assert cfg.memory_enabled is False
+
+    def test_aug_2026_expansion_shows_enabled(self):
+        """env_intel (regulatory arcs) + omni_view (world-news arcs) —
+        the last two news-driven shows without narrative memory."""
+        from engine.config import load_config
+        from engine import show_memory
+        for slug in ("env_intel", "omni_view"):
+            cfg = load_config(PROJECT_ROOT / "shows" / f"{slug}.yaml")
+            assert cfg.memory_enabled is True, slug
+            assert show_memory.get_config(slug) is not None, slug
+            prompt = (PROJECT_ROOT / "shows" / "prompts" /
+                      f"{slug}_digest.txt").read_text(encoding="utf-8")
+            assert "{narrative_memory_section}" in prompt, slug
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_story_recurrence.py
+++ b/tests/test_story_recurrence.py
@@ -1,0 +1,200 @@
+"""Drift guards for the story-recurrence memory (Aug 2026).
+
+Built after the Fort Bend solar-factory story ran in 5 of 10 Tesla
+episodes (and 4 times inside Ep573) past three existing dedup layers:
+the 0.72 title-similarity / 2-day content_freshness check, the
+ContentTracker's flat DO-NOT-REPEAT list, and the exact-duplicate strip.
+The lever is data-side (reads the tracker's dated headline window, no
+LLM calls) and delivers inline update-don't-retell notes attached to the
+exact articles the model is deciding about — the DP Pod lever-memory
+pattern applied to news.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from engine.story_recurrence import (  # noqa: E402
+    RecurrenceIndex,
+    annotate_articles,
+    annotation_for,
+    recurrence_in_digest,
+    salient_tokens,
+)
+
+# The real Fort Bend headline variants that shipped across Tesla
+# Ep565-573 — the class the old layers missed because the titles are
+# lexically far apart while the story is identical.
+_FORT_BEND = [
+    "Tesla plans $10B solar cell factory in Fort Bend County",
+    "Tesla considers $10 billion solar cell plant in Fort Bend County",
+    "Tesla files tax incentive application for $10.1 billion Texas solar cell plant",
+    "Tesla seeks Texas tax incentive for USD-10bn solar cell factory",
+    "Tesla wants tax breaks to build solar manufacturing plant in Fort Bend County",
+]
+
+
+def _window(headlines_by_date):
+    return [{"date": d, "headlines": hs} for d, hs in headlines_by_date]
+
+
+class TestMatching:
+    def _index(self):
+        # Realistic window shape: ~8 headlines/day with the recurring
+        # story once per day. "tesla" crosses the common-token threshold
+        # (as in the real 15-episode window, where it is the ONLY common
+        # token); the story's own tokens must NOT — a token carried only
+        # by one recurring story is exactly the signal we match on.
+        filler = [
+            "Tesla recalls 20,000 vehicles over software issue",
+            "Tesla Optimus demonstrates new dexterity milestone",
+            "Tesla opens 124-stall Supercharger site in Arizona",
+            "Tesla FSD v14 expands to more HW3 vehicles",
+            "Tesla Semi fleet crosses one million miles",
+            "Tesla energy storage deployments hit quarterly record",
+            "Tesla Cybertruck production reaches new weekly high",
+            "Tesla insurance arm expands to three more states",
+            "Tesla megapack order lands with Australian utility",
+            "Tesla updates mobile app with charging planner",
+            "Tesla hires new head of battery engineering",
+            "Tesla robotaxi pilot adds Phoenix service area",
+            "Tesla dojo cluster milestone announced by AI team",
+            "Tesla model y refresh spotted at fremont factory",
+            "Tesla powerwall installations double year over year",
+            "Tesla earnings call scheduled for late october",
+            "Tesla wins fleet contract with logistics giant",
+            "Tesla adds v2h capability in new markets",
+            "Tesla shanghai exports rise on strong quarter",
+            "Tesla roadside assistance expands coverage hours",
+            "Tesla paint shop upgrade begins at giga berlin",
+        ]
+        return RecurrenceIndex(_window([
+            ("2026-08-10", [_FORT_BEND[0]] + filler[:7]),
+            ("2026-08-12", [_FORT_BEND[1]] + filler[7:14]),
+            ("2026-08-14", [_FORT_BEND[2]] + filler[14:21]),
+        ]))
+
+    def test_all_fort_bend_variants_match(self):
+        idx = self._index()
+        for v in _FORT_BEND:
+            m = idx.match(v)
+            assert m, f"re-headlined variant missed: {v!r}"
+
+    # A today's-article probe carrying the story's core tokens — the
+    # realistic case: a new development on the running story.
+    _TODAY_PROBE = "Tesla Fort Bend solar cell plant tax incentive approved"
+
+    def test_times_counts_distinct_days(self):
+        idx = self._index()
+        m = idx.match(self._TODAY_PROBE)
+        assert m and m["times"] == 3  # three window DAYS covered it
+
+    def test_most_recent_match_is_cited(self):
+        idx = self._index()
+        m = idx.match(self._TODAY_PROBE)
+        assert m["date"] == "2026-08-14", (
+            "the note says 'most recently on …' — it must cite the "
+            "newest matching day, not an older copy")
+
+    def test_unrelated_stories_do_not_match(self):
+        idx = self._index()
+        for title in (
+            "SpaceX launches 28 Starlink satellites from Florida",
+            "Tesla Cybertruck wins design award in Germany",
+            "Rivian announces new battery chemistry",
+        ):
+            assert idx.match(title) is None, title
+
+    def test_brand_token_alone_cannot_manufacture_a_match(self):
+        # "tesla" is in >30% of window headlines -> common -> excluded.
+        idx = self._index()
+        assert "tesla" in idx.common
+
+    def test_self_match_excluded_by_date(self):
+        idx = RecurrenceIndex(
+            _window([("2026-08-16", [_FORT_BEND[0]])]),
+            exclude_date="2026-08-16",
+        )
+        assert len(idx) == 0
+
+    def test_empty_window_is_a_clean_noop(self):
+        idx = RecurrenceIndex([])
+        assert idx.match(_FORT_BEND[0]) is None
+        assert annotate_articles([{"title": _FORT_BEND[0]}], idx) == {}
+
+
+class TestAnnotation:
+    def test_annotation_is_instruction_shaped(self):
+        note = annotation_for(
+            {"date": "2026-08-14", "headline": _FORT_BEND[2], "times": 3})
+        # The load-bearing framing: update, don't ban / don't re-tell.
+        assert "NEW development" in note
+        assert "UPDATE" in note
+        assert "never re-tell" in note
+        assert "hook" in note
+        # De-seed rule: the note must self-identify as instruction so an
+        # echo is detectable, and the sanitizer strips that marker.
+        assert note.strip().startswith("[ALREADY-COVERED NOTE")
+
+    def test_sanitizer_strips_an_echoed_note(self):
+        from engine.newsletter_sanitizer import scrub_scaffold
+        echoed = ("Real digest line.\n"
+                  "[ALREADY-COVERED NOTE — instruction, not content: x]\n"
+                  "Another real line.")
+        out = scrub_scaffold(echoed)
+        assert "ALREADY-COVERED" not in out
+        assert "Real digest line." in out and "Another real line." in out
+
+    def test_recurrence_in_digest_counts_matches(self):
+        idx = TestMatching()._index()
+        digest = (
+            "### Top News\n"
+            f"1. **{_FORT_BEND[4]}**\n   body\n"
+            "2. **Rivian announces new battery chemistry**\n   body\n"
+        )
+        assert recurrence_in_digest(digest, idx) == 1
+
+
+class TestWiring:
+    def test_config_field_exists_and_defaults_off(self):
+        from engine.config import load_config
+        cfg = load_config(_ROOT / "shows" / "unintended_consequences.yaml")
+        assert getattr(cfg, "story_recurrence") is False
+
+    def test_news_shows_opted_in(self):
+        for slug in ("tesla", "spacex", "omni_view", "fascinating_frontiers",
+                     "planetterrian", "models_agents",
+                     "models_agents_beginners", "modern_investing",
+                     "env_intel"):
+            data = yaml.safe_load(
+                (_ROOT / "shows" / f"{slug}.yaml").read_text())
+            assert data.get("story_recurrence") is True, slug
+
+    def test_lesson_and_narrative_shows_stay_off(self):
+        # Lesson shows revisit topics as CURRICULUM (vocab_tracker owns
+        # that); narrative-queue shows have their own no-repeat history.
+        for slug in ("finansy_prosto", "privet_russian",
+                     "unintended_consequences", "first_principles"):
+            data = yaml.safe_load(
+                (_ROOT / "shows" / f"{slug}.yaml").read_text())
+            assert not data.get("story_recurrence"), slug
+
+    def test_run_show_wires_annotation_and_metric(self):
+        src = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert "annotate_articles" in src
+        assert "story_recurrence_in_digest" in src
+        # The outcome metric must be computed against a window that
+        # EXCLUDES today (the FF Ep128 self-match class).
+        assert "exclude_date=datetime.date.today().isoformat()" in src
+
+    def test_salient_tokens_drop_stopwords(self):
+        toks = salient_tokens("Tesla says it will report new record today")
+        assert "says" not in toks and "will" not in toks and "new" not in toks
+        assert "tesla" in toks and "record" in toks


### PR DESCRIPTION
Operator-directed build: the story-recurrence memory from the Aug-15 flagship review, plus narrative memory expanded to the last two news-driven shows without it.

## Story-recurrence memory (`engine/story_recurrence.py`)

**The problem, measured**: the Fort Bend solar-factory story ran on **11 distinct days** of Tesla's current tracker window — 5 of 10 episodes re-told it from scratch, 4× inside Ep573 alone — past three existing dedup layers. The 0.72 title-similarity / 2-day `content_freshness` check can't see re-headlined multi-day recurrence ("plans $10B solar cell factory" vs "seeks Texas tax incentive for USD-10bn solar cell factory"), the ContentTracker's flat DO-NOT-REPEAT block is demonstrably ignored, and a ban is editorially wrong anyway — the new filing *deserves* coverage, as an update.

**The design** (DP Pod lever-memory pattern applied to news — data-side, deterministic, no LLM calls, no new storage):
- Salient-token matching over the dated headline window ContentTracker already persists, with an **automatic common-token filter** (doc-frequency): in the real Tesla window the only common token is "tesla", so the brand name can never manufacture a match. Verified against real data: all 5 shipped Fort Bend variants match; unrelated stories don't.
- Delivered **inline** — an `[ALREADY-COVERED NOTE — instruction, not content: …]` under the exact matched article in the digest prompt's listing, citing the most recent covering day and the day count, framed **update-don't-retell** (one clause of recap max, lead with what changed, never the hook again; if nothing is new, pick a different story).
- Enabled on the 9 daily news shows via `story_recurrence: true`; lesson shows (recurrence = curriculum) and narrative-queue shows (own no-repeat history) deliberately off; dp_pod/offshore_north lack tracker section patterns so it would no-op (noted for later).
- **Scoreable**: `story_recurrence_annotated` + `story_recurrence_in_digest` recorded per episode (window excludes today — the FF Ep128 self-match class). Ledger predictions filed in `docs/reviews/ledger/network.yaml`.
- Defense in depth: the sanitizer strips any echoed annotation line before reader surfaces.

## Narrative memory expansion (`engine/show_memory.py`)

**env_intel** (regulatory arcs are the best memory fit in the network — a consultation today is a gazetted rule next year): federal impact assessment, PFAS/emerging contaminants, carbon pricing, species at risk, water/effluent. **omni_view** (months-long world-news arcs feeding the Steel Man format): US-China, Russia-Ukraine, Middle East realignment, global trade, AI governance. Seeded conservatively — arc descriptions + open questions, zero speculative status claims; statuses accrue from coverage via the existing auto-freshness. Hooks wired, `memory_enabled: true`, Story Tracker pages will render once the first trackers commit.

## ⚠️ A/B-listen required (landmine #17)

- **`env_intel_digest.txt` + `omni_view_digest.txt`**: `{narrative_memory_section}` placeholder added (changes prompt context — same gate as the July 24 MIT/DP Pod expansion).
- The recurrence annotations also enter the digest prompt context on 9 shows — the notes are instruction-shaped and the model is told not to reproduce them, but the first post-merge episode on tesla/spacex is worth a read/listen. Any regression is one YAML flag per show to revert (`story_recurrence: false`).

`GROK_API_KEY` was not set in this session — `python run_show.py tesla --test` shows the annotated prompt's output before trusting it.

## Test results

Full suite **6,537 passed / 0 failed** (feedgen sandbox files excluded as before). New guards: `tests/test_story_recurrence.py` (15 tests: real Fort Bend variant matching, distinct-day counting, most-recent-day citation, common-token behavior, self-match exclusion, sanitizer strip, config default + per-show opt-in/opt-out, run_show wiring) + `test_phase3_memory.py` expansion pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015j6gYHJ5tEgpwX4mdvGbgU

---
_Generated by [Claude Code](https://claude.ai/code/session_015j6gYHJ5tEgpwX4mdvGbgU)_