### PR TITLE
Offshore North: web-search sentinel parse bug + de-seed hook/title examples

### DIFF
--- a/engine/fetcher.py
+++ b/engine/fetcher.py
@@ -1009,7 +1009,16 @@ def fetch_web_search_articles(
                 cache_key="nerra-fetch-web",
             )
 
-            if not text or "NO_RECENT_ARTICLES" in text:
+            # The sentinel check must not discard real results: on the
+            # 2026-08-16 offshore_north run the model returned a valid
+            # ARTICLE_TITLE/URL block (a Toronto Star feature on the very
+            # campaign the query asked about) FOLLOWED by a stray
+            # NO_RECENT_ARTICLES, and the old `in text` check threw the
+            # whole response away. Treat the sentinel as "empty" only when
+            # no article block accompanies it.
+            if not text or (
+                "NO_RECENT_ARTICLES" in text and "ARTICLE_TITLE" not in text
+            ):
                 logger.info("Web search: no recent articles for '%s'", query)
                 continue
 

--- a/shows/prompts/offshore_north_digest.txt
+++ b/shows/prompts/offshore_north_digest.txt
@@ -81,9 +81,9 @@ CONTINUITY BUDGET: at most ONE callback in the whole brief. Prefer a date over a
 # Offshore North
 **Week ending:** {today_str}
 
-**HOOK:** [One sentence, under 140 characters, that leads with the consequence or the stake — not just the event. It must be a FACT, not a tease. WEAK: "Big week for Canada Ocean Racing." STRONG: "A Vendée Globe podium boat is now training on Georgian Bay, and its skipper has one shot left at 2026 qualification." No URLs, no dates, no emoji, no question marks.]
+**HOOK:** [One sentence, under 140 characters, that leads with the consequence or the stake — not just the event. It must be a FACT, not a tease, and it obeys the accuracy rules above like every other sentence: never a stale plan stated as current fact, never a location the week's sources don't confirm. The 2026-08-16 draft's hook asserted the boat "remains" somewhere it had already left — the hook is the single most-repeated sentence in the episode's metadata, so a wrong hook is the worst possible wrong fact. No URLs, no dates, no emoji, no question marks.]
 
-**TITLE:** [The episode title for podcast apps: MAXIMUM 60 characters, a headline, not a sentence — podcast apps truncate anything longer. Shape: "EMIRA IV's last week in Collingwood". No episode number, no date, no trailing period. It names the week's biggest story; it is NOT the hook restated.]
+**TITLE:** [The episode title for podcast apps: MAXIMUM 60 characters, a headline, not a sentence — podcast apps truncate anything longer. A noun phrase naming THIS week's biggest story: typically a boat, skipper, or race plus what changed. No episode number, no date, no trailing period. It is NOT the hook restated, and it must be built from THIS brief's content — never from wording that appears in this prompt or the standing facts. Like every output, it obeys the accuracy rules: no stale plan or unconfirmed location stated as fact.]
 
 ━━━━━━━━━━━━━━━━━━━━
 ## The Canadian Boat

--- a/tests/test_offshore_north_weekly_fixes.py
+++ b/tests/test_offshore_north_weekly_fixes.py
@@ -728,3 +728,56 @@ class TestPositionReport:
     def test_accumulation_framing_present(self):
         src = _digest_prompt()
         assert "Never inflate a lock transit into a milestone" in src
+
+
+class TestWebSearchSentinelParsing:
+    """2026-08-16: query 1 returned a valid ARTICLE_TITLE/URL block (a
+    Toronto Star feature on the campaign) followed by a stray
+    NO_RECENT_ARTICLES — and the `in text` sentinel check discarded the
+    whole response. The sentinel is only meaningful with no article."""
+
+    def _run(self, fake_text, monkeypatch):
+        import engine.fetcher as fetcher
+        monkeypatch.setattr(
+            "digests.xai_grok.grok_generate_text",
+            lambda **kw: (fake_text, {}),
+            raising=False,
+        )
+        monkeypatch.setenv("GROK_API_KEY", "test-key")
+        return fetcher.fetch_web_search_articles(["test query"], keywords=[])
+
+    def test_article_plus_stray_sentinel_is_kept(self, monkeypatch):
+        text = (
+            "ARTICLE_TITLE: A real campaign feature\n"
+            "ARTICLE_URL: https://example.com/story\n"
+            "ARTICLE_DESCRIPTION: Something substantive.\n"
+            "ARTICLE_SOURCE: Toronto Star\n\n"
+            "NO_RECENT_ARTICLES"
+        )
+        articles = self._run(text, monkeypatch)
+        assert len(articles) == 1
+        assert articles[0]["title"] == "A real campaign feature"
+
+    def test_bare_sentinel_still_means_empty(self, monkeypatch):
+        assert self._run("NO_RECENT_ARTICLES", monkeypatch) == []
+
+
+class TestNoSeededTitleExample:
+    """The 2026-08-16 draft's TITLE was 'EMIRA IV's last week in
+    Collingwood' — the prompt's own example copied verbatim, asserting a
+    location the boat had left. De-seed by shape (network rule): no
+    quotable, plausible-content example in the TITLE or HOOK spec."""
+
+    def test_title_spec_has_no_quotable_example(self):
+        src = _digest_prompt()
+        assert "last week in Collingwood" not in src
+        assert "**TITLE:**" in src  # the spec itself survives
+
+    def test_hook_spec_has_no_location_asserting_example(self):
+        src = _digest_prompt()
+        assert "now training on Georgian Bay" not in src
+
+    def test_hook_and_title_specs_carry_the_accuracy_tie(self):
+        src = _digest_prompt()
+        # both metadata fields must be explicitly bound to the accuracy rules
+        assert src.count("obeys the accuracy rules") >= 2


### PR DESCRIPTION
Tonight's Ep2 regeneration **skipped again** — 924 words against the 950 floor, $0.16 spent, nothing shipped. The round-3 mechanisms all worked (web search fired with `always=True`, the freshness block injected correctly), but the logs surfaced two real defects, fixed here.

## 1. Sentinel parse bug (network-wide, `engine/fetcher.py`)

The "Canada Ocean Racing Scott Shawyer" query actually **found a Toronto Star feature about the campaign** ("The Everest of the Seas took one Canadian's life and broke another's dream. He's going anyway") — a valid `ARTICLE_TITLE`/`ARTICLE_URL` block. But the model appended a stray `NO_RECENT_ARTICLES` after it, and the `in text` sentinel check **discarded the entire response**. That's part of why tonight's web search netted 0-of-8. The sentinel now means "empty" only when no article block accompanies it. Unit-tested both ways.

## 2. Seeded examples in the metadata specs (digest prompt)

Tonight's draft TITLE was **"EMIRA IV's last week in Collingwood" — the prompt's own example copied verbatim**, asserting a location the boat left Aug 8–9; the HOOK likewise said the boat "remains" on Georgian Bay. Both specs carried quotable, plausible-content examples — the exact landmine this network has now shipped three generations of. The TITLE example and the STRONG-hook example ("now training on Georgian Bay") are replaced with shape descriptions, and both specs are explicitly bound to the accuracy rules (no stale plan or unconfirmed location in metadata). Guarded.

## What happens next

**The show's scheduled Monday cron fires at 06:07 UTC today** — its natural slot, with Monday-morning European press in the window. If this PR is merged before then, the run gets both fixes; either way the cron runs.

**The honest open question for you:** two consecutive Sunday-evening attempts produced 904- and 924-word scripts against the 950 floor. On a daily show a skip costs a day; on this weekly it costs the whole week. If Monday's run also skips, the choice is between accepting skip-weeks as the honest product of dead news weeks, or lowering this show's `min_podcast_word_floor` (e.g. 950 → 850, ~6-minute episodes ship on dead weeks). Deliberately **not** decided in this PR.

Also observed, not changed: `sailingscuttlebutt.com/feed` returned 403 on every pass tonight — if it persists, it's the MIT hard-403 feed class and needs replacing.

Testing: full suite **6,856 passed, 6 skipped**. New guards: `TestWebSearchSentinelParsing`, `TestNoSeededTitleExample`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKDLL1fvxxFMpZiXVyKe9d)_