### PR TITLE
MIT: account on air for the record that disappeared

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,30 @@ today's work, not just explain yesterday's):
   window discipline: verified-window trades when there are enough,
   otherwise labelled indicative-only and explicitly not for air. Guards:
   `TestStrategyFamilies`.
+- **MIT accounts on air for the number that DISAPPEARED** (2026-08-20).
+  Ep141-143 all announced the new era-scoped record; one of three said
+  why, none pointed at the rulebook or ledger, and none mentioned the
+  **+9.28% across forty-five trades** the show had been quoting — which
+  simply stopped appearing. A strong figure that quietly vanishes is
+  indistinguishable from one being buried, and here the truth is the
+  opposite (it could not be reproduced, so it was not ours to claim).
+  `_build_methodology_disclosure` is a SELF-RETIRING correction —
+  `METHODOLOGY_DISCLOSURE_EPISODES = 3` airings, stamped as a list of
+  episode numbers so a second `get_prompt_context` call in one episode
+  cannot burn two, never consumed by read-only runs — and it is NOT a
+  recurring changelog: do not extend it, and keep pipeline internals
+  (rule rotation, review coverage, scoreboard mechanics) out of it. Its
+  payload is the transferable skill, not the apology: the four questions
+  that audit ANY track record (when did it start and was the date chosen
+  after the fact; what is the exit rule and was it fixed in advance; are
+  losers and abandoned positions included; are individual trades
+  published or only the summary). The segment claims the rules and
+  ledger are "published for anyone to check" — that claim was FALSE in
+  practice until this pass, because `api/mit_trade_ledger.*` was built
+  nightly and linked from nowhere; the performance page now carries a
+  *Verify this record yourself* panel and a guard asserts the links and
+  the files both exist. Prompt change => A/B-listen per landmine #17.
+  Guards: `TestMethodologyDisclosure`.
 - **The daily audit reviews late episodes on a CATCH-UP pass** — it runs
   at a fixed 16:15 UTC while shows finish anywhere from 09:32 to 19:41,
   and anything later was logged "critical: Missed episode" then

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -656,3 +656,29 @@ experiments:
       Network-wide, not MIT-specific. The first run surfaced real findings
       that had been invisible, including high cross-episode repetition on
       MIT Ep139/140.
+
+  - id: mit-methodology-correction
+    title: "MIT accounts on air for the record that disappeared"
+    area: quality
+    shipped: 2026-08-20
+    readout: 2026-09-15
+    status: reading
+    baseline: >
+      Ep141-143 all announced the new era-scoped record; 1 of 3 said why,
+      0 of 3 pointed at the rulebook or ledger, and 0 of 3 mentioned the
+      +9.28%-across-45-trades figure the show had been quoting.
+    target: >
+      Exactly 3 episodes carry the correction and then it retires. No
+      listener-value regression below 7.0 on those episodes, and
+      measurable traffic to modern-investing-performance.html within 14
+      days of the first airing.
+    criteria: >
+      A 4th airing means the self-retirement is broken. Flat page traffic
+      means the on-air pointer is not working and needs rewording rather
+      than repeating — do NOT extend the run to compensate.
+    notes: >
+      Deliberately narrow. Pipeline internals are out of scope and a
+      drift guard fails if they leak into the spoken portion. The
+      "published for anyone to check" claim required shipping the
+      performance-page verification panel in the same pass — the ledger
+      was built nightly into api/ and linked from nowhere.

--- a/docs/reviews/ledger/modern_investing.yaml
+++ b/docs/reviews/ledger/modern_investing.yaml
@@ -985,4 +985,62 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-08-20b
+    pr: null
+    doc: docs/reviews/modern_investing_review_2026_08_20b.md
+    reviewer: claude-code (operator question - announce the changes on air)
+    summary: >
+      Checked what Ep141-143 actually aired after the record restarted.
+      All three announced the new regime; one of three said WHY it
+      restarted; none pointed at the rulebook or the ledger; and none
+      mentioned the figure the show used to quote. From a listener's
+      seat the old "+9.28% across forty-five trades" simply vanished -
+      which is indistinguishable from burying a bad result, when the
+      truth is the opposite (it could not be reproduced, so it was not
+      ours to claim). Shipped a NARROW one-off correction rather than a
+      recurring changelog, and made the "published for anyone to check"
+      claim actually true - the ledger was built nightly into api/ and
+      linked from nowhere.
+    shipped:
+      - "_build_methodology_disclosure - a self-retiring on-air segment
+        (METHODOLOGY_DISCLOSURE_EPISODES = 3) covering why the old figure
+        went, the weekday-dependent exit that was the deeper problem, the
+        pre-era trades that match no bars, the published rulebook, the
+        honest cost of a small record, and how to audit ANY track record"
+      - "stamped on the tracker as a list of episode numbers, so a second
+        get_prompt_context call in one episode cannot consume two airings
+        and the record shows which episodes carried it"
+      - "read-only (test/rehearse) runs never consume an airing"
+      - "internals are deliberately out of scope - rule rotation, review
+        coverage and scoreboard mechanics are not listener content, and a
+        drift guard fails if they leak into the spoken portion"
+      - "performance page gained a Verify this record yourself panel
+        linking the rulebook and the trade ledger (JSON + CSV); a guard
+        asserts both the links and the files exist"
+    predictions:
+      - metric: episodes carrying the methodology correction
+        baseline: "0 - Ep141-143 announced the new regime but never
+          explained the disappearance of the old figure"
+        expected: "exactly 3, then 0 forever; if a 4th airs the
+          self-retirement is broken"
+        verdict: pending
+        evidence: null
+      - metric: listener-value score on the correction episodes
+        baseline: "~7.3 steady state since Ep128"
+        expected: "no regression below 7.0 - the segment displaces
+          roughly 250 words of regular content, and if it costs more than
+          it teaches it should not have aired 3 times"
+        verdict: pending
+        evidence: null
+      - metric: visits to modern-investing-performance.html in the 14
+          days after the correction airs
+        baseline: "unmeasured - the page existed but the show never
+          pointed at the primary sources"
+        expected: "measurable and non-zero; if it stays flat the on-air
+          pointer is not working and the ask needs rewording, not
+          repeating"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/docs/reviews/modern_investing_review_2026_08_20b.md
+++ b/docs/reviews/modern_investing_review_2026_08_20b.md
@@ -1,0 +1,92 @@
+# Modern Investing Techniques — on-air disclosure of the record restart
+
+**Date:** 2026-08-20
+**Trigger:** operator question — *"Should we add a segment into the next
+show to discuss all the recent changes and how it will impact future
+episodes?"*
+
+## What the show actually said
+
+The question is worth answering from the tape, not from intent. Ep141–143
+are the first three episodes after the era-scoped record started:
+
+| | Ep141 | Ep142 | Ep143 |
+|---|---|---|---|
+| Announces the new regime | ✅ | ✅ | ✅ |
+| Explains **why** it restarted | — | ✅ | — |
+| Points at the rulebook or ledger | — | — | — |
+| Mentions the figure it used to quote | — | — | — |
+
+So the show told listeners a new record had started and, once, roughly
+why. What it never did was account for what left. The old cumulative
+figure — **+9.28% across forty-five trades** — was quoted on air for
+weeks and then simply stopped appearing.
+
+## Why that is the problem worth fixing
+
+A strong number that quietly disappears from a track record is the
+oldest tell in performance reporting, and a listener has no way to
+distinguish it from the honest case. Here the honest case is the actual
+one: that figure blended trades whose entry and exit prices could not be
+tied back to the sessions the trade was held, an audit could not
+reproduce it, and it was therefore not the show's to claim.
+
+Saying that out loud is not damage control. It is the single most
+transferable thing this show has had to teach — the listener's real
+takeaway is not "MIT restarted its record", it is **how to interrogate
+any track record they are shown**.
+
+## What shipped
+
+A **one-off** correction, not a standing changelog.
+
+- `_build_methodology_disclosure()` emits a ~250-word segment inside
+  Portfolio Performance and retires itself after
+  `METHODOLOGY_DISCLOSURE_EPISODES = 3` airings.
+- Airings are stamped on the tracker as a list of episode numbers, so a
+  second `get_prompt_context` call within one episode cannot consume two
+  airings, and the record shows exactly which episodes carried it.
+- Read-only (`--test` / rehearse) runs never consume an airing.
+- Content covers, in order: the figure is gone and that is deliberate;
+  it could not be reproduced; the exit rule was the deeper problem (a
+  Monday pick was held ~5 sessions and a Wednesday pick ~1, so per-trade
+  performance was measuring the weekday as much as the idea); some older
+  trades match no market bars at all and include both the best and the
+  worst results; the published rulebook that replaced it; the honest cost
+  (a small record means a near-meaningless alpha number for weeks); and
+  the four questions to ask of any record — when did it start and was
+  that date chosen after the fact, what is the exit rule and was it fixed
+  in advance, are losers and abandoned positions included, and are the
+  individual trades published or only the summary.
+
+**Deliberately out of scope:** rule rotation, review coverage, scoreboard
+mechanics, model choices, anything about the pipeline. A listener cares
+what the numbers mean, not how the repo is wired, and a drift guard fails
+if any of it leaks into the spoken portion.
+
+## The claim had to be made true first
+
+The segment tells listeners the rules and the trade-by-trade ledger are
+"published for anyone to check". Before this pass that was true only for
+someone who knew the repo layout: `scripts/build_mit_ledger.py` wrote
+`api/mit_trade_ledger.json` + `.csv` nightly and **nothing linked them**.
+
+`modern-investing-performance.html` now carries a *Verify this record
+yourself* panel linking the rulebook and both ledger formats, with the
+framing that matters — the ledger includes the losers, the voided picks,
+and the pre-era trades that are flagged and never blended into the
+on-air number. A guard asserts both the links and the files exist, so the
+claim cannot silently become false again.
+
+## Predictions
+
+Scored in `docs/reviews/ledger/modern_investing.yaml` (2026-08-20b):
+exactly three airings then zero; no listener-value regression below 7.0
+on the correction episodes; and measurable traffic to the performance
+page within 14 days — if that stays flat, the on-air pointer is not
+working and needs rewording rather than repeating.
+
+## Landmine #17
+
+This is a prompt change and it changes shipped audio. **A/B-listen the
+first episode that carries the correction** before trusting it.

--- a/run_show.py
+++ b/run_show.py
@@ -1547,6 +1547,10 @@ def run(args: argparse.Namespace) -> None:
         # Tone hint (Tesla + SpaceX prompts reference it; supplied by their
         # hooks from the day's stock tape). Neutral default on hook failure.
         template_vars.setdefault("tone_hint", "steady day — natural and conversational")
+        # Modern Investing one-off methodology correction (Aug 2026) —
+        # hook-supplied and self-retiring. Empty default so a hook failure
+        # degrades to an episode without the correction, never a KeyError.
+        template_vars.setdefault("methodology_disclosure", "")
 
         # 7. Generate digest
         #

--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -272,6 +272,13 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # guard) — persist it immediately so a later benchmark-refresh failure
     # can't lose the stamp and re-review the same trade next episode.
     context["yesterday_trade_review"] = _build_trade_review(tracker, episode_num)
+
+    # One-off methodology correction (August 2026). Stamps the tracker the
+    # same way the trade review does, so it rides the save below rather
+    # than risking a re-air if a later step raises.
+    context["methodology_disclosure"] = _build_methodology_disclosure(
+        tracker, episode_num)
+
     if not readonly:
         _save_tracker(tracker, tracker_path)
 
@@ -2667,6 +2674,106 @@ def _weekly_hold_update(open_trades: list) -> str:
             f"**Status:** Holding until Friday evaluation\n"
         )
     return ""
+
+
+# How many episodes carry the one-off methodology correction. The record
+# the show used to quote (+9.28% across 45 trades) DISAPPEARED from air
+# when the era-scoped record started, and from a listener's seat a show
+# that stops quoting a strong number looks exactly like a show burying a
+# bad result. The truth is the opposite — the old number could not be
+# reproduced — and saying so is both the honest move and the single most
+# transferable lesson the show has ever had to teach. Three episodes is
+# enough for the correction to reach a daily audience without becoming a
+# recurring changelog; internal plumbing (rule rotation, review coverage,
+# scoreboard mechanics) is deliberately NOT in scope — a listener cares
+# what the numbers mean, not how the repo is wired.
+METHODOLOGY_DISCLOSURE_EPISODES = 3
+
+
+def _build_methodology_disclosure(
+    tracker: dict, episode_num: int | None = None
+) -> str:
+    """One-off on-air correction explaining why the record restarted.
+
+    Returns an empty string once the disclosure has aired
+    ``METHODOLOGY_DISCLOSURE_EPISODES`` times, so this can never become a
+    permanent segment. The airing count is stamped on the tracker (a list
+    of episode numbers, so the record shows exactly which episodes carry
+    it) and, like every other stamp in this module, is skipped on
+    read-only (test/rehearse) runs.
+    """
+    aired = list(
+        (tracker.get("metadata") or {}).get(
+            "methodology_disclosure_episodes", []
+        )
+    )
+    if len(aired) >= METHODOLOGY_DISCLOSURE_EPISODES:
+        return ""
+    if episode_num is not None and episode_num in aired:
+        return ""
+
+    start = era_inception()
+    start_str = start.strftime("%B %-d, %Y") if start else "the inception date"
+
+    if episode_num is not None and not _hooks_readonly():
+        aired.append(episode_num)
+        tracker.setdefault("metadata", {})[
+            "methodology_disclosure_episodes"
+        ] = aired
+
+    remaining = METHODOLOGY_DISCLOSURE_EPISODES - len(aired)
+    return (
+        "**METHODOLOGY CORRECTION — include this as a short segment "
+        "(roughly 200-300 words) inside Portfolio Performance, then move "
+        f"on. This airs {remaining} more time(s) after today and is then "
+        "retired — do NOT turn it into a recurring feature.**\n"
+        "\n"
+        "The show recently restarted its simulated track record, and a "
+        "listener who was here before deserves to be told why in plain "
+        "language. Cover these points in your own words, in this order, "
+        "without jargon and without defensiveness:\n"
+        "\n"
+        "1. The show used to quote a cumulative alpha figure across "
+        "roughly forty-five trades. It is gone from the scoreboard, and "
+        "that is deliberate. Say so directly — a number that quietly "
+        "vanishes is the oldest tell in performance reporting.\n"
+        "2. Why it went: that figure blended trades whose entry and exit "
+        "prices could not be tied back to the actual sessions the trade "
+        "was held. An audit could not reproduce it, so it was not the "
+        "show's to claim.\n"
+        "3. The exit rule was the deeper problem. A position used to be "
+        "closed on whichever session the next pre-market run happened to "
+        "price it — so a Monday pick was held about five sessions and a "
+        "Wednesday pick about one. Per-trade performance was measuring "
+        "the day of the week as much as the quality of the idea. The "
+        "hold is now a fixed, published number of sessions.\n"
+        "4. Some older trades match no market prices at all, and they "
+        "include the best and the worst results on the books. They stay "
+        "published as history, flagged, and they are never blended into "
+        "what the show says on air.\n"
+        f"5. What replaced it: from {start_str}, every pick is scored "
+        "under one written rulebook — entry at the first session open on "
+        "or after the pick, exit at the stop or at the fixed horizon, "
+        "one position, one thousand dollars, no discretionary exits. The "
+        "rules and the full trade-by-trade ledger, including the losers "
+        "and the voided picks, are published for anyone to check.\n"
+        "6. The honest cost, stated plainly: the record is now small, so "
+        "for the next several weeks the alpha number will be based on a "
+        "handful of trades and will not mean much on its own. That is "
+        "what an honest track record looks like early. Do not spin it.\n"
+        "7. Close on the transferable skill, because this is the point "
+        "of the segment: this is exactly how a listener should audit ANY "
+        "track record they are shown — ask when the record started and "
+        "whether that date was chosen after the fact, ask what the exit "
+        "rule is and whether it was fixed in advance, ask whether losers "
+        "and abandoned positions are included, and ask whether the "
+        "individual trades are published or only the summary. A record "
+        "that cannot answer those four questions is a story.\n"
+        "\n"
+        "Do NOT discuss internal tooling, code, prompts, or pipeline "
+        "mechanics. Speak only about the trading method and what it "
+        "means for the listener."
+    )
 
 
 def _build_trade_review(tracker: dict, episode_num: int | None = None) -> str:

--- a/shows/prompts/modern_investing_digest.txt
+++ b/shows/prompts/modern_investing_digest.txt
@@ -34,6 +34,8 @@ Use ONLY the pre-fetched articles above. Do NOT hallucinate, invent, or fabricat
 **PORTFOLIO vs NASDAQ COMPOSITE (the scoreboard — state every episode):**
 {benchmark_state}
 
+{methodology_disclosure}
+
 **RECURSIVE IMPROVEMENT RULES IN EFFECT:**
 {lessons_learned_block}
 

--- a/templates/mit_performance_page.html.j2
+++ b/templates/mit_performance_page.html.j2
@@ -49,6 +49,32 @@
     </p>
   </div>
 
+  <!-- Verify this record. The show tells listeners the rulebook and the
+       trade-by-trade ledger are published for anyone to check; this panel
+       is what makes that claim true. Every trade is here, including the
+       losers, the voided picks and the pre-era history that is flagged and
+       never blended into the on-air number. -->
+  <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">
+    <h2 style="margin-top:0; font-size:1.2rem;">Verify this record yourself</h2>
+    <p style="color: var(--nn-text-muted); margin-bottom: var(--sp-4);">
+      A track record you cannot check is a story. These are the primary sources
+      behind every number on this page — the rules were written before the
+      trades, and the ledger includes the losers, the voided picks and the
+      older trades that are flagged and deliberately excluded from what the
+      show says on air.
+    </p>
+    <ul style="margin:0; padding-left: 1.2rem; line-height: 1.9;">
+      <li><a href="{{ path_prefix }}docs/mit_trading_method.md">The rulebook</a>
+        — entry, exit, position size, options handling, and what is
+        <em>not</em> modelled.</li>
+      <li><a href="{{ path_prefix }}api/mit_trade_ledger.json">Trade ledger (JSON)</a>
+        · <a href="{{ path_prefix }}api/mit_trade_ledger.csv">CSV</a>
+        — every trade with its entry and exit sessions, stop, horizon,
+        invalidation, stated confidence, the rules in effect and any option
+        contract.</li>
+    </ul>
+  </div>
+
   {% if performance_data and performance_data.available %}
     <!-- Core Performance Snapshot -->
     <div class="glass-card" style="padding: var(--sp-6); margin-bottom: var(--sp-8);">

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2548,3 +2548,96 @@ class TestReviewCatchUp:
         # Without persistence the catch-up pass re-reviews the same
         # episodes every run and never drains.
         assert "api/review_coverage.json" in wf
+
+
+class TestMethodologyDisclosure:
+    """The old cumulative-alpha figure vanished from air when the
+    era-scoped record started.
+
+    A number that quietly disappears is indistinguishable, from the
+    listener's seat, from a number being buried — and here the truth is
+    the opposite (it could not be reproduced, so it was not ours to
+    claim). The correction is a one-off segment, not a standing
+    changelog: it must retire itself, it must never re-air on the same
+    episode twice, and it must stay out of pipeline internals.
+    """
+
+    @staticmethod
+    def _tracker():
+        return {"metadata": {}, "trades": []}
+
+    def test_airs_then_retires(self, monkeypatch):
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: False)
+        tracker = self._tracker()
+        aired = [
+            bool(mi._build_methodology_disclosure(tracker, episode_num=ep))
+            for ep in range(200, 210)
+        ]
+        assert aired[:mi.METHODOLOGY_DISCLOSURE_EPISODES] == (
+            [True] * mi.METHODOLOGY_DISCLOSURE_EPISODES)
+        assert not any(aired[mi.METHODOLOGY_DISCLOSURE_EPISODES:]), (
+            "the correction became a permanent segment")
+
+    def test_same_episode_never_consumes_two_airings(self, monkeypatch):
+        # get_prompt_context can run more than once per episode; without
+        # this guard a single episode would burn the whole allowance.
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: False)
+        tracker = self._tracker()
+        first = mi._build_methodology_disclosure(tracker, episode_num=200)
+        second = mi._build_methodology_disclosure(tracker, episode_num=200)
+        assert first and not second
+        assert tracker["metadata"]["methodology_disclosure_episodes"] == [200]
+
+    def test_readonly_runs_do_not_stamp(self, monkeypatch):
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: True)
+        tracker = self._tracker()
+        assert mi._build_methodology_disclosure(tracker, episode_num=200)
+        assert not tracker["metadata"].get(
+            "methodology_disclosure_episodes"), (
+            "a rehearsal run consumed a real airing")
+
+    def test_covers_the_four_audit_questions(self, monkeypatch):
+        # The transferable lesson is the reason this segment is worth
+        # airing at all: how to audit any track record you are shown.
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: False)
+        text = mi._build_methodology_disclosure(self._tracker(), 200).lower()
+        for probe in ("exit rule", "losers", "published", "reproduce"):
+            assert probe in text, f"missing audit question: {probe}"
+
+    def test_stays_out_of_pipeline_internals(self, monkeypatch):
+        # A listener cares what the numbers mean, not how the repo is
+        # wired. Naming internal machinery on air is noise at best.
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: False)
+        block = mi._build_methodology_disclosure(self._tracker(), 200)
+        # Everything from the closing directive on is guidance to the
+        # model, never spoken — the ban applies to the content above it.
+        marker = "Do NOT discuss"
+        assert marker in block, "the internals ban went missing"
+        text = block.split(marker)[0].lower()
+        # "scoreboard" is deliberately absent from this list — it is the
+        # show's own on-air word for the benchmark block, not internals.
+        for leak in ("rotation", "prompt", "pipeline", "codebase",
+                     "repository", "workflow"):
+            assert leak not in text, f"internal detail leaked on air: {leak}"
+
+    def test_prompt_and_runner_are_wired(self):
+        prompt = (_ROOT / "shows/prompts/modern_investing_digest.txt").read_text(
+            encoding="utf-8")
+        assert "{methodology_disclosure}" in prompt
+        runner = (_ROOT / "run_show.py").read_text(encoding="utf-8")
+        # Defaulted in the runner so a hook failure degrades to an
+        # episode without the correction rather than a KeyError.
+        assert 'setdefault("methodology_disclosure", "")' in runner
+
+    def test_published_sources_are_reachable_from_the_site(self):
+        # The segment tells listeners the rulebook and the trade-by-trade
+        # ledger are published "for anyone to check". Before this pass the
+        # ledger was built nightly into api/ and linked from nowhere, so
+        # the claim was true only for someone who knew the repo layout.
+        tpl = (_ROOT / "templates/mit_performance_page.html.j2").read_text(
+            encoding="utf-8")
+        for target in ("docs/mit_trading_method.md",
+                       "api/mit_trade_ledger.json",
+                       "api/mit_trade_ledger.csv"):
+            assert target in tpl, f"performance page does not link {target}"
+            assert (_ROOT / target).exists(), f"linked file missing: {target}"


### PR DESCRIPTION
## What the show actually said

Checked from the tape, not from intent. Ep141–143 are the first three episodes after the era-scoped record started:

| | Ep141 | Ep142 | Ep143 |
|---|---|---|---|
| Announces the new regime | ✅ | ✅ | ✅ |
| Explains **why** it restarted | — | ✅ | — |
| Points at the rulebook or ledger | — | — | — |
| Mentions the figure it used to quote | — | — | — |

So the show said a new record had started and, once, roughly why. What it never did was account for what left: the **+9.28% across forty-five trades** it had been quoting for weeks simply stopped appearing.

## Why that's the problem worth fixing

A strong number that quietly vanishes from a track record is the oldest tell in performance reporting, and a listener has no way to distinguish it from the honest case. Here the honest case is the actual one — that figure blended trades whose entry and exit prices couldn't be tied back to the sessions they were held, an audit couldn't reproduce it, and it wasn't the show's to claim.

The listener's real takeaway isn't "MIT restarted its record". It's **how to interrogate any track record they're shown**.

## What this ships

A **one-off** correction, not a standing changelog.

- `_build_methodology_disclosure()` emits a ~250-word segment inside Portfolio Performance and retires itself after `METHODOLOGY_DISCLOSURE_EPISODES = 3` airings.
- Airings are stamped on the tracker as a **list of episode numbers**, so a second `get_prompt_context` call within one episode can't consume two airings — and the record shows exactly which episodes carried it.
- Read-only (`--test` / rehearse) runs never consume an airing.
- `run_show` defaults the placeholder, so a hook failure degrades to an episode without the correction rather than a `KeyError`.

Content, in order: the figure is gone and that's deliberate; it couldn't be reproduced; the exit rule was the deeper problem (a Monday pick was held ~5 sessions and a Wednesday pick ~1, so per-trade performance was measuring the weekday as much as the idea); some older trades match no market bars at all and include both the best and the worst results; the published rulebook that replaced it; the honest cost (a small record means a near-meaningless alpha number for weeks); and the four questions that audit **any** record — when did it start and was that date chosen after the fact, what is the exit rule and was it fixed in advance, are losers and abandoned positions included, are individual trades published or only the summary.

**Deliberately out of scope:** rule rotation, review coverage, scoreboard mechanics, model choices, anything about the pipeline. A listener cares what the numbers mean, not how the repo is wired — and a drift guard fails if any of it leaks into the spoken portion.

## The claim had to be made true first

The segment tells listeners the rules and the trade-by-trade ledger are "published for anyone to check". Before this pass that was true only for someone who knew the repo layout: `scripts/build_mit_ledger.py` wrote `api/mit_trade_ledger.json` + `.csv` nightly and **nothing linked them**.

`modern-investing-performance.html` now carries a *Verify this record yourself* panel linking the rulebook and both ledger formats, with the framing that matters — the ledger includes the losers, the voided picks, and the pre-era trades that are flagged and never blended into the on-air number. A guard asserts both the links and the files exist, so the claim can't silently become false again.

## ⚠️ A/B-listen required

This is a **prompt change** and it changes shipped audio (landmine #17). A/B-listen the first episode that carries the correction before trusting it.

## Testing

- `tests/test_mit_benchmark_integrity.py` — 199 passed, including the new `TestMethodologyDisclosure` (self-retirement, no double-consumption within an episode, read-only runs don't stamp, the four audit questions are present, internals stay out of the spoken portion, prompt + runner wiring, published sources reachable).
- Full suite: 6,925 passed. The 26 failures are **identical before and after this diff** on a clean `main` checkout in this environment — they're pre-existing and environment-related (YouTube/token env vars present here that those tests assume absent).

## Predictions (scored next review)

Recorded in `docs/reviews/ledger/modern_investing.yaml` (`2026-08-20b`) and `docs/experiments.yaml` (`mit-methodology-correction`, readout 2026-09-15):

1. **Exactly 3 airings, then 0 forever.** A 4th means the self-retirement is broken.
2. **No listener-value regression below 7.0** on the correction episodes — it displaces ~250 words of regular content, and if it costs more than it teaches it shouldn't have aired 3 times.
3. **Measurable traffic to the performance page within 14 days.** If flat, the on-air pointer isn't working and needs rewording — *not* extending the run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_