### PR TITLE
Nerra Daily review fixes: 3s cut-offset bug, segment fault tolerance, stale-checkout race

### DIFF
--- a/.github/workflows/nerra-daily.yml
+++ b/.github/workflows/nerra-daily.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # ALWAYS the current tip of main, never the event's pinned SHA:
+          # a workflow_run event resolves GITHUB_SHA at dispatch time, so a
+          # run queued behind an in-flight build would otherwise start from
+          # a tree WITHOUT the edition commit, see the date as unpublished,
+          # and rebuild it — overwriting the live R2 object under the
+          # enclosure URL the first build already published.
+          ref: main
           fetch-depth: 1
 
       - uses: ./.github/actions/setup-python

--- a/docs/nerra_daily.md
+++ b/docs/nerra_daily.md
@@ -54,7 +54,10 @@ are noise, so each segment is trimmed:
   outside the edition's own paths.
 
 Transcript times are raw-voice-track times; the final-MP3 cut adds the
-show's `voice_intro_delay + intro_duration` (3.0 s network-wide).
+show's `voice_intro_delay` ONLY (0.0 network-wide since the July 2026
+cold-open pass — `intro_duration` is music under the opening line, not
+before it, so it shifts nothing). Verified against Ep578: final 563.1 s
+= raw 533.1 s + 30 s music outro + 0 s shift.
 
 ## Audio assembly
 

--- a/engine/daily_edition.py
+++ b/engine/daily_edition.py
@@ -304,9 +304,16 @@ def discover_segments(
                 content=str(entry.get("content") or ""),
                 digest_dir=digest_dir,
                 transcript_path=_transcript_path_for(digest_dir, audio_url),
-                music_intro_offset=float(
-                    (cfg.audio.voice_intro_delay or 0.0) + (cfg.audio.intro_duration or 0.0)
-                ),
+                # Raw-voice-track time -> final-MP3 time. The mixer shifts
+                # the voice by ``voice_intro_delay`` ONLY (engine/audio.py's
+                # delayed-intro branch; engine/config.py documents it) —
+                # ``intro_duration`` is music played UNDER the cold open,
+                # not before it, and every show pins delay 0.0. Adding
+                # intro_duration here landed every cut 3 s late and leaked
+                # the plug's opening words into the edition (caught in the
+                # 2026-08-21 review — verified against Ep578: final 563.1 s
+                # = raw 533.1 s + 30 s outro + 0 s shift).
+                music_intro_offset=float(cfg.audio.voice_intro_delay or 0.0),
             )
         )
     return segments, missing

--- a/scripts/build_daily_edition.py
+++ b/scripts/build_daily_edition.py
@@ -127,6 +127,15 @@ def _append_summary(
                     encoding="utf-8")
 
 
+def _annotate(kind: str, message: str) -> None:
+    """GitHub Actions annotation. Workflow commands must START the line,
+    so this bypasses the logger (whose format prefixes the level name and
+    would make GitHub ignore the command) — the backfill_content_lake
+    convention."""
+    print(f"::{kind}::{message}", flush=True)
+    (logger.error if kind == "error" else logger.warning)(message)
+
+
 def _run(cmd: List[str], what: str) -> None:
     proc = subprocess.run(cmd, capture_output=True, text=True)
     if proc.returncode != 0:
@@ -174,11 +183,11 @@ def _generate_links(
             links = parse_links_json(text, handoff_count)
             if links:
                 return links
-            logger.warning("::warning::Nerra Daily link generation returned an "
-                           "unusable shape — using the deterministic fallback")
+            _annotate("warning", "Nerra Daily link generation returned an "
+                                 "unusable shape — using the deterministic fallback")
         except Exception as exc:  # noqa: BLE001 — links must never sink the edition
-            logger.warning("::warning::Nerra Daily link generation failed (%s) — "
-                           "using the deterministic fallback", exc)
+            _annotate("warning", f"Nerra Daily link generation failed ({exc}) "
+                                 "— using the deterministic fallback")
     return fallback_links(spec, segments, target_date)
 
 
@@ -218,9 +227,10 @@ def build_edition(
     if missing:
         logger.warning("expected but absent today: %s", ", ".join(missing))
     if len(segments) < spec.min_segments:
-        logger.error("::error::only %d segment(s) available for %s — refusing "
-                     "to publish below the %d-segment floor",
-                     len(segments), target_date, spec.min_segments)
+        _annotate("error",
+                  f"only {len(segments)} segment(s) available for "
+                  f"{target_date} — refusing to publish below the "
+                  f"{spec.min_segments}-segment floor")
         return 1
     logger.info("lineup today (%d segments): %s", len(segments),
                 ", ".join(s.slug for s in segments))
@@ -232,34 +242,57 @@ def build_edition(
     aoai_today = aoai_new_episode(ROOT, target_date)
     tracker = create_tracker(spec.name, episode_num)
 
-    links = _generate_links(spec, segments, target_date, aoai_today, tracker,
-                            skip_llm=skip_llm)
-
     workdir = Path(tempfile.mkdtemp(prefix=f"{spec.slug}_"))
     try:
-        # --- Segments: download, locate the promo cut, trim + re-encode.
+        # --- Segments FIRST (before any LLM/TTS spend): download, locate
+        # the promo cut, trim + re-encode. A failing segment (404 on a
+        # fallback audio_url after an R2 upload failure, a transient CDN
+        # error) is DROPPED loudly rather than sinking the whole edition —
+        # Mira's links are written afterward against the survivors, so the
+        # rundown she speaks always matches what actually spliced.
         pieces: List[Path] = []
         chapter_pieces: List[tuple] = []
+        survivors: List[Segment] = []
         for seg in segments:
             raw = workdir / f"raw_{seg.slug}.mp3"
-            _download(seg.audio_url, raw)
-            cut_final = None
-            if seg.transcript_path:
-                transcript = load_transcript(seg.transcript_path)
-                hit = find_promo_cut(transcript) if transcript else None
-                if hit:
-                    cut_final = hit["raw_seconds"] + seg.music_intro_offset
-                    seg.cut_kind = hit["kind"]
-            if cut_final is None:
-                logger.warning("no promo cut found for %s Ep%s — segment ships "
-                               "whole (plug included)", seg.slug, seg.episode_num)
             trimmed = workdir / f"seg_{seg.slug}.mp3"
-            _run(segment_trim_cmd(raw, trimmed, cut_final),
-                 f"trim/encode {seg.slug}")
+            try:
+                _download(seg.audio_url, raw)
+                cut_final = None
+                if seg.transcript_path:
+                    transcript = load_transcript(seg.transcript_path)
+                    hit = find_promo_cut(transcript) if transcript else None
+                    if hit:
+                        cut_final = hit["raw_seconds"] + seg.music_intro_offset
+                        seg.cut_kind = hit["kind"]
+                if cut_final is None:
+                    logger.warning("no promo cut found for %s Ep%s — segment "
+                                   "ships whole (plug included)",
+                                   seg.slug, seg.episode_num)
+                _run(segment_trim_cmd(raw, trimmed, cut_final),
+                     f"trim/encode {seg.slug}")
+            except Exception as exc:  # noqa: BLE001 — one segment never sinks the day
+                _annotate("warning",
+                          f"segment {seg.slug} Ep{seg.episode_num} dropped "
+                          f"from the edition: {exc}")
+                continue
+            finally:
+                raw.unlink(missing_ok=True)
             seg.cut_final_seconds = cut_final
             seg.duration_seconds = get_audio_duration(trimmed) or 0.0
-            raw.unlink(missing_ok=True)
+            survivors.append(seg)
             pieces.append(trimmed)
+
+        segments = survivors
+        if len(segments) < spec.min_segments:
+            _annotate("error",
+                      f"only {len(segments)} segment(s) assembled for "
+                      f"{target_date} — below the {spec.min_segments}-segment "
+                      "floor; not publishing")
+            return 1
+
+        links = _generate_links(spec, segments, target_date, aoai_today,
+                                tracker, skip_llm=skip_llm)
 
         # --- Mira's links: TTS + normalize to the segment format.
         def mira(name: str, text: str) -> Path:
@@ -390,9 +423,9 @@ def build_edition(
             [sys.executable, "generate_html.py", "--show", spec.slug, "--blogs"],
             cwd=ROOT, capture_output=True, text=True, timeout=900)
         if proc.returncode != 0:
-            logger.warning("::warning::page regeneration failed (episode is "
-                           "published; nightly will repair): %s",
-                           proc.stderr[-500:])
+            _annotate("warning", "page regeneration failed (episode is "
+                                 "published; nightly will repair): "
+                                 + proc.stderr[-500:])
 
         logger.info("published %s Ep%d (%s) -> %s",
                     spec.name, episode_num, title, r2_url)

--- a/shows/prompts/nerra_daily_links.txt
+++ b/shows/prompts/nerra_daily_links.txt
@@ -21,10 +21,11 @@ Write, as STRICT JSON with exactly these keys:
 INTRO (spoken before the first episode, 110-170 words):
 - Greet the listener, name the show and the date, and identify yourself as Mira.
 - Sketch the shape of today — not a full table of contents. Pick the two or three most striking threads across the lineup and let the rest be "and more".
-- Land on a specific, concrete detail from the FIRST show's episode so the handoff into it is seamless.
+- Land on a specific, concrete detail from the FIRST show's episode so the handoff into it is seamless — but not its headline itself, which the episode is about to speak as its own opening line.
 
 HANDOFFS (exactly {handoff_count} entries — entry N is spoken between episode N and episode N+1, and introduces episode N+1; 35-75 words each):
 - Each handoff names the next show and sets it up with one specific detail drawn from that episode's summary above.
+- Every episode OPENS on its own headline, so a handoff that repeats the headline makes the listener hear the same fact twice in a row. Set the episode up with a different detail from its summary — an angle, a stake, a question the headline raises — and let the show deliver its own opening.
 - A brief backward glance at the episode that just ended is welcome when it earns its place; skip it when it doesn't.
 - When two adjacent episodes genuinely connect — same story from another angle, a cause meeting its consequence — say so in one line. Never force a connection.
 - Vary the construction: no two handoffs in one edition may open with the same words or follow the same sentence skeleton. Do not open every handoff by naming the show; sometimes lead with the detail and let the show name arrive mid-sentence.

--- a/tests/test_daily_edition.py
+++ b/tests/test_daily_edition.py
@@ -161,6 +161,20 @@ class TestPromoCutRealTranscripts:
         lo, hi = window
         assert lo <= hit["raw_seconds"] <= hi, (rel_path, hit)
 
+    def test_offset_is_voice_intro_delay_only(self):
+        """Raw-voice-track -> final-MP3 mapping. The mixer shifts voice by
+        ``voice_intro_delay`` ONLY (intro music plays UNDER the cold open,
+        not before it) — adding intro_duration landed every cut 3 s late
+        and leaked the plug's opening words into every edition segment
+        (2026-08-21 review; Ep578: final 563.1 s = raw 533.1 s + 30 s
+        outro + 0 s shift). Every current show pins delay 0.0."""
+        date = dt.date(2026, 8, 20)
+        segments, _ = discover_segments(SPEC, ROOT, date)
+        if not segments:
+            pytest.skip("2026-08-20 summaries entries pruned")
+        for seg in segments:
+            assert seg.music_intro_offset == 0.0, seg.slug
+
     def test_all_lineup_shows_cut_on_a_real_day(self):
         """Every English show's committed transcript from one full slate
         must yield a promo cut — a show whose outro shape drifts past the


### PR DESCRIPTION
# Deep-review fixes for Nerra Daily (before Ep1 airs)

A high-effort review pass over the just-merged edition (#1049) found one critical bug and three operational issues. All fixed and verified.

## 1. CRITICAL — every promo cut landed 3 seconds late
`discover_segments` mapped raw-transcript time → final-MP3 time as `voice_intro_delay + intro_duration` (3.0 s). But the mixer shifts voice by **`voice_intro_delay` only** — since the July 2026 cold-open pass, intro music plays *under* the opening line, not before it, and every show pins delay = 0.0. Result: every trimmed segment would have audibly shipped ~3 s of the plug ("And before you go: this show is part of the Ne—") fading out mid-sentence — the exact artifact the trim exists to remove.

**Verified against real audio**: Tesla Ep578 final MP3 = 563.1 s = raw voice 533.1 s + 30 s music outro + **0 s shift**. Corrected dry run on the 2026-08-20 slate reclaims the 33 leaked seconds (101.5 min vs 102.1). New drift test pins `music_intro_offset == 0.0` across the real slate; `docs/nerra_daily.md` corrected.

## 2. One failed segment download no longer sinks the edition
Downloads/trims now run **first** (before any LLM/TTS spend); a failing segment (404 fallback URL after an R2 upload failure, transient CDN error) is dropped with a loud annotation, the 4-segment floor re-checks, and Mira's links are generated against the survivors — so her spoken rundown always matches what actually spliced.

## 3. Stale-checkout race → R2 overwrite
A `workflow_run` event pins its SHA at dispatch time, so a run queued behind an in-flight build could start from a tree *without* the edition commit, miss the idempotency key, and rebuild the same date — overwriting the live R2 object under the already-published enclosure URL. Checkout now pins `ref: main`.

## 4. GitHub annotations never rendered
`::error::`/`::warning::` were emitted through a logger whose format prefixes the level name, so GitHub ignored every one. They now print at line start (the `backfill_content_lake` convention).

## Editorial: no double-spoken headlines
The link prompt now tells Mira to set each show up with a detail that is **not** its headline — every episode opens on its own headline, so a headline handoff made the listener hear the same fact twice back to back. ⚠️ Prompt change → shipped audio; Ep1 listen covers it.

## Tests
`tests/test_daily_edition.py`: 39/39 (new offset drift guard included). Ruff clean. Full corrected dry run on the real 2026-08-20 slate: 11/11 segments, 11/11 cuts at the true positions (Tesla cut 492.31 s, plug starts 492.46 s).

**Timing note**: worth merging before ~10:30 UTC today so Ep1 assembles with the corrected cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV)_