### PR TITLE
MIT: give the learning loop variation, report alpha by approach, review late episodes

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -263,6 +263,7 @@ jobs:
         with:
           add-paths: |
             api/daily-review.json
+            api/review_coverage.json
           commit-message: "Daily audit artifacts"
 
       - name: Notify on operational problems

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,40 @@ today's work, not just explain yesterday's):
   actually committed, which is what makes them comparable with a $1,000
   share position. Early assignment is NOT modelled and the prompts
   require saying so. Guards: `TestOptionsPositions`.
+- **MIT's learned rules ROTATE, or the loop can never score any of them**
+  (2026-08-20). Across the first 15 stamped trades only two rule sets
+  ever existed, differing by one rule and only because the ledger
+  happened to change — four of five rules were common to both, so no rule
+  could be told apart from another and the (honest) scoreboard would have
+  stayed silent forever while looking like a working feedback loop.
+  `learning.rule_rotation` in [`shows/_trading_policy.yaml`](shows/_trading_policy.yaml)
+  now shows a rotating subset (4 slots from a ~6-rule pool, cycling on
+  the episode number, so it is reproducible from the trade record) which
+  gives every rule BOTH a with-rule and a without-rule arm. A rule that
+  demonstrates an edge is PINNED and stops rotating (`_proven_rule_ids`,
+  >=5 trades on both arms); `always_on: true` pins by hand for
+  safety-shaped rules. Do not "simplify" the selector back to
+  most-recent-N — that is what made attribution impossible. Guards:
+  `TestRuleRotation`.
+- **MIT reports alpha by strategy FAMILY, not just by sector**
+  (2026-08-20). 61 trades produced 61 unique free-text strategy strings,
+  so "are our momentum entries better than our valuation screens" was
+  unanswerable. `STRATEGY_FAMILIES` / `strategy_family()` is a closed
+  vocabulary REQUIRED on new picks and DERIVED from the free text for
+  history (unmatched => `other`, never forced). The block inherits the
+  window discipline: verified-window trades when there are enough,
+  otherwise labelled indicative-only and explicitly not for air. Guards:
+  `TestStrategyFamilies`.
+- **The daily audit reviews late episodes on a CATCH-UP pass** — it runs
+  at a fixed 16:15 UTC while shows finish anywhere from 09:32 to 19:41,
+  and anything later was logged "critical: Missed episode" then
+  auto-closed next day by confirming the FILE EXISTS, so its content was
+  never reviewed at all (four shows on 2026-08-19; a 32-episode
+  network-wide backlog at first run). `review_episodes.py` now reviews
+  the previous 3 days' unmarked episodes, tracked in
+  `api/review_coverage.json` (14-day prune, committed by daily-audit so
+  the pass is idempotent), capped at 10/run oldest-first because the AI
+  review calls Grok per episode. Guards: `TestReviewCatchUp`.
 - **MIT's rule scoreboard must refuse to claim what it cannot measure.**
   It was emitting FIVE identical `RETIREMENT CANDIDATE` verdicts (same 10
   trades, same -0.17% vs +0.43%) because all five rules were stamped on

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -601,3 +601,58 @@ experiments:
       The loop is allowed to say nothing — that is the fix. What would
       falsify it is a retirement flag appearing while every stamped trade
       still carries the same rule set.
+
+  - id: mit-rule-rotation
+    title: "Rule rotation gives the learning loop the variation it needs"
+    area: quality
+    shipped: 2026-08-20
+    readout: 2026-10-01
+    status: reading
+    baseline: "2 rule sets across 15 stamped trades, differing by one rule, arising by accident — 0 rules scoreable, ever"
+    target: >
+      >=4 distinct rule sets within 20 era trades, every rule carrying
+      both arms, and at least one genuinely scored rule by ~25 era trades.
+    criteria: >
+      If 0 rules are scoreable at readout despite the rotation running,
+      the pool (6 rules) is too small and needs widening — not more
+      waiting. If a rule scores well it is pinned automatically and stops
+      rotating, which is the intended end state, not a bug.
+    notes: >
+      This is an intervention on the product, not just the measurement:
+      some picks are now made without some rules. Proven and hand-pinned
+      rules never rotate out. Rotation is a pure function of the episode
+      number, so any pick's rule set is reproducible from the ledger.
+
+  - id: mit-strategy-families
+    title: "Alpha reported by approach, not only by sector"
+    area: quality
+    shipped: 2026-08-20
+    readout: 2026-10-01
+    status: reading
+    baseline: "61 trades, 61 unique free-text strategy strings, 0 groupable"
+    target: >
+      >=90% of new picks carry an explicit family, and at least one family
+      reaches 5 verified-window trades so the show can say on air which
+      approach is actually earning its keep.
+    notes: >
+      Derived retroactively for the 61 historic trades so the record is
+      groupable now. Inherits the window discipline — indicative-only and
+      not for air until computed over verified windows.
+
+  - id: network-review-catch-up
+    title: "Late-finishing episodes finally get content-reviewed"
+    area: quality
+    shipped: 2026-08-20
+    readout: 2026-09-10
+    status: reading
+    baseline: "4 shows unreviewed on 2026-08-19; a 32-episode network-wide backlog"
+    target: >
+      Zero episodes that finish after the audit window go permanently
+      unreviewed. The backlog drains at <=10/run and stays at 0.
+    criteria: >
+      Watch the AI-review cost line while the backlog drains — if it
+      spikes, lower CATCH_UP_MAX_PER_RUN rather than dropping the pass.
+    notes: >
+      Network-wide, not MIT-specific. The first run surfaced real findings
+      that had been invisible, including high cross-episode repetition on
+      MIT Ep139/140.

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -898,4 +898,91 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-08-20
+    pr: null
+    doc: docs/reviews/modern_investing_review_2026_08_20.md
+    reviewer: claude-code (operator question — further improvements)
+    summary: >
+      Audit for remaining improvements found four; three shipped. (1) The
+      learning loop was honest but POWERLESS - across 15 stamped trades
+      only two rule sets ever existed, differing by one rule and only
+      because the ledger happened to change. Four of five rules were
+      common to both, so no rule could ever be told apart from another and
+      the scoreboard would have stayed silent indefinitely while looking
+      like a working feedback loop. (2) 61 trades produced 61 UNIQUE
+      free-text strategy strings, so the show could report alpha by sector
+      but never by APPROACH - "are our momentum entries better than our
+      valuation screens" was unanswerable. (3) The daily audit runs at a
+      fixed 16:15 UTC while shows finish anywhere from 09:32 to 19:41; a
+      late episode was logged "critical: Missed episode" and auto-closed
+      next day by confirming the FILE EXISTS, so its content was never
+      reviewed. On 2026-08-19 that hit four shows at once, and the first
+      catch-up run found a 32-episode network-wide backlog.
+    shipped:
+      - "deterministic rule rotation (shows/_trading_policy.yaml
+        learning.rule_rotation) - 4 slots from a ~6-rule pool cycling by
+        episode number, giving every rule both a with-rule and a
+        without-rule arm; reproducible from the trade record"
+      - "proven rules are pinned and stop rotating; always_on: true pins
+        by hand for safety-shaped rules"
+      - "_proven_rule_ids scores a rule as proven only with >=5 trades on
+        both arms and a positive difference"
+      - "closed strategy-family vocabulary (10 families) REQUIRED on new
+        picks and DERIVED from free text for the 61 historic trades, so
+        per-approach alpha is reportable immediately"
+      - "_build_strategy_family_performance feeds the pick prompt and
+        inherits the window discipline - verified-window trades when there
+        are enough, otherwise labelled indicative-only and not for air"
+      - "review_episodes.py catch-up pass: episodes from the previous 3
+        days with no coverage mark are reviewed, tracked in
+        api/review_coverage.json (14-day prune), capped at 10 per run
+        oldest-first so the AI review cost never spikes"
+      - "daily-audit.yml commits api/review_coverage.json so the pass is
+        idempotent across CI runs"
+      - 18 new drift guards (TestRuleRotation, TestStrategyFamilies,
+        TestReviewCatchUp)
+    deferred:
+      - "LISTENER FEEDBACK LOOP - the biggest remaining gap. The system
+        learns from its trades, its rules, YouTube retention and an LLM
+        judge, but has NO path for a listener's experience to enter the
+        loop (zero mentions of reply/email/question in the podcast
+        prompt) despite running a newsletter that could carry one. For a
+        show that exists to teach investing, the one signal it never
+        collects is whether anyone learned anything. Needs an inbox and a
+        triage path — operator decision, not just code"
+      - "long-form YouTube retention 10% vs 33% on Shorts across 169
+        videos; long-form is where subscribers convert, but this is a
+        network-wide video problem"
+      - "audience flat at 221 downloads/30d (weekly 52/44/61/50)"
+      - "carried: the 8 pre-era trades reconciling to no market bar;
+        significance-qualifier accept-or-abandon; SnapTrade Phase-0"
+    predictions:
+      - metric: distinct rule sets stamped across era trades
+        baseline: "2 sets across 15 trades, differing by one rule, by accident"
+        expected: ">=4 distinct sets within 20 era trades, and every
+          active rule carrying both a with-rule and a without-rule arm"
+        verdict: pending
+        evidence: null
+      - metric: rules with enough evidence to be scored (>=5 trades on
+          both arms)
+        baseline: "0 - structurally impossible before rotation"
+        expected: ">=1 scored rule within ~25 era trades; if still 0 by
+          then, the pool is too small and needs widening rather than more
+          waiting"
+        verdict: pending
+        evidence: null
+      - metric: picks carrying an explicit strategy family
+        baseline: "0 - the field did not exist; 61 unique free-text strings"
+        expected: ">=90% of new picks, and a per-family record the show
+          can quote once any family reaches 5 verified-window trades"
+        verdict: pending
+        evidence: null
+      - metric: episodes that finish after the audit window and are never
+          content-reviewed
+        baseline: "4 on 2026-08-19 alone; a 32-episode backlog at first run"
+        expected: "0 - the catch-up pass reviews them within 3 days"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/docs/reviews/modern_investing_review_2026_08_20.md
+++ b/docs/reviews/modern_investing_review_2026_08_20.md
@@ -1,0 +1,132 @@
+# Modern Investing — making the learning loop able to learn
+
+**Date:** 2026-08-20
+**Scope:** operator question — are there further improvements to the show
+or the recursively-improving investing system.
+
+Four candidates were found by audit; three were chosen and are shipped
+here. The fourth (a listener feedback loop) is recorded as the biggest
+remaining gap.
+
+---
+
+## 1. The loop was honest but could never produce a verdict
+
+The 2026-08-19 pass stopped the rule scoreboard inventing findings. It did
+not give it the ability to produce real ones.
+
+Across the first 15 stamped trades, **only two rule sets have ever
+existed**:
+
+```
+13 trades: LL-015, LL-017, LL-028, LL-041, LL-054
+ 2 trades: LL-017, LL-028, LL-041, LL-054, LL-066
+```
+
+They differ by one rule, and that difference arose because the lesson
+ledger happened to change — not by design. Four of five rules are common
+to both sets, so those four can never be told apart from each other, and
+neither arm of the one that varies clears the 5-trade minimum. **The
+experiment had no variation, so it had no power.** It would have stayed
+silent indefinitely while looking like a working feedback loop.
+
+**Shipped: deterministic rule rotation.** Each pick is shown a rotating
+subset of the unproven rules (4 slots from a pool of ~6, cycling by
+episode number). Over ten episodes that produces five distinct rule sets
+and gives **every rule both a with-rule and a without-rule arm**, which is
+the precondition for attribution. Because the rotation is a pure function
+of the episode number, a reader auditing the ledger can recompute which
+rules were in effect on any pick.
+
+Two safeguards, because this is an intervention on the product and not
+just on the measurement:
+
+- **A rule that demonstrates an edge is pinned** and stops rotating. The
+  point is to find out which heuristics work, not to withhold ones already
+  known to.
+- **Anything can be pinned by hand** with `always_on: true` — intended for
+  safety-shaped rules, never for a hunch.
+
+Honest expectation: with a pool of 6 and 4 slots each rule sits out about
+a third of picks, so both arms reach the 5-trade minimum in roughly 20-25
+era trades. That is about five weeks at the current cadence. It is slow
+because the sample is small, not because the design is lazy — and it is
+the first time the number is reachable at all.
+
+## 2. The show could say which sectors worked, never which approaches
+
+61 trades produced **61 unique free-text strategy strings**. "Momentum
+play on earnings beat", "Earnings-surprise entry after reported beat",
+"AI momentum entry on earnings-revision catalyst" — three descriptions of
+what is arguably one method, with nothing to group them by. So
+"are our momentum entries better than our valuation screens?" was
+unanswerable, for the operator and for the audience, while the
+performance page happily reported alpha by sector.
+
+**Shipped: a closed strategy-family vocabulary** (momentum,
+mean_reversion, valuation, catalyst_event, earnings_surprise,
+dividend_income, macro_rotation, technical_breakout, merger_arb, other),
+required on every new pick *and derived from the existing free text* so
+the 61 historic trades are groupable immediately rather than starting the
+count from zero. Derivation is deterministic regex over the strategy
+string; an unmatched strategy becomes `other` rather than being forced
+into a wrong bucket.
+
+The resulting block feeds the pick prompt, and it inherits the same window
+discipline as every other number the show speaks: computed over
+verified-window trades when there are enough, otherwise labelled
+*"indicative only, do NOT quote these as measured results on air"*.
+
+## 3. The quality reviewer was skipping episodes silently
+
+The daily audit runs on a fixed cron at 16:15 UTC. Shows finish at wildly
+different times — MIT's last three episodes landed at 14:29, 19:41 and
+09:32 UTC. Anything finishing after the audit window was recorded as
+**"critical: Missed episode"**, and the next day an auto-close routine
+resolved the issue by confirming *the file now exists*.
+
+So a late episode got a false critical, a tidy auto-close, and **no
+content review at all** — its digest length, required sections,
+repetition, TTS artifacts and hallucination checks were never run. On
+2026-08-19 that happened to four shows at once: modern_investing,
+fascinating_frontiers, models_agents, models_agents_beginners.
+
+**Shipped: a catch-up pass.** The audit now also reviews episodes from the
+previous three days that carry no coverage mark, recording what it has
+reviewed in `api/review_coverage.json` (pruned to 14 days) so the pass is
+idempotent and the file persists across CI runs.
+
+The first run found a **32-episode network-wide backlog** and immediately
+surfaced real findings that had been invisible — including high
+cross-episode repetition on MIT Ep139 and Ep140 (23 and 21 already-covered
+stories). Catch-up is capped at 10 episodes per run, oldest first, because
+the AI review calls Grok once per episode and a 42-episode run would spike
+cost; the backlog drains over a few days at the same total cost.
+
+This one is network-wide, not MIT-specific.
+
+---
+
+## The gap that remains: nothing learns from listeners
+
+The system improves from its trades, its rules, YouTube retention, and an
+LLM judge scoring its own scripts. It has **no path for a listener's
+experience to enter the loop at all** — zero mentions of reply, email or
+question in the podcast prompt, despite the show running a newsletter that
+could carry one.
+
+For a show whose stated purpose is teaching people to invest better, the
+one signal it never collects is whether anyone learned anything. DP Pod
+already solved the mechanics of this (email replies as a submission
+channel, named on air). Deferred pending an operator decision, since it
+needs an inbox and a triage path rather than just code.
+
+## Also noted, not acted on
+
+- **Long-form YouTube retention is 10% against 33% on Shorts** (169
+  videos). Long-form is where subscribers convert, so the gap matters —
+  but it is a network-wide video problem, not a MIT one.
+- **Audience is flat**: 221 downloads/30d, weekly 52/44/61/50.
+- **Listener-value scores stepped from ~3.9 to ~7.3** around Ep128 and
+  have held, which is a real quality improvement showing up in an
+  independent gauge.

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -1937,6 +1937,100 @@ def _review_exit_code(
     return 0
 
 
+REVIEW_COVERAGE_PATH = PROJECT_ROOT / "api" / "review_coverage.json"
+CATCH_UP_DAYS = 3
+# Bound per run: the AI review calls Grok once per episode, and the first
+# run after this shipped found a 32-episode backlog. Draining it over a
+# few days costs the same in total but never spikes a single run, and the
+# oldest are taken first so nothing is starved.
+CATCH_UP_MAX_PER_RUN = 10
+_COVERAGE_RETENTION_DAYS = 14
+
+
+def _load_coverage() -> dict:
+    try:
+        return json.loads(REVIEW_COVERAGE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"reviewed": {}}
+
+
+def _save_coverage(state: dict, today: datetime.date) -> None:
+    """Persist which episodes have been content-reviewed, pruned to 14 days."""
+    cutoff = (today - datetime.timedelta(days=_COVERAGE_RETENTION_DAYS)).isoformat()
+    state["reviewed"] = {
+        k: v for k, v in (state.get("reviewed") or {}).items()
+        if k.split("|")[-1] >= cutoff
+    }
+    try:
+        REVIEW_COVERAGE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        REVIEW_COVERAGE_PATH.write_text(
+            json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not persist review coverage: %s", exc)
+
+
+def _episode_day(ep: "EpisodeReview", fallback: datetime.date) -> datetime.date:
+    """The date an episode belongs to, from its ``date`` field.
+
+    Accepts both the ISO and compact forms the discovery path produces;
+    a mangled value falls back to the run date rather than raising, since
+    coverage bookkeeping must never break a review.
+    """
+    raw = str(getattr(ep, "date", "") or "")
+    for fmt in ("%Y-%m-%d", "%Y%m%d"):
+        try:
+            return datetime.datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    return fallback
+
+
+def _coverage_key(slug: str, day: datetime.date) -> str:
+    return f"{slug}|{day.isoformat()}"
+
+
+def find_catch_up_episodes(
+    target_date: datetime.date, show_filter: str = "",
+    days: int = CATCH_UP_DAYS,
+) -> List[EpisodeReview]:
+    """Episodes from recent days that were never content-reviewed.
+
+    The audit runs on a fixed daily cron, but shows finish at wildly
+    different times — MIT's episodes have landed anywhere from 09:32 to
+    19:41 UTC. Anything finishing after the audit was recorded as
+    "critical: Missed episode" and then auto-closed the next day by
+    confirming the FILE EXISTS, so its digest, script and audio were
+    never actually checked. On 2026-08-19 that was four shows at once
+    (modern_investing, fascinating_frontiers, models_agents,
+    models_agents_beginners) — a quality loop that reported itself
+    healthy while reviewing nothing.
+
+    Returns episodes that now exist, were scheduled, and carry no
+    coverage mark.
+    """
+    covered = (_load_coverage().get("reviewed") or {})
+    caught: List[EpisodeReview] = []
+    for back in range(1, max(1, days) + 1):
+        day = target_date - datetime.timedelta(days=back)
+        for ep in discover_episodes(day, show_filter):
+            if covered.get(_coverage_key(ep.show_slug, day)):
+                continue
+            info = SHOW_REGISTRY.get(ep.show_slug, {})
+            if not _should_run_on(info.get("schedule", "daily"), day):
+                continue
+            caught.append(ep)
+    # Oldest first, then capped — a starved episode would otherwise sit
+    # behind newer ones forever.
+    caught.sort(key=lambda e: (str(getattr(e, "date", "")), e.show_slug))
+    if len(caught) > CATCH_UP_MAX_PER_RUN:
+        logger.info(
+            "Catch-up backlog is %d episodes; taking the oldest %d this run.",
+            len(caught), CATCH_UP_MAX_PER_RUN,
+        )
+        caught = caught[:CATCH_UP_MAX_PER_RUN]
+    return caught
+
+
 def run_review(
     target_date: datetime.date,
     create_issues: bool = False,
@@ -1958,6 +2052,24 @@ def run_review(
             logger.warning("Auto-close encountered an error: %s", exc)
 
     episodes = discover_episodes(target_date, show_filter)
+
+    # Catch-up: episodes that finished after a previous run's audit window
+    # and have therefore never been content-reviewed (see
+    # find_catch_up_episodes). Without this a late show is permanently
+    # invisible to the quality loop.
+    try:
+        catch_up = find_catch_up_episodes(target_date, show_filter)
+    except Exception as exc:  # pragma: no cover — never block the review
+        logger.warning("Catch-up discovery failed: %s", exc)
+        catch_up = []
+    if catch_up:
+        logger.info(
+            "Catch-up: %d episode(s) from previous days were never reviewed "
+            "(finished after their audit window): %s",
+            len(catch_up),
+            ", ".join(f"{e.show_slug} Ep{e.episode_num:03d}" for e in catch_up),
+        )
+        episodes = episodes + catch_up
 
     # --- Missed episode detection ---
     missed_issues = check_missed_episodes(target_date, episodes, show_filter)
@@ -1993,6 +2105,19 @@ def run_review(
         check_story_duplication(ep)
         check_tts_artifacts(ep)
         check_hallucination_patterns(ep)  # New: detect common LLM fabrication patterns from past incidents (e.g. May 29 2026)
+
+    # Mark every episode reviewed in this run, so the catch-up pass never
+    # re-reports the same one and a late show is caught exactly once.
+    if not show_filter:
+        try:
+            state = _load_coverage()
+            reviewed = state.setdefault("reviewed", {})
+            for ep in episodes:
+                day = _episode_day(ep, target_date)
+                reviewed[_coverage_key(ep.show_slug, day)] = True
+            _save_coverage(state, target_date)
+        except Exception as exc:  # pragma: no cover — never block the review
+            logger.warning("Could not record review coverage: %s", exc)
 
     # Cross-episode checks
     check_cross_episode_duplicates(episodes)

--- a/shows/_trading_policy.yaml
+++ b/shows/_trading_policy.yaml
@@ -104,6 +104,32 @@ options:
     covered_call: hundred_times_underlying_entry
     cash_secured_put: hundred_times_strike
 
+learning:
+  # The rule scoreboard can only attribute an effect to a rule if some
+  # picks were made WITH it and some WITHOUT. Across the first 15 stamped
+  # trades only two rule sets were ever used, differing by a single rule
+  # and arising by accident (the lesson ledger changed) rather than by
+  # design — so no rule could be scored, and the honest scoreboard was
+  # permanently silent. Rotation gives the experiment the variation it
+  # needs.
+  rule_rotation:
+    enabled: true
+    # How many unproven rules are shown on any one pick. Fewer than the
+    # pool size, or nothing ever rotates out. With a pool of 6 and 4
+    # slots, each rule is absent from a third of picks and both arms
+    # accrue in ~20 trades.
+    slots: 4
+    # A rule that has DEMONSTRATED an edge is pinned and never rotated
+    # out — the point is to learn which heuristics work, not to withhold
+    # ones already known to. Rules can also be pinned by hand with
+    # `always_on: true` in lessons_learned.json (use it for anything
+    # safety-shaped, never for a hunch).
+    pin_proven: true
+  disclosure: >
+    Which rules were in effect on each pick is recorded on the trade and
+    published in the ledger, so the rotation is auditable rather than a
+    hidden variable.
+
 benchmark:
   # The index is bought and sold on the SAME sessions as the trade, so the
   # comparison answers "did this pick beat the index over the time it was

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -331,6 +331,8 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # are producing alpha and which are underperforming, so it can refine
     # future trade selection. The regime check (rolling streak + drawdown
     # → selection pressure) rides in the same prompt slot.
+    context["strategy_family_performance"] = (
+        _build_strategy_family_performance(tracker))
     strategy_block = _build_strategy_performance(tracker)
     regime = _build_regime_block(tracker)
     if regime:
@@ -681,7 +683,9 @@ def post_generate(config, *, digest_text: str = "", episode_num: int | None = No
             pick_day_lessons = _load_lessons_learned(
                 output_dir / LESSONS_LEARNED_FILENAME)
             trade["rules_in_effect"] = [
-                e["id"] for e in _selected_active_rules(pick_day_lessons)
+                e["id"] for e in _selected_active_rules(
+                    pick_day_lessons, episode_num=episode_num,
+                    tracker=tracker)
             ]
         except Exception as exc:  # noqa: BLE001
             logger.warning("rules_in_effect stamping failed: %s", exc)
@@ -3373,7 +3377,180 @@ def _is_trading_rule(entry: dict) -> bool:
     return not _PIPELINE_RULE_RE.search(text)
 
 
-def _selected_active_rules(data: dict, *, max_active: int = 5) -> list[dict]:
+# ---------------------------------------------------------------------------
+# Strategy families (2026-08-20)
+# ---------------------------------------------------------------------------
+# 61 trades produced 61 UNIQUE free-text strategy strings, so the show could
+# report which SECTORS worked but never which APPROACHES did — "are our
+# momentum entries better than our valuation screens?" was unanswerable for
+# the operator and for the audience. A closed vocabulary makes per-strategy
+# alpha reportable; deriving it from the existing text makes the 61 historic
+# trades usable immediately instead of starting the count from zero.
+#
+# Order matters: the first family whose pattern matches wins, so the more
+# specific ones are listed first.
+STRATEGY_FAMILIES: list[tuple[str, str]] = [
+    ("merger_arb", r"\bm&a\b|merger|acquisition|takeover|arb\b|spread capture"),
+    ("earnings_surprise", r"earnings[- ](beat|surprise|revision|driven|momentum)|"
+                          r"beat and|post-earnings|reported beat"),
+    ("dividend_income", r"dividend|distribution|yield|buyback|issuer bid|"
+                        r"covered call|cash[- ]secured put"),
+    ("catalyst_event", r"catalyst|announced|launch|approval|contract win|"
+                       r"policy|regulatory|phase 3|data readout"),
+    ("valuation", r"valuation|value assessment|multiple|cheap|discount|"
+                  r"free cash flow|screen on"),
+    ("mean_reversion", r"mean[- ]reversion|contrarian|oversold|recovery from|"
+                       r"fade of|rebound"),
+    ("technical_breakout", r"breakout|technical|moving average|range|"
+                           r"chart|support|resistance"),
+    ("macro_rotation", r"macro|sector rotation|rotation into|geopolitical|"
+                       r"rate|cross-asset|commodity"),
+    ("momentum", r"momentum|follow-through|price action|relative strength"),
+]
+
+
+def strategy_family(trade: dict) -> str:
+    """The closed-vocabulary family for a trade's strategy.
+
+    Prefers an explicit ``strategy_family`` written by the digest; falls
+    back to deriving one from the free-text strategy so the historic
+    record is groupable too. ``other`` when nothing matches — an honest
+    bucket beats forcing a wrong label.
+    """
+    explicit = (trade.get("strategy_family") or "").strip().lower()
+    known = {name for name, _ in STRATEGY_FAMILIES}
+    if explicit in known:
+        return explicit
+    text = f"{trade.get('strategy', '')} {trade.get('target_range', '')}".lower()
+    for name, pattern in STRATEGY_FAMILIES:
+        if re.search(pattern, text):
+            return name
+    return "other"
+
+
+def _build_strategy_family_performance(tracker: dict, *,
+                                       min_trades: int = 3) -> str:
+    """Per-approach scoreboard for the pick prompt.
+
+    Sector performance answers "what have we been buying"; this answers
+    "which of our methods actually works", which is the question the show
+    is nominally in business to resolve.
+    """
+    from collections import defaultdict
+
+    def _usable(t: dict) -> bool:
+        alpha = t.get("alpha_pct")
+        return (t.get("status") == "closed"
+                and isinstance(alpha, (int, float)) and math.isfinite(alpha))
+
+    # Same window discipline as every other number this show speaks:
+    # prefer trades whose benchmark window was built by the pick-date
+    # aligned path. Fall back to the legacy windows only when the verified
+    # set is too thin to say anything — and then SAY it is legacy, so this
+    # block can never be quoted as if it carried the same weight.
+    closed = [t for t in tracker.get("trades", []) if _usable(t)]
+    verified = [t for t in closed if t.get("entry_bar_date")]
+    if len(verified) >= min_trades * 2:
+        pool, scope = verified, "verified-window trades"
+    else:
+        pool, scope = closed, (
+            "trades that INCLUDE pre-2026-08-18 benchmark windows — "
+            "indicative only, do NOT quote these as measured results on air"
+        )
+
+    buckets: dict[str, list[float]] = defaultdict(list)
+    for t in pool:
+        buckets[strategy_family(t)].append(t["alpha_pct"])
+
+    if not buckets:
+        return ""
+    ranked = sorted(
+        ((name, vals) for name, vals in buckets.items()
+         if len(vals) >= min_trades),
+        key=lambda kv: sum(kv[1]) / len(kv[1]), reverse=True,
+    )
+    if not ranked:
+        return ""
+    lines = [f"STRATEGY-FAMILY RECORD (alpha by APPROACH, not by sector; "
+             f"computed over {scope}):"]
+    for name, vals in ranked:
+        mean = sum(vals) / len(vals)
+        beat = sum(1 for a in vals if a > 0)
+        note = ""
+        if len(vals) < _MIN_SAMPLE_TRADES:
+            note = " — too few to lean on"
+        lines.append(
+            f"- {name}: {mean:+.2f}% mean alpha over {len(vals)} trades "
+            f"({beat} beat the benchmark){note}"
+        )
+    thin = [n for n, v in buckets.items() if len(v) < min_trades]
+    if thin:
+        lines.append(
+            f"- Not yet scoreable ({min_trades}-trade minimum): "
+            + ", ".join(sorted(thin))
+        )
+    lines.append(
+        "Favour approaches with a positive record and enough trades behind "
+        "it. When choosing one with a negative record, say what is "
+        "different about today's setup rather than ignoring the history."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _proven_rule_ids(tracker: dict | None, data: dict) -> set[str]:
+    """Rules that have demonstrated an edge, or are pinned by hand.
+
+    A proven rule is never rotated out: the point of rotation is to learn
+    which heuristics work, not to withhold one already known to.
+    """
+    pinned = {
+        e["id"] for e in (data.get("entries") or [])
+        if e.get("always_on") and e.get("id")
+    }
+    if not tracker:
+        return pinned
+    closed = [
+        t for t in tracker.get("trades", [])
+        if t.get("status") == "closed" and _in_era(t)
+        and isinstance(t.get("alpha_pct"), (int, float))
+        and math.isfinite(t["alpha_pct"])
+    ]
+    for entry in (data.get("entries") or []):
+        rid = entry.get("id")
+        if not rid:
+            continue
+        with_rule = [t for t in closed
+                     if rid in (t.get("rules_in_effect") or [])]
+        without = [t for t in closed
+                   if rid not in (t.get("rules_in_effect") or [])]
+        if len(with_rule) < _MIN_SAMPLE_TRADES or len(without) < _MIN_SAMPLE_TRADES:
+            continue
+        avg_with = sum(t["alpha_pct"] for t in with_rule) / len(with_rule)
+        avg_without = sum(t["alpha_pct"] for t in without) / len(without)
+        if avg_with > avg_without:
+            pinned.add(rid)
+    return pinned
+
+
+def _rotate(pool: list[dict], slots: int, episode_num: int | None) -> list[dict]:
+    """A deterministic, evenly-cycling subset of *pool*.
+
+    Deterministic on the episode number so the selection is reproducible
+    from the trade record — a listener auditing the ledger can recompute
+    which rules were in effect. Consecutive-with-wraparound gives every
+    rule the same exposure over a cycle instead of the lumpy coverage a
+    hash would produce.
+    """
+    if slots >= len(pool) or slots <= 0:
+        return pool
+    offset = (episode_num or 0) % len(pool)
+    doubled = pool + pool
+    return doubled[offset:offset + slots]
+
+
+def _selected_active_rules(data: dict, *, max_active: int = 5,
+                           episode_num: int | None = None,
+                           tracker: dict | None = None) -> list[dict]:
     """The distinct active rules shown to the LLM today (most recent first).
 
     Shared by the prompt block AND the trade-stamping in post_generate so
@@ -3384,21 +3561,38 @@ def _selected_active_rules(data: dict, *, max_active: int = 5) -> list[dict]:
         e for e in (data.get("entries") or [])
         if e.get("status") == "active" and _is_trading_rule(e)
     ]
-    selected: list[dict] = []
+
+    # Distinct rules, most recent first. Deduped over the WHOLE pool, not
+    # just the first max_active, so pinning below can reach a proven rule
+    # that recency alone would have pushed out of the window.
+    eligible: list[dict] = []
     for entry in reversed(entries):
-        if len(selected) >= max_active:
-            break
         if any(
             _lesson_similarity(entry.get("adjustment", ""), s.get("adjustment", ""))
             >= _LESSON_SIMILARITY_THRESHOLD
             or _lesson_similarity(
                 _rule_core(entry.get("adjustment", "")),
                 _rule_core(s.get("adjustment", ""))) >= _RULE_CORE_THRESHOLD
-            for s in selected
+            for s in eligible
         ):
             continue
-        selected.append(entry)
-    return selected
+        eligible.append(entry)
+
+    # Rotation (2026-08-20). Without it the stamped rule set is constant
+    # between ledger edits, every trade carries the same rules, and no
+    # rule can ever be told apart from any other — the scoreboard is
+    # honest and permanently silent. Proven rules stay pinned; the rest
+    # cycle so each accrues both a with-rule and a without-rule arm.
+    pol = ((load_policy().get("learning") or {}).get("rule_rotation") or {})
+    if pol.get("enabled") and len(eligible) > 1:
+        proven = (_proven_rule_ids(tracker, data)
+                  if pol.get("pin_proven", True) else set())
+        pinned = [e for e in eligible if e.get("id") in proven]
+        pool = [e for e in eligible if e.get("id") not in proven]
+        slots = max(1, int(pol.get("slots", 4)) - len(pinned))
+        return (pinned + _rotate(pool, slots, episode_num))[:max(
+            max_active, len(pinned) + 1)]
+    return eligible[:max_active]
 
 
 def _build_lessons_learned_block(data: dict, *, max_active: int = 5) -> str:
@@ -3941,6 +4135,11 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
 
     # Options structure (2026-08-19). Absent or "shares" => a plain long
     # equity position, which is every trade before this date.
+    family_match = re.search(
+        r"\*\*Strategy Family:\*\*\s*\[?([a-z_]+)", digest_text, re.IGNORECASE)
+    strategy_family_raw = (
+        family_match.group(1).strip().lower() if family_match else "")
+
     structure_match = re.search(
         r"\*\*Structure:\*\*\s*\[?([A-Za-z \-_]+)", digest_text)
     structure = ""
@@ -3978,6 +4177,7 @@ def _extract_trade_from_digest(digest_text: str, episode_num: int | None = None)
         "target_range": target,
         "invalidation": invalidation,
         "structure": structure or "long_equity",
+        "strategy_family": strategy_family_raw,
         "trade_type": trade_type,
         "policy_version": load_policy().get("version"),
         "horizon_sessions": horizon_sessions(trade_type),

--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -63,6 +63,9 @@ If any item above overlaps with a story you are about to lead with, change cours
 
 **PORTFOLIO LEARNING — WHAT'S WORKING AND WHAT ISN'T:**
 {strategy_performance}
+
+**WHICH APPROACHES EARN THEIR KEEP (by strategy family, not sector):**
+{strategy_family_performance}
 Use this analysis to inform today's Practice Investment pick. Favor sectors and approaches with positive alpha. Avoid repeating strategies that have consistently underperformed. When picking a sector with negative history, acknowledge the track record and explain what's DIFFERENT about today's setup.
 
 **FRESHNESS RULES:**
@@ -154,6 +157,7 @@ This is the show's signature segment. Uses a HYBRID model — NOT financial advi
 **Market:** [TSX / TSX-V / NYSE / NASDAQ / Crypto]
 **Sector:** [REQUIRED — one of: precious_metals, energy, tech, financials, healthcare, consumer, crypto, industrials, utilities, other. MUST NOT match any sector listed in the sector-concentration warning above.]
 **Strategy:** [Brief 1-sentence description: e.g., "Momentum play on earnings beat", "Mean reversion after oversold RSI"]
+**Strategy Family:** [REQUIRED — exactly one of: momentum, mean_reversion, valuation, catalyst_event, earnings_surprise, dividend_income, macro_rotation, technical_breakout, merger_arb, other. This is what lets the show report which APPROACHES earn their keep rather than only which sectors do — see the STRATEGY-FAMILY RECORD above. Pick the family that describes the actual reason for the entry, not the one with the best record.]
 **Hold Period:** [5 sessions from entry / Same-day (Flash Trade only)] — the rule is fixed; do not invent a different horizon
 **Invalidation:** [REQUIRED — one sentence naming the specific, observable thing that would prove this thesis WRONG, stated so a listener could check it themselves. Not "if it goes down" — name the level, the data release, the guidance number, or the event. This is what the stop-loss is derived from, and it is the single most teachable line in the segment.]
 **Lesson Tags:** [REQUIRED — comma-separated from: bid_ask_spread, order_flow_slippage, sector_rotation, sector_concentration, risk_management, position_sizing, tax_loss_harvesting, tfsa_rrsp_mechanics, momentum_entry, mean_reversion, catalyst_confirmation, catalyst_fade, earnings_surprise, technical_breakout, technical_support, valuation_discipline, macro_rotation, geopolitical_premium, insider_buying, analyst_upgrade, activist_defense, dividend_compounding, dollar_cost_averaging, covered_call, fx_hedging, portfolio_rebalancing. DO NOT use any tag listed in the cooldown block above.]

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2335,3 +2335,216 @@ class TestPublicLedger:
             encoding="utf-8")
         assert "scripts/build_mit_ledger.py" in wf
         assert "api/mit_trade_ledger.json" in wf.split("add-paths")[1]
+
+
+class TestRuleRotation:
+    """The scoreboard can only attribute an effect to a rule if some picks
+    were made WITH it and some WITHOUT.
+
+    Across the first 15 stamped trades only two rule sets were ever used
+    — differing by a single rule, and arising because the lesson ledger
+    happened to change rather than by design. The honest scoreboard was
+    therefore permanently silent. Rotation supplies the variation.
+    """
+
+    # Genuinely distinct constraints — near-identical wording would be
+    # collapsed by the near-duplicate filter before rotation ever runs,
+    # which is correct behaviour but makes for a useless fixture.
+    _ADJUSTMENTS = [
+        "Require volume above the 20-day average",
+        "Cap any single sector at 30% of the trailing window",
+        "Wait for a confirmed earnings beat",
+        "Avoid names inside an active short squeeze",
+        "Size down when the VIX is above 25",
+        "Skip picks with earnings inside the holding window",
+    ]
+
+    @classmethod
+    def _ledger(cls, n=6):
+        return {"entries": [
+            {"id": f"LL-{i + 1:03d}", "status": "active",
+             "adjustment": cls._ADJUSTMENTS[i]}
+            for i in range(min(n, len(cls._ADJUSTMENTS)))
+        ]}
+
+    def test_rule_set_varies_between_episodes(self):
+        data = self._ledger()
+        sets = {tuple(e["id"] for e in mi._selected_active_rules(
+            data, episode_num=ep)) for ep in range(100, 112)}
+        assert len(sets) > 1, "rotation produced a constant rule set"
+
+    def test_every_rule_gets_both_arms_over_a_cycle(self):
+        from collections import Counter
+        data = self._ledger()
+        seen = Counter()
+        episodes = list(range(100, 130))
+        for ep in episodes:
+            for e in mi._selected_active_rules(data, episode_num=ep):
+                seen[e["id"]] += 1
+        # Each rule appears sometimes and is absent sometimes — without
+        # both arms no rule can ever be scored.
+        for rid, count in seen.items():
+            assert 0 < count < len(episodes), f"{rid} never varies"
+
+    def test_rotation_is_deterministic(self):
+        data = self._ledger()
+        a = [e["id"] for e in mi._selected_active_rules(data, episode_num=207)]
+        b = [e["id"] for e in mi._selected_active_rules(data, episode_num=207)]
+        assert a == b  # reproducible from the trade record
+
+    def test_proven_rules_are_never_rotated_out(self):
+        data = self._ledger()
+        era = mi.era_inception() or datetime.date(2026, 8, 18)
+
+        def closed(alpha, rules, i):
+            d = (era + datetime.timedelta(days=i)).isoformat()
+            return {"status": "closed", "alpha_pct": alpha, "pnl_pct": alpha,
+                    "nasdaq_return_pct": 0.0, "date": d, "entry_bar_date": d,
+                    "rules_in_effect": rules}
+
+        # LL-001 clearly outperforms; it must stop rotating.
+        tracker = {"trades": [closed(5.0, ["LL-001"], i) for i in range(6)]
+                   + [closed(-2.0, ["LL-002"], i + 6) for i in range(6)]}
+        assert "LL-001" in mi._proven_rule_ids(tracker, data)
+        for ep in range(100, 112):
+            ids = [e["id"] for e in mi._selected_active_rules(
+                data, episode_num=ep, tracker=tracker)]
+            assert "LL-001" in ids
+
+    def test_hand_pinned_rules_are_never_rotated_out(self):
+        data = self._ledger()
+        data["entries"][3]["always_on"] = True
+        pinned = data["entries"][3]["id"]
+        for ep in range(100, 112):
+            ids = [e["id"] for e in mi._selected_active_rules(
+                data, episode_num=ep)]
+            assert pinned in ids
+
+    def test_small_pool_is_not_rotated_away(self):
+        # With fewer rules than slots there is nothing to rotate and every
+        # rule must still be shown.
+        data = self._ledger(n=2)
+        ids = [e["id"] for e in mi._selected_active_rules(data, episode_num=5)]
+        assert len(ids) == 2
+
+
+class TestStrategyFamilies:
+    """61 trades produced 61 unique free-text strategy strings, so the show
+    could report which SECTORS worked but never which APPROACHES did."""
+
+    def test_families_are_derived_from_free_text(self):
+        cases = [
+            ("Momentum play on earnings beat", "earnings_surprise"),
+            ("Mean-reversion entry on 80% recovery from lows", "mean_reversion"),
+            ("M&A spread capture on announced acquisition", "merger_arb"),
+            ("Dividend-compounding entry on a midstream pipeline", "dividend_income"),
+            ("Technical breakout attempt from one-month range", "technical_breakout"),
+            ("Valuation screen on memory-chip names", "valuation"),
+        ]
+        for text, expected in cases:
+            assert mi.strategy_family({"strategy": text}) == expected, text
+
+    def test_explicit_family_wins_over_derivation(self):
+        trade = {"strategy": "Momentum play on earnings beat",
+                 "strategy_family": "macro_rotation"}
+        assert mi.strategy_family(trade) == "macro_rotation"
+
+    def test_unknown_explicit_family_falls_back_to_derivation(self):
+        trade = {"strategy": "Dividend-growth entry",
+                 "strategy_family": "not_a_real_family"}
+        assert mi.strategy_family(trade) == "dividend_income"
+
+    def test_unmatched_strategy_is_other_not_forced(self):
+        assert mi.strategy_family({"strategy": "Something entirely novel"}) == "other"
+
+    def test_record_prefers_verified_windows_and_labels_its_scope(self):
+        era = mi.era_inception() or datetime.date(2026, 8, 18)
+        trades = []
+        for i in range(8):
+            d = (era + datetime.timedelta(days=i)).isoformat()
+            trades.append({"status": "closed", "alpha_pct": 1.0 + i,
+                           "strategy": "Momentum play on earnings beat",
+                           "date": d, "entry_bar_date": d})
+        block = mi._build_strategy_family_performance({"trades": trades})
+        assert "verified-window trades" in block
+        assert "earnings_surprise" in block
+
+    def test_legacy_only_record_is_labelled_indicative(self):
+        trades = [{"status": "closed", "alpha_pct": 5.0,
+                   "strategy": "Momentum play on earnings beat"}
+                  for _ in range(4)]
+        block = mi._build_strategy_family_performance({"trades": trades})
+        assert "indicative only" in block
+        assert "do NOT quote" in block
+
+    def test_thin_buckets_are_flagged_not_hidden(self):
+        trades = [{"status": "closed", "alpha_pct": 2.0,
+                   "strategy": "Momentum play on earnings beat"}
+                  for _ in range(3)]
+        block = mi._build_strategy_family_performance({"trades": trades})
+        assert "too few to lean on" in block
+
+    def test_digest_prompt_requires_a_family(self):
+        prompt = (_ROOT / "shows/prompts/modern_investing_digest.txt").read_text(
+            encoding="utf-8")
+        assert "**Strategy Family:**" in prompt
+        assert "{strategy_family_performance}" in prompt
+        for name, _ in mi.STRATEGY_FAMILIES:
+            assert name in prompt, name
+
+
+class TestReviewCatchUp:
+    """The daily audit runs on a fixed cron; shows finish at wildly
+    different times (MIT has landed 09:32-19:41 UTC). Anything finishing
+    after the audit was logged 'critical: Missed episode' and auto-closed
+    the next day by confirming the FILE EXISTS — its content was never
+    reviewed. On 2026-08-19 that was four shows at once.
+    """
+
+    @staticmethod
+    def _mod():
+        import importlib
+        return importlib.import_module("review_episodes")
+
+    def test_catch_up_helpers_exist_and_are_bounded(self):
+        mod = self._mod()
+        assert mod.CATCH_UP_DAYS >= 1
+        assert mod.CATCH_UP_MAX_PER_RUN >= 1
+        assert callable(mod.find_catch_up_episodes)
+
+    def test_coverage_key_and_day_parsing(self):
+        mod = self._mod()
+        day = datetime.date(2026, 8, 19)
+        assert mod._coverage_key("modern_investing", day) == \
+            "modern_investing|2026-08-19"
+        ep = SimpleNamespace(show_slug="x", date="2026-08-19")
+        assert mod._episode_day(ep, datetime.date(2000, 1, 1)) == day
+        compact = SimpleNamespace(show_slug="x", date="20260819")
+        assert mod._episode_day(compact, datetime.date(2000, 1, 1)) == day
+
+    def test_unparseable_date_falls_back_instead_of_raising(self):
+        mod = self._mod()
+        fallback = datetime.date(2026, 1, 2)
+        ep = SimpleNamespace(show_slug="x", date="not-a-date")
+        assert mod._episode_day(ep, fallback) == fallback
+
+    def test_coverage_prunes_old_entries(self, tmp_path, monkeypatch):
+        mod = self._mod()
+        monkeypatch.setattr(mod, "REVIEW_COVERAGE_PATH",
+                            tmp_path / "review_coverage.json")
+        today = datetime.date(2026, 8, 20)
+        state = {"reviewed": {
+            "a|2026-08-19": True,          # recent — kept
+            "b|2026-01-01": True,          # ancient — pruned
+        }}
+        mod._save_coverage(state, today)
+        reloaded = mod._load_coverage()["reviewed"]
+        assert "a|2026-08-19" in reloaded
+        assert "b|2026-01-01" not in reloaded
+
+    def test_audit_workflow_persists_coverage(self):
+        wf = (_ROOT / ".github/workflows/daily-audit.yml").read_text(
+            encoding="utf-8")
+        # Without persistence the catch-up pass re-reviews the same
+        # episodes every run and never drains.
+        assert "api/review_coverage.json" in wf


### PR DESCRIPTION
You asked whether there were further improvements. The audit found four; three are here. The fourth is recorded as the biggest remaining gap.

Write-up: [`docs/reviews/modern_investing_review_2026_08_20.md`](docs/reviews/modern_investing_review_2026_08_20.md)

## ⚠️ A/B-listen (landmine #17)

One prompt change — picks now declare a strategy family.

---

## 1. The loop was honest but *powerless*

Yesterday's pass stopped the scoreboard inventing findings. It didn't give it the ability to produce real ones. Across the first 15 stamped trades, **only two rule sets have ever existed**:

```
13 trades: LL-015, LL-017, LL-028, LL-041, LL-054
 2 trades: LL-017, LL-028, LL-041, LL-054, LL-066
```

They differ by one rule — and only because the ledger happened to change. Four of five rules are common to both, so those four can *never* be told apart, and neither arm of the one that varies clears the 5-trade minimum. **No variation, no power.** It would have stayed silent indefinitely while looking like a working feedback loop.

**Shipped: deterministic rule rotation.** 4 slots from a ~6-rule pool, cycling on the episode number so any pick's rule set is reproducible from the ledger. Over ten episodes: five distinct sets, and **every rule gets both a with-rule and a without-rule arm** — the precondition for attribution.

```
ep144: LL-002, LL-067, LL-066, LL-041
ep145: LL-067, LL-066, LL-041, LL-028
ep146: LL-066, LL-041, LL-028, LL-002
```

Two safeguards, because this intervenes on the *product*, not just the measurement:
- A rule that **demonstrates an edge is pinned** and stops rotating (≥5 trades on both arms). The point is to find which heuristics work, not withhold ones already known to.
- `always_on: true` pins by hand — for safety-shaped rules, never a hunch.

**Honest expectation:** both arms reach the minimum in ~20–25 era trades — about five weeks. Slow because the sample is small, but reachable for the first time.

## 2. Which *sectors* worked, never which *approaches*

61 trades produced **61 unique free-text strategy strings**. "Momentum play on earnings beat", "Earnings-surprise entry after reported beat", "AI momentum entry on earnings-revision catalyst" — arguably one method, nothing to group by. So "are our momentum entries better than our valuation screens?" was unanswerable, for you and the audience, while the performance page happily reported alpha by sector.

**Shipped:** a closed 10-family vocabulary, required on new picks **and derived from the existing text** so the 61 historic trades are groupable immediately:

```
14 catalyst_event · 12 earnings_surprise · 6 macro_rotation · 6 merger_arb
 6 dividend_income · 5 momentum · 4 other · 3 mean_reversion · 3 valuation
```

Unmatched strategies become `other` rather than being forced into a wrong bucket. The block inherits the same window discipline as every other number the show speaks — computed over verified-window trades when there are enough, otherwise labelled *"indicative only, do NOT quote these as measured results on air."*

## 3. The quality reviewer was skipping episodes silently

The daily audit runs at a fixed **16:15 UTC**. Shows finish anywhere from **09:32 to 19:41** — MIT's last three landed at 14:29, 19:41 and 09:32.

Anything finishing later was logged **"critical: Missed episode"**, then auto-closed the next day by confirming *the file now exists*. So a late episode got a false critical, a tidy auto-close, and **no content review at all** — digest length, required sections, repetition, TTS artifacts and hallucination checks never ran. On 2026-08-19 that hit four shows at once.

**Shipped: a catch-up pass.** Reviews the previous 3 days' unmarked episodes, tracked in `api/review_coverage.json` (14-day prune, committed by daily-audit so it's idempotent).

The first run found a **32-episode network-wide backlog** and immediately surfaced findings that had been invisible — including high cross-episode repetition on MIT Ep139/140 (23 and 21 already-covered stories). Capped at 10/run, oldest first, because the AI review calls Grok once per episode and a 42-episode run would spike cost.

**This one is network-wide, not MIT-specific.**

---

## The gap I did *not* close

**Nothing learns from listeners.** The system improves from its trades, its rules, YouTube retention, and an LLM judge scoring its own scripts. There are **zero mentions of reply, email or question** in the podcast prompt — no path for a listener's experience to enter the loop, despite the show running a newsletter that could carry one.

For a show that exists to teach people to invest better, the one signal it never collects is whether anyone learned anything. DP Pod already solved the mechanics (email replies as a submission channel, named on air). Left for you — it needs an inbox and a triage path, not just code.

## Also noted, not acted on

- **Long-form YouTube retention 10% vs 33% on Shorts** (169 videos). Long-form is where subscribers convert — but it's a network-wide video problem.
- **Audience flat**: 221 downloads/30d (weekly 52/44/61/50).
- **Listener-value scores stepped ~3.9 → ~7.3** around Ep128 and held. Real quality improvement showing up in an independent gauge.

## Testing

- MIT guards: **192 pass** (18 new: `TestRuleRotation`, `TestStrategyFamilies`, `TestReviewCatchUp`).
- Full suite: **6918 pass / 26 failed** — same pre-existing video-feed/youtube/lang-dub set, verified identical on a clean tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_