### PR TITLE
Daily audit: 4.6 reviewer at low effort + wall-clock budget — the report always ships

### DIFF
--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -448,6 +448,17 @@ experiments:
       repetitive at the tightened spec, THEN revert the model pin.
       UC untouched (on-spec, no complaint); dp_pod Ep041 swung short
       (1,101w vs 1,550 target, LV 7.9) — single-day watch item.
+      2026-08-21 retune VERDICT: Ep077 landed in band (brief 1,752w,
+      script 1,960w, 0 near-dup pairs, 13:16 vs 20:00) — say-it-once
+      worked; FPD stays on 4.6. New watch: FPD digest ran 506s under
+      the tightened band (vs 190-236s before) — close to the 600s
+      timeout; if it trends up, the model pin is the lever. Same day:
+      the 4.6 REVIEWER at default effort timed out the whole daily
+      audit (no report written); reviewer now runs reasoning_effort
+      LOW + the audit's AI loop has a wall-clock budget
+      (REVIEW_AI_BUDGET_SECONDS, default 1200s) so the report always
+      ships. FACTUAL_ERRORS rates from 08-21 on are 4.6-LOW — compare
+      cross-show within a day, never across effort eras.
   - id: grok-46-funnel-and-ops
     title: "grok-4.6 on the funnel + ops surfaces — titles, restock, specials"
     area: growth

--- a/review_episodes.py
+++ b/review_episodes.py
@@ -1363,6 +1363,16 @@ def ai_review_episode(ep: EpisodeReview) -> None:
             # to grok-4.3 with reasoning effort "none". Keep effort none so
             # the explicit pin changes nothing about the served review.
             extra["extra_body"] = {"reasoning_effort": "none"}
+        elif reviewer_model.startswith("grok-4.6"):
+            # 2026-08-21: at its default (high) effort the 4.6 reviewer
+            # blew the 300s request timeout on ~1/3 of episodes and the
+            # 35-min audit job died with no report written. This is a
+            # structured YES/NO + score task — "low" keeps 4.6's sharper
+            # judgment (the 08-19 cross-show read) at a latency the audit
+            # can actually afford. Instrument note: FACTUAL_ERRORS rates
+            # from 08-21 on are 4.6-LOW; compare cross-show within a day,
+            # never across effort eras.
+            extra["extra_body"] = {"reasoning_effort": "low"}
         resp = client.chat.completions.create(
             model=reviewer_model,
             messages=[{"role": "user", "content": prompt}],
@@ -2123,10 +2133,29 @@ def run_review(
     check_cross_episode_duplicates(episodes)
     check_content_freshness(episodes, target_date)
 
-    # Optional AI review
+    # Optional AI review — under a wall-clock budget (2026-08-21: with a
+    # 20-episode catch-up backlog and several reviews timing out at 300s
+    # each, the loop alone blew the 35-minute job limit and the audit
+    # died WITHOUT writing daily-review.json or the GitHub issue. The
+    # budget guarantees the report always ships: episodes past the budget
+    # keep every structural check and simply skip the AI layer, loudly.
     if os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY"):
+        import time as _time
+        _ai_budget = float(os.getenv("REVIEW_AI_BUDGET_SECONDS", "1200"))
+        _ai_started = _time.monotonic()
+        _ai_skipped = 0
         for ep in episodes:
+            if _time.monotonic() - _ai_started > _ai_budget:
+                _ai_skipped += 1
+                continue
             ai_review_episode(ep)
+        if _ai_skipped:
+            logger.warning(
+                "AI-review budget (%ds) exhausted — %d of %d episodes "
+                "got structural checks only (their AI layer is skipped "
+                "for good; coverage marks them reviewed).",
+                int(_ai_budget), _ai_skipped, len(episodes),
+            )
     else:
         logger.info("Skipping AI review (no GROK_API_KEY)")
 

--- a/tests/test_llm_usage_pass.py
+++ b/tests/test_llm_usage_pass.py
@@ -285,3 +285,24 @@ class TestGrok46FunnelAndOpsWave:
         tsrc = (REPO_ROOT / "engine" / "tracking.py").read_text(
             encoding="utf-8")
         assert 'grok[step]["model"] = model' in tsrc
+
+
+class TestReviewerLatencyEnvelope:
+    """2026-08-21: the grok-4.6 reviewer at default (high) effort blew the
+    300s request timeout on ~1/3 of episodes; with a 20-episode catch-up
+    backlog the 35-minute audit job died WITHOUT writing its report or
+    issue — the audit's whole job is to always report. Two contracts:"""
+
+    SRC = (REPO_ROOT / "review_episodes.py").read_text(encoding="utf-8")
+
+    def test_46_reviewer_runs_at_low_effort(self):
+        """Structured YES/NO + score doesn't need deep reasoning; 'low'
+        keeps 4.6's judgment at a latency the audit can afford."""
+        assert 'reviewer_model.startswith("grok-4.6")' in self.SRC
+        assert '"reasoning_effort": "low"' in self.SRC
+
+    def test_ai_review_loop_has_a_wall_clock_budget(self):
+        """Past the budget, episodes keep structural checks and skip the
+        AI layer — the report and GitHub issue always ship."""
+        assert "REVIEW_AI_BUDGET_SECONDS" in self.SRC
+        assert "budget" in self.SRC.lower()


### PR DESCRIPTION
# Summary

Fixes today's daily-audit failure (timed out at 35 min, **no report written, no issue filed**) — and I own the cause: the staged trial's **grok-4.6 reviewer at default (high) reasoning effort** blows the 300s request timeout on longer transcripts. Five episodes lost 5 minutes each (the `max_retries=0` guard from the outage post-mortem held — 5 minutes per failure, not 15), and a 20-episode catch-up backlog did the rest.

## Fixes (both in `review_episodes.py`)

1. **4.6 reviewer runs `reasoning_effort: low`.** Structured YES/NO + score doesn't need deep reasoning; low keeps the sharper cross-show judgment (the Aug 19 read that put the trial shows at 9/10) at audit-affordable latency. Instrument note recorded in the register: FACTUAL_ERRORS from Aug 21 on are 4.6-LOW — compare cross-show within a day, never across effort eras.
2. **AI-review loop under a wall-clock budget** (`REVIEW_AI_BUDGET_SECONDS`, default 1200s). Past the budget, remaining episodes keep every structural check and skip only the AI layer — loudly — so the structured report and GitHub issue **always ship** regardless of upstream latency. Same fail-loud-but-finish class as the July Spotify connector budget.

No workflow changes needed: with the budget, the job mathematically fits its 35-minute limit.

## Also in this PR: the FPD retune verdict (register interim note)

**Ep077 confirms yesterday's fix worked**: brief 1,752w / script 1,960w (in band), **0 near-duplicate sentence pairs**, runtime **13:16** vs the repetitive era's ~20:00. FPD stays on grok-4.6. New watch item: its digest ran **506s** under the tightened band (vs 190–236s before) — close to the 600s timeout; if that trends up, the model pin is the next lever.

## After merge

I'll re-dispatch the daily audit so today gets its review report (the 16:45 run died before writing it).

## Test plan

Full suite: **7,112 passed**. New drift guards: `TestReviewerLatencyEnvelope` (4.6-low branch present; budget present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJHRVbrFUhDGP9xw9cc2UZ)_