### PR TITLE
Setup-step hang guard: fail fast instead of eating the day's slot

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -308,6 +308,15 @@ jobs:
           fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
+        # Hung-setup guard (2026-08-19): a GitHub-side cache/download
+        # stall froze this step for SIX HOURS on four shows' scheduled
+        # runs (FF/M&A/MAB/MIT all cancelled at the 6h job limit having
+        # produced nothing; FF's setup had already taken 46 min the day
+        # before). Normal is 1-2 min; 45 gives a degraded-but-moving
+        # install room while turning a genuine hang into a fast, LOUD
+        # failure the daily audit's retry path can recover the same
+        # morning instead of after the whole slot is gone.
+        timeout-minutes: 45
         with:
           python-version: '3.12'
           requirements-file: 'requirements.txt'
@@ -804,6 +813,7 @@ jobs:
           fetch-depth: 1
 
       - uses: ./.github/actions/setup-python
+        timeout-minutes: 45   # hung-setup guard — see the run job's note
         with:
           python-version: '3.12'
           requirements-file: 'requirements.txt'

--- a/tests/test_pipeline_safety.py
+++ b/tests/test_pipeline_safety.py
@@ -156,6 +156,23 @@ class TestTimeoutEnvelope:
             f"the step hard-kill ({step_limit_s}s) or it can never fire"
         )
 
+    def test_setup_steps_carry_a_hang_guard(self):
+        """2026-08-19: a GitHub-side stall froze the setup-python step for
+        SIX HOURS on four shows' scheduled runs (killed only by the 6h job
+        limit — four missed episodes, recovered by the audit's retry path
+        at 16:52). Every setup step in this workflow must carry its own
+        timeout so a hung dependency install fails fast and loud instead
+        of silently eating the day's slot."""
+        import yaml
+        wf = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        for job_name in ("run", "finalize"):
+            for step in wf["jobs"][job_name]["steps"]:
+                if str(step.get("uses", "")).endswith("actions/setup-python"):
+                    assert step.get("timeout-minutes"), (
+                        f"{job_name}: setup-python step needs timeout-minutes"
+                    )
+                    assert int(step["timeout-minutes"]) <= 60
+
     def test_llm_client_owns_no_retries(self):
         """_call_grok must create its OpenAI client with max_retries=0.
 


### PR DESCRIPTION
# Summary

Fixes the root cause of today's "4 missed episodes" page. This morning a GitHub-side cache/download stall froze the `setup-python` step for **six hours** on four shows' scheduled runs (fascinating_frontiers, models_agents, models_agents_beginners, modern_investing) — each killed only by GitHub's 6-hour job limit, each producing nothing. The pipeline step's 60-minute limit never applied because the hang was *before* it. FF's setup had already taken an anomalous 46 minutes yesterday — same degradation, now hanging outright.

The daily audit did its job (paged, then its retry path re-dispatched all four at 16:52), but the episodes ran ~9 hours late.

## Change

- Both `setup-python` steps in `run-show.yml` carry `timeout-minutes: 45`. Normal is 1–2 minutes; 45 tolerates a degraded-but-progressing install while turning a genuine hang into a fast, loud failure that the audit's retry path can recover the same morning.
- Drift guard: `TestTimeoutEnvelope::test_setup_steps_carry_a_hang_guard` asserts every setup step in the workflow has a bounded timeout.

## Not in this PR (context)

The audit's editorial findings today are the 4.6 reviewer's first cross-show read and worth noting: the two trial shows scored **9/10 and 9/10 with zero factual flags** (FPD, UC) while the 4.3 news shows drew repetition criticals and one real factual error (SpaceX Ep074 said Falcon Heavy has "nine Merlin engines"; it has 27). One reviewer flag is a false positive against show design: SpaceX's "off-topic" AI/Cursor segments are its charter's deliberate AI & Compute beat — the reviewer prompt doesn't know show charters, which is a candidate improvement for a future pass.

## Test plan

- `tests/test_pipeline_safety.py` + `tests/test_scheduling_punctuality.py`: 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ)_