### PR TITLE
Staged grok-4.6 trial: DP Pod script stage, FPD + UC whole-show, synth + reviewer

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -512,6 +512,15 @@ jobs:
           # what ends an overrun (2026-08-18 outage; drift guard in
           # tests/test_pipeline_safety.py::TestTimeoutEnvelope).
           PIPELINE_TIMEOUT_SECONDS: '3000'
+          # Per-request LLM timeout (engine/generator._call_grok). Raised
+          # 300 -> 600 for the 2026-08-18 staged grok-4.6 trial: measured
+          # 4.6 latency on the trial shows is 205-242s, and 600 gives the
+          # tail room without letting one hung stage burn the job — with
+          # SDK retries off, worst-case is 3 tenacity attempts x 600s =
+          # 30 min per LLM stage, still under the 50-min watchdog above.
+          # A grok-4.3 call is unaffected (this only bounds how long we
+          # wait for a hung request, it never slows a fast one).
+          NERRA_LLM_TIMEOUT_SECONDS: '600'
           # Single-pass video render (engine.video._single_pass_enabled).
           # Fuses the slideshow and composite into one ffmpeg graph,
           # removing an intermediate 1080p encode+decode: 23-34% faster

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1394,11 +1394,21 @@ one**. Everything is back on grok-4.3 (refusal fallback back on
 grok-4.20-reasoning; the translation pin deliberately stays grok-4.6 —
 it froze what `grok-latest` already served, and its small chunks never
 tripped a timeout). Experiment `network-grok-46-upgrade` is closed
-`reverted`; grok-4.6's hallucination profile remains UNMEASURED. **Any
-future model upgrade follows
+(status `done`, outcome REVERTED); grok-4.6's hallucination profile
+remains UNMEASURED. **Any future model upgrade follows
 [`docs/model_upgrade_playbook.md`](docs/model_upgrade_playbook.md)** —
 staged one-show-first rollout with a digest-latency gate — never a
-network-wide day-one flip.
+network-wide day-one flip. **The first staged trial started the same
+day** (operator-directed; experiment `staged-grok-46-trial`, readout
+2026-09-01): grok-4.6 on dp_pod's SCRIPT stage only, first_principles +
+unintended_consequences whole-show (narrative — no news fetch), and the
+synth + reviewer stages; `NERRA_LLM_TIMEOUT_SECONDS` raised to 600 in
+run-show.yml to cover 4.6 latency. Every daily NEWS show's digest/fetch
+stays grok-4.3 — scope pinned by
+`tests/test_llm_usage_pass.py::TestStagedGrok46Trial`. Reviewer
+FACTUAL_ERRORS comparisons from 2026-08-18 on must be cross-show under
+the same 4.6 reviewer, never against pre-08-18 history (the instrument
+changed with the trial).
 The review also shipped three silent-number fixes: (1) **search billed per CALL** ($5/1k, env
 `XAI_SEARCH_COST_PER_CALL`) — xAI dropped per-source billing and the usage
 object's source count, so 100% of credit files since 07-29 recorded $0

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -327,7 +327,10 @@ experiments:
     area: quality
     shipped: 2026-08-18
     readout: 2026-08-18
-    status: reverted
+    # 'done' is the register's closed state (the dashboard coerces unknown
+    # statuses to 'reading', which would render this as still active);
+    # the outcome — REVERTED same day — is the notes' first line.
+    status: done
     baseline: >
       grok-4.3 on digest/fetch/scripts/synth/titles/reviewer; 30d LLM
       token spend ~$25 (would be ~$47 at 4.6 rates on the same tokens);
@@ -371,6 +374,53 @@ experiments:
       is UNANSWERED — the experiment never reached an editorial readout.
       Any retry follows docs/model_upgrade_playbook.md: one show first,
       digest-latency gate before network-wide.
+  - id: staged-grok-46-trial
+    title: "grok-4.6 staged trial — dp_pod script, FPD+UC whole-show, synth, reviewer"
+    area: quality
+    shipped: 2026-08-18
+    readout: 2026-09-01
+    status: reading
+    baseline: >
+      All stages on grok-4.3 after the same-day revert of the network-wide
+      4.6 upgrade. dp_pod on 4.3: zero exclamation points in 27/30
+      episodes, Ep22 65% verbatim digest paste. FPD/UC: the accepted
+      grok-4.3 narrative-length plateau (briefs 848-1116w vs 1600 ask).
+      FPD/UC digest latency on 4.3: ~30-50s.
+    target: >
+      dp_pod scripts follow the delivery spec (exclamations/voice tags
+      present, shingle overlap with the digest clearly below the 65%/42%
+      worst cases). FPD/UC briefs come off the 4.3 plateau without the
+      banned podcast-side retries. No latency regressions: stage durations
+      in metrics_ep*.json stay under 50% of NERRA_LLM_TIMEOUT_SECONDS
+      (600s) and zero 'Slow LLM completion' warnings after week one.
+    criteria: >
+      Operator-directed staged rollout per docs/model_upgrade_playbook.md
+      (the first trial run under it). SCOPE: dp_pod llm.podcast_model
+      ONLY (digest stays 4.3); first_principles + unintended_consequences
+      whole-show (narrative — the brief is model-knowledge prose);
+      synth_model + reviewer_model in _defaults. Every daily NEWS show's
+      digest/fetch stays grok-4.3. REVERT TRIGGERS, any one suffices,
+      revert = delete the named pin: (1) an invented fact/date/name in an
+      FPD or UC story (these are factual histories) — judged against the
+      other shows' FACTUAL_ERRORS under the SAME 4.6 reviewer, never
+      against pre-08-18 history (the reviewer instrument changed this
+      date too); (2) a digest/script stage exceeding ~300s repeatedly or
+      any request timeout on a trial show; (3) a missed episode
+      attributable to the model; (4) dp_pod A/B-listen verdict against
+      the 4.6 scripts (landmine #17 — prose changes with the model).
+    notes: >
+      Follow-up to network-grok-46-upgrade (reverted for latency, not
+      quality — the quality question was never answered). Trial shows
+      were picked benefit-over-risk: dp_pod's dialogue writing is its
+      product and its 4.3 failures are documented writing-model
+      limitations; FPD/UC have no news fetch so a stronger model is the
+      only sanctioned length/depth lever; synth + reviewer are
+      analysis-stage, operator-gated or non-published. The four
+      biggest-prompt news shows (tesla, spacex, omni_view, MIT) stay
+      OFF 4.6 — highest hallucination stakes and the four that timed
+      out on outage day. NERRA_LLM_TIMEOUT_SECONDS raised 300 -> 600 in
+      run-show.yml (worst-case per stage 3 x 600s = 30 min, still under
+      the 50-min watchdog). Cost: ~+$3-5/mo at trial scope.
   - id: mit-verified-window-alpha
     title: "Modern Investing states verified-window alpha only"
     area: quality

--- a/engine/config.py
+++ b/engine/config.py
@@ -109,15 +109,16 @@ class LLMConfig:
     # A/B-listen required (landmine #17).
     podcast_model: str = ""
     # Synthesizer (weekly newsletter, monthly report, cross-show briefing)
-    # defaults. Empty synth_model means "use model".
-    synth_model: str = "grok-4.3"
+    # defaults. Empty synth_model means "use model". grok-4.6 since the
+    # 2026-08-18 staged trial (staged-grok-46-trial) — mirrors
+    # shows/_defaults.yaml.
+    synth_model: str = "grok-4.6"
     synth_max_tokens: int = 8000
     synth_temperature: float = 0.4
-    # Episode quality reviewer defaults. grok-4.3 pinned explicitly (the
-    # retired grok-4-1-fast-non-reasoning slug had been silently served
-    # by 4.3 since May 15); reverted from the short-lived 4.6 upgrade
-    # together with the primary on 2026-08-18.
-    reviewer_model: str = "grok-4.3"
+    # Episode quality reviewer defaults. grok-4.6 since the 2026-08-18
+    # staged trial (staged-grok-46-trial) — mirrors shows/_defaults.yaml,
+    # including the instrument-change caveat documented there.
+    reviewer_model: str = "grok-4.6"
     reviewer_max_tokens: int = 1500
     reviewer_temperature: float = 0.3
     # Optional xAI reasoning depth for models that support it (grok-4.5:

--- a/engine/synthesizer.py
+++ b/engine/synthesizer.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import calendar
 import json
+import os
 import logging
 import re
 from collections import Counter
@@ -18,6 +19,14 @@ from typing import Any, Dict, List, Optional
 
 from engine.content_lake import query_all_shows_range, query_show_range
 from engine.generator import _call_grok
+
+# Synth calls are the network's LARGEST completions (8k tokens), and the
+# synth workflows (weekly newsletter, monthly report) don't carry the
+# run-show env, so give them their own generous request timeout instead
+# of inheriting _call_grok's 300s default. 2026-08-18 staged grok-4.6
+# trial: 4.6 latency scales with completion size — 300s risks a timeout
+# on exactly the calls this module makes. Env-tunable for rollback.
+_SYNTH_TIMEOUT_S = float(os.environ.get("NERRA_SYNTH_TIMEOUT_SECONDS", "900"))
 
 logger = logging.getLogger(__name__)
 
@@ -564,6 +573,7 @@ def synthesize_weekly_newsletter(
             temperature=synth_temperature,
             max_tokens=synth_max_tokens,
             system_prompt=system_prompt,
+            timeout=_SYNTH_TIMEOUT_S,
         )
         envelope = _parse_envelope(
             text, show_name=show_name, week_ending=week_ending
@@ -711,6 +721,7 @@ Keep the tone authoritative and analytical. Target 2500-3500 words."""
             temperature=synth_temperature,
             max_tokens=synth_max_tokens,
             system_prompt=system_prompt,
+            timeout=_SYNTH_TIMEOUT_S,
         )
         logger.info(
             "[Synthesizer] Monthly report for %s %d-%02d: %d chars (model=%s)",
@@ -831,6 +842,7 @@ on connections that no single-domain publication would catch."""
                 "independent podcast network. You specialize in finding "
                 "cross-domain connections."
             ),
+            timeout=_SYNTH_TIMEOUT_S,
         )
         logger.info(
             "[Synthesizer] Cross-show briefing: %d chars (model=%s)",

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -1345,7 +1345,17 @@ def ai_review_episode(ep: EpisodeReview) -> None:
     reviewer_model, reviewer_max_tokens, reviewer_temperature = _load_reviewer_settings(ep.show_slug)
     try:
         from openai import OpenAI
-        client = OpenAI(api_key=api_key, base_url="https://api.x.ai/v1", timeout=120)
+        # max_retries=0: same contract as engine.generator._call_grok
+        # (2026-08-18 outage — the SDK's hidden internal retries tripled
+        # every hang under the caller's own retry logic). Timeout raised
+        # 120 -> 300 for the grok-4.6 reviewer (staged-grok-46-trial):
+        # 4.6 reasons before answering, and 120s was tuned for the
+        # effort-none 4.3 redirect this call used to ride.
+        client = OpenAI(
+            api_key=api_key, base_url="https://api.x.ai/v1",
+            timeout=float(os.environ.get("NERRA_LLM_TIMEOUT_SECONDS", 300)),
+            max_retries=0,
+        )
         extra = {}
         if reviewer_model.startswith("grok-4.3"):
             # Parity with the retired-slug redirect this call ran on from

--- a/shows/_defaults.yaml
+++ b/shows/_defaults.yaml
@@ -34,17 +34,24 @@ llm:
   # (primary is grok-4.3 again, so 4.3 can no longer be its own fallback).
   fallback_model: grok-4.20-reasoning
   # Synthesizer (weekly newsletter, monthly report, cross-show briefing).
-  # Follows the network primary (reverted with it 2026-08-18 — synth calls
-  # are the network's LARGEST completions, the worst case for 4.6 latency).
-  synth_model: grok-4.3
+  # grok-4.6 (2026-08-18 staged trial, operator-directed — experiment
+  # staged-grok-46-trial): analysis-stage output, not the daily critical
+  # path — synth jobs run in their own workflows with their own timeouts,
+  # and the raised NERRA_LLM_TIMEOUT_SECONDS covers 4.6 latency. The
+  # daily digest/script default above stays grok-4.3.
+  synth_model: grok-4.6
   synth_max_tokens: 8000
   synth_temperature: 0.4
-  # Episode quality reviewer. grok-4.3 pinned explicitly (2026-08-18 LLM
-  # usage pass; reverted from the same-day 4.6 upgrade with the primary).
-  # History: the original grok-4-1-fast-non-reasoning slug was RETIRED by
-  # xAI on May 15 and silently redirected to grok-4.3 at 4.3 billing —
-  # this pin makes that explicit.
-  reviewer_model: grok-4.3
+  # Episode quality reviewer. grok-4.6 (2026-08-18 staged trial,
+  # operator-directed — experiment staged-grok-46-trial): a sharper
+  # analyst on a short, non-published output; small calls, low latency
+  # risk. NOTE the instrument-change caveat: FACTUAL_ERRORS rates from
+  # this date on come from a different reviewer than the historical
+  # baseline, so the 4.6 shows' rates are read AGAINST THE OTHER SHOWS
+  # under this same reviewer, never against pre-08-18 history.
+  # (History: the original grok-4-1-fast-non-reasoning slug was RETIRED
+  # by xAI on May 15 and silently served by grok-4.3 at 4.3 billing.)
+  reviewer_model: grok-4.6
   reviewer_max_tokens: 1500
   reviewer_temperature: 0.3
   # Optional (July 2026): set to low|medium|high only when using a model

--- a/shows/dp_pod.yaml
+++ b/shows/dp_pod.yaml
@@ -134,9 +134,16 @@ llm:
   # 2026-08-18: the grok-4.5 podcast_model pin (experiment
   # dp-pod-script-model-45) was superseded by the operator-directed
   # NETWORK grok-4.6 upgrade — which was itself REVERTED the same day
-  # for latency, so the script stage now follows the grok-4.3 default
-  # like every other show. Score the 08-24 ledger predictions against
-  # the 4.5 episodes actually shipped (08-10 .. 08-18).
+  # for latency. Score the 08-24 ledger predictions against the 4.5
+  # episodes actually shipped (08-10 .. 08-18).
+  # 2026-08-18 (later, operator-directed STAGED trial per
+  # docs/model_upgrade_playbook.md — experiment staged-grok-46-trial):
+  # script stage back on 4.6. SCRIPT ONLY — the digest (the facts) stays
+  # on the grok-4.3 network default; dialogue quality is this show's
+  # product and its documented 4.3 failures (zero exclamations 27/30,
+  # 65% verbatim digest paste) are writing-model limitations. Revert =
+  # delete this line. A/B-listen the first episode (landmine #17).
+  podcast_model: grok-4.6
 
 tts:
   # Two-host dialogue mode: DAN:/PATRICK: labeled turns, one Grok voice per

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -19,6 +19,17 @@ multilingual:
   - fr
 llm:
   provider: xai
+  # 2026-08-18 STAGED grok-4.6 trial (operator-directed; experiment
+  # staged-grok-46-trial, per docs/model_upgrade_playbook.md). Narrative
+  # show: no news fetch — the brief IS model-knowledge prose, so a
+  # stronger model is the first sanctioned lever against the accepted
+  # grok-4.3 narrative-length plateau (podcast-side retries stay banned).
+  # Measured 4.6 latency on this show's digest: ~205s (fits the raised
+  # NERRA_LLM_TIMEOUT_SECONDS=600 with wide margin). Watch: reviewer
+  # FACTUAL_ERRORS vs the other shows on the same reviewer, stage
+  # durations in metrics_ep*.json, Slow-LLM-completion warnings.
+  # Revert = delete this line. A/B-listen the first episode (#17).
+  model: grok-4.6
   system_prompt_file: shows/prompts/first_principles_system.txt
   digest_prompt_file: shows/prompts/first_principles_episode.txt
   podcast_prompt_file: shows/prompts/first_principles_podcast.txt

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -13,6 +13,16 @@ multilingual:
   enabled: false
 llm:
   provider: xai
+  # 2026-08-18 STAGED grok-4.6 trial (operator-directed; experiment
+  # staged-grok-46-trial, per docs/model_upgrade_playbook.md). Narrative
+  # show: no news fetch — the brief is model-knowledge prose. Measured
+  # 4.6 latency on this show: digest ~215s, script ~208s (both fit the
+  # raised NERRA_LLM_TIMEOUT_SECONDS=600 with margin — this show's Ep093
+  # ran the full pipeline successfully on 4.6 on outage day). These are
+  # FACTUAL history stories, so the sharpest watch is invented
+  # facts/dates: reviewer FACTUAL_ERRORS vs the other shows on the same
+  # reviewer. Revert = delete this line. A/B-listen the first ep (#17).
+  model: grok-4.6
   system_prompt_file: shows/prompts/unintended_consequences_system.txt
   digest_prompt_file: shows/prompts/unintended_consequences_episode.txt
   podcast_prompt_file: shows/prompts/unintended_consequences_podcast.txt

--- a/tests/test_dp_pod_show.py
+++ b/tests/test_dp_pod_show.py
@@ -1030,5 +1030,5 @@ class TestLeverRotationMemory:
         network review). The digest/fetch stage must stay on the network
         default — grok-4.5's confident-hallucination rate is the wrong
         trade for the facts-first stage."""
-        assert CFG.llm.podcast_model in ("", "grok-4.5")
+        assert CFG.llm.podcast_model in ("", "grok-4.5", "grok-4.6")
         assert CFG.llm.model != "grok-4.5"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -850,13 +850,17 @@ class TestSystemPrompts:
         if not config_path.exists():
             pytest.skip(f"Config not found: {config_path}")
 
-        # grok-4.3 network-wide again since the 2026-08-18 revert of the
-        # same-day grok-4.6 upgrade (4.6 digest latency ran 5-10x and
+        # grok-4.3 is the network default since the 2026-08-18 revert of
+        # the same-day grok-4.6 upgrade (4.6 digest latency ran 5-10x and
         # timed out the four biggest shows — docs/model_upgrade_playbook.md).
-        # A future re-upgrade goes through that playbook's staged rollout,
-        # which will re-widen this set deliberately, one show at a time.
+        # grok-4.6 is allowed for the playbook's STAGED trial shows
+        # (experiment staged-grok-46-trial: first_principles + UC, both
+        # narrative). TestStagedGrok46Trial in test_llm_usage_pass.py pins
+        # the trial's exact scope — this set only says both ids are
+        # currently blessed somewhere on the network.
         allowed = {
             "grok-4.3",
+            "grok-4.6",
         }
         config = load_config(config_path)
         assert config.llm.model in allowed, (

--- a/tests/test_llm_usage_pass.py
+++ b/tests/test_llm_usage_pass.py
@@ -65,19 +65,18 @@ class TestNoLiveRetiredSlugs:
     def test_reviewer_default_is_an_explicit_priced_model(self):
         """The reviewer ran on the retired grok-4-1-fast-non-reasoning slug
         from 2026-05-15 to 2026-08-18 — served by grok-4.3 (effort none)
-        but costed at the retired model's 6x-cheaper rates. It is now
-        pinned to grok-4.3 explicitly (the same-day 4.6 upgrade was
-        reverted for latency) — the invariant is: an explicit, priced,
-        non-retired model id."""
+        but costed at the retired model's 6x-cheaper rates. grok-4.6
+        since the 2026-08-18 staged trial (staged-grok-46-trial) — the
+        invariant is: an explicit, priced, non-retired model id."""
         from engine.config import LLMConfig
         from engine.tracking import GROK_PRICING
 
-        assert LLMConfig().reviewer_model == "grok-4.3"
+        assert LLMConfig().reviewer_model == "grok-4.6"
 
         defaults = yaml.safe_load(
             (REPO_ROOT / "shows" / "_defaults.yaml").read_text(
                 encoding="utf-8"))
-        assert defaults["llm"]["reviewer_model"] == "grok-4.3"
+        assert defaults["llm"]["reviewer_model"] == "grok-4.6"
         assert defaults["llm"]["reviewer_model"] in GROK_PRICING
 
     def test_review_episodes_fallback_is_pinned_and_priced(self):
@@ -166,3 +165,78 @@ class TestDashboardCostBreakout:
         assert net30["images"] == pytest.approx(0.16)
         assert net30["search"] == pytest.approx(0.03)
         assert net30["total"] == pytest.approx(0.31)
+
+
+class TestStagedGrok46Trial:
+    """Scope guards for the 2026-08-18 staged grok-4.6 trial
+    (experiment ``staged-grok-46-trial`` — the first rollout run under
+    docs/model_upgrade_playbook.md).
+
+    The trial's whole safety argument is its SCOPE: dialogue/narrative
+    writing and analysis stages move, the facts-first news digests do
+    not. A pin quietly widening (or quietly disappearing) is exactly the
+    silent-config drift class this file exists for.
+    """
+
+    TRIAL_NARRATIVE_SHOWS = ("first_principles", "unintended_consequences")
+    NEWS_SHOWS_STAY_43 = (
+        "tesla", "spacex", "omni_view", "modern_investing",
+        "models_agents", "models_agents_beginners", "planetterrian",
+        "fascinating_frontiers", "env_intel", "finansy_prosto",
+        "privet_russian", "offshore_north",
+    )
+
+    def _load(self, slug):
+        from engine.config import load_config
+        return load_config(REPO_ROOT / "shows" / f"{slug}.yaml")
+
+    def test_trial_narrative_shows_are_on_46(self):
+        for slug in self.TRIAL_NARRATIVE_SHOWS:
+            assert self._load(slug).llm.model == "grok-4.6", slug
+
+    def test_dp_pod_script_stage_only(self):
+        """dp_pod's DIGEST must keep inheriting the grok-4.3 network
+        default — only the script stage rides 4.6."""
+        cfg = self._load("dp_pod")
+        assert cfg.llm.podcast_model == "grok-4.6"
+        assert cfg.llm.model == "grok-4.3"
+
+    def test_every_news_show_digest_stays_on_43(self):
+        """The four biggest-prompt shows timed out on 4.6 and the
+        facts-first digests carry the hallucination stakes — none of
+        them may follow the trial by accident."""
+        for slug in self.NEWS_SHOWS_STAY_43:
+            path = REPO_ROOT / "shows" / f"{slug}.yaml"
+            if not path.exists():
+                continue
+            assert self._load(slug).llm.model == "grok-4.3", slug
+
+    def test_request_timeout_covers_46_latency(self):
+        """Measured 4.6 latency on the trial shows is 205-242s — the
+        workflow must carry NERRA_LLM_TIMEOUT_SECONDS >= 600 while any
+        show is on 4.6, and the envelope arithmetic must still hold
+        (3 tenacity attempts x timeout under the 50-min watchdog)."""
+        wf = yaml.safe_load(
+            (REPO_ROOT / ".github" / "workflows" / "run-show.yml")
+            .read_text(encoding="utf-8"))
+        step = next(s for s in wf["jobs"]["run"]["steps"]
+                    if s.get("name") == "Run show pipeline")
+        llm_timeout = int(step["env"]["NERRA_LLM_TIMEOUT_SECONDS"])
+        watchdog = int(step["env"]["PIPELINE_TIMEOUT_SECONDS"])
+        assert llm_timeout >= 600
+        assert 3 * llm_timeout <= watchdog + 600, (
+            "one worst-case LLM stage must not be able to consume the "
+            "whole watchdog budget by itself"
+        )
+
+    def test_trial_models_are_priced(self):
+        from engine.tracking import GROK_PRICING
+        assert "grok-4.6" in GROK_PRICING
+        assert "grok-4.3" in GROK_PRICING
+
+    def test_trial_is_registered(self):
+        reg = yaml.safe_load(
+            (REPO_ROOT / "docs" / "experiments.yaml").read_text(
+                encoding="utf-8"))
+        ids = {e.get("id") for e in reg["experiments"]}
+        assert "staged-grok-46-trial" in ids


### PR DESCRIPTION
# Summary

Operator-directed follow-up to this morning's revert: move the five surfaces where grok-4.6's writing quality is the upside and the risk profile is manageable — the first rollout run under `docs/model_upgrade_playbook.md`. Registered as experiment **`staged-grok-46-trial`**, readout **2026-09-01**.

## What moves to 4.6

| Surface | Scope | Why |
|---|---|---|
| **DP Pod** | `llm.podcast_model` — **script stage only** | Its documented 4.3 failures are writing-model limitations (zero exclamations in 27/30 episodes, 65% verbatim digest paste); dialogue is the show's product. The facts-first digest **stays on 4.3**. |
| **First Principles** | whole show | Narrative, no news fetch — the brief is model-knowledge prose, and 4.6 is the only sanctioned lever against the accepted 4.3 narrative-length plateau (podcast-side retries stay banned). |
| **Unintended Consequences** | whole show | Same; and UC Ep093 already ran its **entire pipeline on 4.6 successfully on outage day** (digest 214.6s, script ~208s) — real end-to-end evidence it fits the envelope. |
| **Synthesizer** | `synth_model` in `_defaults` | Weekly newsletter / monthly report — analysis output, own workflows, not the daily critical path. |
| **Reviewer** | `reviewer_model` in `_defaults` | Sharper analyst on a short non-published output. |

Every daily **news** show's digest/fetch stays on grok-4.3 — the four biggest-prompt shows (tesla, spacex, omni_view, MIT) are both the latency casualties from this morning and the highest hallucination stakes.

## Ensuring it can't regress

- **Latency headroom**: `NERRA_LLM_TIMEOUT_SECONDS` raised 300 → 600 in `run-show.yml` (measured 4.6 latency on the trial shows: 205–242s). Envelope arithmetic still holds: worst-case stage = 3 tenacity attempts × 600s = 30 min, under the 50-min watchdog, under the 60-min hard kill.
- **Synth calls get their own timeout** (`NERRA_SYNTH_TIMEOUT_SECONDS`, default 900) inside `engine/synthesizer.py` — they're the network's largest completions and their workflows don't carry the run-show env.
- **Reviewer client hardened**: `review_episodes.py` built its own OpenAI client with a hardcoded 120s timeout (tuned for the effort-none 4.3 redirect) and the SDK's hidden default retries — the same landmine `_call_grok` had this morning. Now `max_retries=0` + env-driven timeout.
- **Scope drift guards**: `tests/test_llm_usage_pass.py::TestStagedGrok46Trial` pins that DP Pod's digest and every news show stay on 4.3, the trial shows are on 4.6, the workflow timeout covers 4.6 latency, both models are priced, and the experiment is registered. Full suite green (6,933 passed; the only exclusion is a sandbox-local pandas C-extension artifact — that file passes standalone, 38/38).
- **Honest measurement**: the reviewer instrument changes on the same date as the trial, so FACTUAL_ERRORS on the 4.6 shows is judged **cross-show under the same 4.6 reviewer**, never against pre-08-18 history — documented in `_defaults.yaml`, CLAUDE.md, and the experiment entry.
- **Register rendering fix**: the dashboard coerces unknown experiment statuses to "reading", so `network-grok-46-upgrade`'s `status: reverted` was displaying as an *active* experiment — now `done`, with the revert outcome leading its notes.

## Revert triggers (any one; each is a one-line revert)

1. An invented fact/date/name in an FPD or UC story (these are factual histories).
2. A trial show's stage repeatedly exceeding ~300s, or any request timeout.
3. A missed episode attributable to the model.
4. DP Pod A/B-listen verdict against the 4.6 scripts.

## ⚠️ A/B-listen required (landmine #17)

Prose changes with the model on **dp_pod, first_principles, and unintended_consequences** — listen to each show's first post-merge episode. I'll do a first-episode text check (stage durations, tics, slow-LLM warnings) after tomorrow's runs and report.

## Test plan

- Full suite: 6,933 passed, 6 skipped locally on the rebased tree.
- Trial-scope guards added and passing; experiments register validates (`test_dashboard_growth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ)_