### PR TITLE
Effectiveness audit + round 3: live search terms feed titles/tags, open-cliff retention instrument

### DIFF
--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -340,3 +340,43 @@ experiments:
       The recompute has been an open operator item in the MIT ledger
       since 2026-07-03. This change stops the unrun backfill from
       silently flattering the on-air number in the meantime.
+
+  - id: search-terms-loop
+    title: "Live search queries feed titles + tags"
+    area: reach
+    shipped: 2026-08-17
+    readout: 2026-08-31
+    status: reading
+    baseline: "EN search share 15% of channel views (2026-08-17); terms: starship flight 14, fsd v14.1 lite, ..."
+    target: >
+      EN YT_SEARCH share of views up vs 15%, and search terms appearing
+      in shipped titles/tags. The Analytics search-terms report now
+      flows per-show (token-matched, conservative) into
+      youtube_performance.json — the title prompt gets a LIVE SEARCH
+      QUERIES line and uploads prepend the matched terms as tags.
+    notes: >
+      Channel-level terms are attributed to a show only when they share
+      a meaningful token with its recent titles/hooks; unmatched terms
+      are dropped rather than sprayed across the channel. Metadata-only.
+
+  - id: long-open-cliff
+    title: "Long-form open cliff — hold at the 5% mark"
+    area: retention
+    shipped: 2026-08-17
+    readout: 2026-09-07
+    status: reading
+    metric: long_open_hold_5pct_en
+    baseline: 0.51
+    target: >
+      Mean EN audienceWatchRatio at 5% elapsed above 0.55. The curves
+      show ~half the audience gone inside the first 30-45 s while decay
+      flattens after 25% — the open is the dominant remaining retention
+      lever. This entry TRACKS the instrument (new dashboard card +
+      metric); the accelerating open, chapters, and the motion batch are
+      the levers currently in flight against it. Content-side changes
+      to the spoken open are audio (landmine #17) and stay operator-gated.
+    notes: >
+      Curves accrue nightly for each channel's top 5 recent longs.
+      Outliers worth studying: tesla-RU ep554 held 72% at 5%,
+      spacex ep65 68% — both had thumbnail/title promises the opening
+      delivered immediately.

--- a/docs/reviews/video_pipeline_review_2026_08_12.md
+++ b/docs/reviews/video_pipeline_review_2026_08_12.md
@@ -167,3 +167,43 @@ entry in the experiments register.
 - `pytest -x`/`maxfail=1` hid the second failure behind the first for
   two days — worth considering `--maxfail=5` in CI so one red guard
   can't mask others.
+
+## Effectiveness audit — 2026-08-17 (3 production days on)
+
+Measured from `api/youtube_stats.json` (generated 08-17, analytics
+through ~08-15; the 08-15+ motion-era renders are still inside the
+2-day analytics lag):
+
+- **Long-form median AVP 13.1% → 16.2%** (n=129 pre / 20 post-08-13) —
+  the chapters + caption-continuity batch is the change in that window.
+  Early and small-n, but the direction is right and the size (~24%
+  relative) is larger than any prior single-week move.
+- **Shorts median AVP 49.3% → 51.2%** (n=357/62).
+- **Retention curves (new instrument) localize the remaining lever**:
+  mean audienceWatchRatio at the 5% mark is EN 0.51 / RU 0.54 / FR
+  0.55 — half the audience leaves inside the first 30-45 s, then decay
+  flattens after 25%. Outliers that held (tesla-RU ep554 0.72, spacex
+  ep65 0.68) opened on exactly what the title promised.
+- **Traffic mix**: EN is 53% Shorts feed / 16% suggested / **15%
+  search** / 10% subscribers; RU is 98% Shorts feed; FR 89%. The EN
+  search queries are concrete and content-adjacent ("starship flight
+  14", "fsd v14.1 lite", "spacex flight 14") — demand that provably
+  exists and that nothing was feeding back into titles or tags.
+- All round-2 instruments verified live in production: traffic_sources
+  + search_terms on all 3 channels, 15 retention curves, policy
+  `shorts_pending`/`shorts_streak` hysteresis fields present (ru/spacex
+  correctly holding 3 with streak tracking).
+
+### Round 3 — shipped 2026-08-17
+
+- **Search-terms loop closed**: channel-level search terms are
+  token-matched to shows (conservative — unmatched terms drop) into
+  `youtube_performance.json`; the title prompt gains a LIVE SEARCH
+  QUERIES line and uploads prepend the matched terms as tags (through
+  the guarded `build_tags`). Register: `search-terms-loop`.
+- **Open-cliff instrument**: dashboard card "Long-form open cliff"
+  (mean hold at 5% by channel + per-video 5/10/25/50% ladder) and the
+  `long_open_hold_5pct_en` live metric (baseline 0.51). Register:
+  `long-open-cliff`. Content-side changes to the spoken open are audio
+  (landmine #17) and stay operator-gated; the in-flight levers against
+  it are chapters, the accelerating open, and the motion batch.

--- a/engine/video_metadata.py
+++ b/engine/video_metadata.py
@@ -327,6 +327,27 @@ _build_tags = build_tags
 # Public API
 # ---------------------------------------------------------------------------
 
+def _live_search_terms(config) -> List[str]:
+    """Live YouTube search queries matched to this show (best-effort).
+
+    Written by scripts/update_youtube_performance.py into the show's
+    youtube_performance.json from the Analytics search-terms report —
+    the literal queries already reaching the channel (EN measured 15%
+    of views from search, 2026-08-17). Prepending them as upload tags
+    aims the videos at demand that provably exists. [] on any failure.
+    """
+    try:
+        out_dir = Path(getattr(config.episode, "output_dir", "") or "")
+        path = (_REPO_ROOT / out_dir / "youtube_performance.json"
+                if not out_dir.is_absolute()
+                else out_dir / "youtube_performance.json")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        terms = [str(t).strip() for t in (data.get("search_terms") or [])]
+        return [t for t in terms if 3 <= len(t) <= 60][:6]
+    except Exception:  # noqa: BLE001 — tags must never block an upload
+        return []
+
+
 def build_pinned_comment_text(
     config, *, hook: str = "", episode_num: int = 0, today_str: str = "",
     rss_link: str = "", audio_url: str = "",
@@ -597,7 +618,8 @@ def build_long_form_metadata(
     except Exception:  # noqa: BLE001 — tags must never block an upload
         _entity_tags = []
     tags = _build_tags(
-        _entity_tags + list(config.youtube.tags or []),
+        _live_search_terms(config) + _entity_tags
+        + list(config.youtube.tags or []),
         list(getattr(config, "keywords", []) or []),
         network_tags=[],  # already merged into youtube.tags via _defaults.yaml
     )
@@ -726,7 +748,8 @@ def build_short_metadata(
     except Exception:  # noqa: BLE001
         _entity_tags = []
     tags = _build_tags(
-        _entity_tags + list(config.youtube.tags or []) + ["shorts", "podcast clip"],
+        _live_search_terms(config) + _entity_tags
+        + list(config.youtube.tags or []) + ["shorts", "podcast clip"],
         list(getattr(config, "keywords", []) or []),
         network_tags=[],
     )

--- a/management.html
+++ b/management.html
@@ -1180,6 +1180,36 @@
       grid.appendChild(card);
     }
 
+    // Where long-form viewers LEAVE — audience-retention curves (Aug 2026).
+    {
+      const rc = data.retention_curves || {};
+      const card = sectionCard("Long-form open cliff",
+        "audienceWatchRatio at 5/10/25/50% elapsed");
+      if (!rc.configured) {
+        card.appendChild(h("p", { class: "fine-list",
+          text: rc.note || "No retention curves yet." }));
+      } else {
+        const means = rc.mean_hold_5pct_by_channel || {};
+        const meanTxt = Object.keys(means).sort().map(
+          (ch) => ch.toUpperCase() + " " + Math.round(means[ch] * 100) + "%"
+        ).join(" · ");
+        card.appendChild(h("div", { class: "fine-list", style: "font-weight:600;",
+          text: "Audience still watching at the 5% mark (~30-45s): " +
+                (meanTxt || "—") }));
+        (rc.videos || []).slice(0, 8).forEach((r) => {
+          card.appendChild(h("div", { class: "fine-list",
+            text: r.show + " " + r.channel + " ep" + r.episode +
+                  " (" + fmtOrDash(r.views) + " views): " +
+                  Math.round(r.hold_5pct * 100) + "% → " +
+                  Math.round(r.hold_10pct * 100) + "% → " +
+                  Math.round(r.hold_25pct * 100) + "% → " +
+                  Math.round(r.hold_50pct * 100) + "%" }));
+        });
+        card.appendChild(h("p", { class: "fine-list", text: rc.note || "" }));
+      }
+      grid.appendChild(card);
+    }
+
     // Experiments in flight — the continuous-improvement register.
     {
       const card = sectionCard("Levers in flight",

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -2000,7 +2000,81 @@ def _experiment_live_metrics(root: Path) -> Dict[str, Any]:
             frag += 1
     out["dub_fragment_title_share_14d"] = (
         round(frag / total, 2) if total else None)
+
+    # Long-form open hold (Aug 2026, from the retention CURVES): mean
+    # audienceWatchRatio at 5% elapsed across the EN longs that carry a
+    # curve. The 2026-08-17 baseline read ~0.50 — half the audience gone
+    # inside the first ~30-45 s — making the open the dominant remaining
+    # retention lever. None until curves exist.
+    holds = []
+    for show in (stats.get("shows") or {}).values():
+        for v in show.get("videos", []):
+            curve = v.get("retention_curve")
+            if not curve or (v.get("channel") or "en") != "en":
+                continue
+            try:
+                pts = {float(p["t"]): float(p["ratio"]) for p in curve}
+                k = min(pts, key=lambda t: abs(t - 0.05))
+                holds.append(pts[k])
+            except (KeyError, TypeError, ValueError):
+                continue
+    out["long_open_hold_5pct_en"] = (
+        round(sum(holds) / len(holds), 2) if holds else None)
     return out
+
+
+def build_retention_curves_section(root: Path) -> Dict[str, Any]:
+    """Where long-form viewers actually LEAVE, from the per-video
+    audience-retention curves the analytics fetch collects for each
+    channel's top recent longs (Aug 2026). Renders as a dashboard card;
+    the honest-null rules apply — no curves means an unconfigured card,
+    never zeros.
+    """
+    stats = _load_json(root / "api" / "youtube_stats.json") or {}
+    rows: List[Dict[str, Any]] = []
+    by_channel: Dict[str, List[float]] = {}
+    for dir_name, show in (stats.get("shows") or {}).items():
+        for v in show.get("videos", []):
+            curve = v.get("retention_curve")
+            if not curve:
+                continue
+            try:
+                pts = {float(p["t"]): float(p["ratio"]) for p in curve}
+
+                def at(t, _p=pts):
+                    return _p[min(_p, key=lambda x: abs(x - t))]
+
+                ch = (v.get("channel") or "en").lower()
+                row = {
+                    "show": dir_name,
+                    "channel": ch,
+                    "episode": v.get("episode"),
+                    "views": v.get("views"),
+                    "hold_5pct": round(at(0.05), 2),
+                    "hold_10pct": round(at(0.10), 2),
+                    "hold_25pct": round(at(0.25), 2),
+                    "hold_50pct": round(at(0.50), 2),
+                }
+                rows.append(row)
+                by_channel.setdefault(ch, []).append(row["hold_5pct"])
+            except (KeyError, TypeError, ValueError):
+                continue
+    if not rows:
+        return {"configured": False,
+                "note": "No retention curves yet — they accrue from the "
+                        "nightly analytics fetch (top 5 recent longs per "
+                        "channel)."}
+    rows.sort(key=lambda r: -(r.get("views") or 0))
+    return {
+        "configured": True,
+        "as_of": stats.get("generated"),
+        "note": ("audienceWatchRatio at 5/10/25/50% elapsed. The 5% mark "
+                 "is ~30-45 s in — the open cliff. Baseline 2026-08-17: "
+                 "EN mean ~0.50 at 5%."),
+        "mean_hold_5pct_by_channel": {
+            ch: round(sum(v) / len(v), 2) for ch, v in by_channel.items()},
+        "videos": rows[:20],
+    }
 
 
 def build_experiments_section(root: Path) -> Dict[str, Any]:
@@ -2729,6 +2803,7 @@ def build_dashboard(root: Path, *, offline: bool = False, previous_flat: Optiona
         "content_lake": lake_section,
         "distribution": build_distribution_section(root),
         "youtube_policy": build_youtube_policy_section(root),
+        "retention_curves": build_retention_curves_section(root),
         "funnel": build_funnel_section(root),
         "benchmarks": benchmarks,
         "investor": investor,

--- a/scripts/update_youtube_performance.py
+++ b/scripts/update_youtube_performance.py
@@ -180,6 +180,48 @@ def _compose_kind_hints(videos: List[dict], *, channel: str = "en") -> str:
     return _build_hint(videos, channel=channel)
 
 
+def _show_search_terms(channels_block: Dict[str, dict],
+                       videos: List[dict],
+                       max_terms: int = 6) -> List[str]:
+    """The live YouTube search queries plausibly aimed at THIS show.
+
+    The Analytics API reports search terms per CHANNEL, but a channel
+    carries many shows — so a term is attributed to a show when it
+    shares a meaningful token with the show's recent video titles/hooks.
+    Deliberately conservative: an unmatched term is dropped rather than
+    handed to every show on the channel. These are the literal queries
+    already reaching the channel (EN measured 15% of views from search,
+    2026-08-17) — the highest-value tag/title input there is.
+    """
+    import re as _re
+
+    show_tokens: set = set()
+    for v in videos[-40:]:
+        for field in ("title", "hook"):
+            show_tokens.update(
+                t for t in _re.findall(r"[a-zа-яё0-9]+",
+                                       str(v.get(field) or "").lower())
+                if len(t) >= 4)
+    if not show_tokens:
+        return []
+    seen: set = set()
+    out: List[str] = []
+    show_channels = {(v.get("channel") or "en").lower() for v in videos}
+    for ch in sorted(show_channels):
+        for row in (channels_block.get(ch) or {}).get("search_terms") or []:
+            term = str(row.get("term") or "").strip().lower()
+            if not term or term in seen:
+                continue
+            term_tokens = {t for t in _re.findall(r"[a-zа-яё0-9]+", term)
+                           if len(t) >= 4}
+            if term_tokens & show_tokens:
+                seen.add(term)
+                out.append(term)
+            if len(out) >= max_terms:
+                return out
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--stats", default="api/youtube_stats.json")
@@ -191,9 +233,9 @@ def main() -> int:
                     stats_path)
         return 0
     try:
-        shows: Dict[str, dict] = (
-            json.loads(stats_path.read_text(encoding="utf-8")).get("shows") or {}
-        )
+        _stats_doc = json.loads(stats_path.read_text(encoding="utf-8"))
+        shows: Dict[str, dict] = _stats_doc.get("shows") or {}
+        channels_block: Dict[str, dict] = _stats_doc.get("channels") or {}
     except Exception as exc:
         logger.warning("Could not parse %s: %s — skipping", stats_path, exc)
         return 0
@@ -226,11 +268,17 @@ def main() -> int:
         if not out_dir.exists():
             logger.info("%s: no output dir — skipped", dir_name)
             continue
+        matched_terms = _show_search_terms(channels_block, videos)
+        if matched_terms:
+            hint = (hint + "\nLIVE SEARCH QUERIES already reaching this "
+                    "channel (fold the phrasing in when honest): "
+                    + "; ".join(matched_terms))
         out = {
             "schema_version": 2,
             "generated": _dt.datetime.now(_dt.timezone.utc).isoformat(),
             "video_count": len(videos),
             "title_hint": hint,
+            "search_terms": matched_terms,
         }
         for ch, h in hints.items():
             out[f"title_hint_{ch}"] = h

--- a/tests/test_youtube_feedback_loop.py
+++ b/tests/test_youtube_feedback_loop.py
@@ -449,3 +449,54 @@ class TestGalleryRetentionPrior:
         b = {"image_id": "b", "episode_date": "2026-07-01", "tags": [],
              "prompt": "", "caption": ""}
         assert [e["image_id"] for e in _rank([b, a], "")] == ["a", "b"]
+
+
+class TestSearchTermsLoop:
+    """Aug 2026: the Analytics search-terms report flows per-show into
+    youtube_performance.json (title hint line + upload tags)."""
+
+    def _mod(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "upd_perf", _ROOT / "scripts" / "update_youtube_performance.py")
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return m
+
+    def test_terms_match_by_token_overlap(self):
+        m = self._mod()
+        videos = [{"title": "Starship Flight 14 stacks for launch",
+                   "hook": "Starship news", "channel": "en"}]
+        channels = {"en": {"search_terms": [
+            {"term": "starship flight 14", "views": 50},
+            {"term": "house of the dragon", "views": 40},
+        ]}}
+        terms = m._show_search_terms(channels, videos)
+        assert "starship flight 14" in terms
+        # Unmatched terms are dropped, not sprayed across the channel.
+        assert "house of the dragon" not in terms
+
+    def test_no_terms_without_overlap(self):
+        m = self._mod()
+        assert m._show_search_terms({"en": {"search_terms": [
+            {"term": "starship", "views": 5}]}}, []) == []
+
+    def test_upload_tags_read_perf_search_terms(self, tmp_path):
+        from types import SimpleNamespace
+        import json as _json
+        import engine.video_metadata as vm
+        out_dir = tmp_path / "digests" / "showdir"
+        out_dir.mkdir(parents=True)
+        (out_dir / "youtube_performance.json").write_text(_json.dumps(
+            {"search_terms": ["starship flight 14", "fsd v14.1 lite"]}))
+        cfg = SimpleNamespace(episode=SimpleNamespace(
+            output_dir=str(out_dir)))
+        terms = vm._live_search_terms(cfg)
+        assert terms == ["starship flight 14", "fsd v14.1 lite"]
+
+    def test_live_search_terms_absent_file_is_empty(self):
+        from types import SimpleNamespace
+        import engine.video_metadata as vm
+        cfg = SimpleNamespace(episode=SimpleNamespace(
+            output_dir="/nonexistent/nowhere"))
+        assert vm._live_search_terms(cfg) == []


### PR DESCRIPTION
In-depth review of the recent batches against 3 days of production data, plus the next improvement round the data pointed at. Audit + details appended to `docs/reviews/video_pipeline_review_2026_08_12.md`.

## What the data says about the recent changes

- **Long-form median AVP 13.1% → 16.2%** in the chapters + caption-continuity window (n=20 post-08-13; early but the largest single-week move on record). Shorts 49.3% → 51.2%. The 08-15+ motion-era renders are still inside the ~2-day analytics lag.
- **All round-2 instruments verified live**: traffic-source splits + search terms on all 3 channels, 15 retention curves captured, policy `shorts_pending`/`shorts_streak` hysteresis working (ru/spacex holding 3 with streak tracking).
- **The retention curves localize the dominant remaining lever**: half the audience leaves inside the first 30–45 s (mean hold at the 5% mark: EN 0.51 / RU 0.54 / FR 0.55) and decay flattens after 25%. The outliers that held (tesla-RU ep554 at 0.72, spacex ep65 at 0.68) opened on exactly what their title promised.
- **EN gets 15% of views from search** with concrete, content-adjacent queries ("starship flight 14", "fsd v14.1 lite") that nothing was feeding back into titles or tags. RU is 98% Shorts-feed; FR 89%.

## Round 3 (this PR)

- **Search-terms loop closed**: `update_youtube_performance` token-matches the channel-level Analytics search terms to each show (conservative — unmatched terms drop rather than spray across the channel), writes them into `youtube_performance.json`, folds a `LIVE SEARCH QUERIES` line into the title-prompt hint, and both upload metadata builders prepend the matched terms as tags through the guarded `build_tags`. Register: `search-terms-loop` (readout 08-31).
- **Open-cliff instrument**: new dashboard card **"Long-form open cliff"** (per-channel mean hold at 5% + per-video 5/10/25/50% ladders) and a `long_open_hold_5pct_en` live metric (baseline 0.51) backing the `long-open-cliff` register entry (readout 09-07). Content-side changes to the spoken open are audio (landmine #17) and stay operator-gated — the in-flight levers against the cliff are chapters, the accelerating open, and the motion batch.

Metadata/dashboard-only — no audio changes. Drift guards: `tests/test_youtube_feedback_loop.py::TestSearchTermsLoop`, dashboard guards green.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_