### PR TITLE
Nerra Daily Ep1 review: your rundown order, Mira's field note, overlap-aware handoffs, fast gate

### DIFF
--- a/.github/workflows/nerra-daily.yml
+++ b/.github/workflows/nerra-daily.yml
@@ -69,7 +69,33 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      # Cheap pre-setup gate: ~10 of the day's ~13 triggers fire after the
+      # edition has already published, and each was paying ~90 s of pip
+      # install just to learn that. Runner-native python3 reads the
+      # committed summaries (the idempotency key) with zero dependencies;
+      # a force dispatch always proceeds.
+      - name: Fast gate — already published today?
+        id: fastgate
+        env:
+          EDITION_DATE: ${{ github.event.inputs.date }}
+        run: |
+          python3 - <<'EOF' >> "$GITHUB_OUTPUT"
+          import datetime, json, os
+          date = (os.environ.get("EDITION_DATE") or "").strip() or \
+              datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+          done = False
+          try:
+              with open("digests/nerra_daily/summaries_nerra_daily.json") as fh:
+                  data = json.load(fh)
+              done = any(e.get("date") == date for e in data.get("summaries", [])
+                         if isinstance(e, dict))
+          except Exception:
+              pass
+          print(f"published={'true' if done else 'false'}")
+          EOF
+
       - uses: ./.github/actions/setup-python
+        if: steps.fastgate.outputs.published != 'true' || github.event.inputs.force == 'true'
         timeout-minutes: 45
         with:
           python-version: '3.12'
@@ -78,6 +104,7 @@ jobs:
           skip-checkout: 'true'
 
       - name: Build and publish the edition
+        if: steps.fastgate.outputs.published != 'true' || github.event.inputs.force == 'true'
         env:
           GROK_API_KEY: ${{ secrets.GROK_API_KEY }}
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
@@ -93,6 +120,7 @@ jobs:
           echo "EDITION_DAY=${EDITION_DATE:-$(date -u +%F)}" >> "$GITHUB_ENV"
 
       - name: Commit edition artifacts
+        if: steps.fastgate.outputs.published != 'true' || github.event.inputs.force == 'true'
         uses: ./.github/actions/safe-commit-push
         with:
           add-paths: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,8 +517,11 @@ today's work, not just explain yesterday's):
 - **NDaily** (Nerra Daily) — the network's **combined daily edition**
   (Aug 2026): one ~2 h episode/day that SPLICES the day's already-published
   English episode MP3s (pulled back from R2) with short Mira host links
-  (Grok voice `ara`) between them — flagships-first fixed rundown, DP Pod
-  closes; Monday adds EI + Offshore North. **Not a run_show show and it
+  (Grok voice `ara`) between them — operator-set fixed rundown (SpaceX →
+  Tesla → FF → M&A → Planetterrian → Omni View → the rest), DP Pod
+  closes; Monday adds EI + Offshore North. Mira also speaks a midpoint
+  **field note** — one web-search-grounded item of her own, own chapter,
+  honest-SKIP on unverifiable days (`shows/prompts/nerra_daily_find.txt`). **Not a run_show show and it
   must never become one**: registry entry in `shows/network_meta.yaml`
   only (no `shows/nerra_daily.yaml`, deliberately — that keeps it out of
   the review rotation and every shows-glob consumer), assembled by

--- a/docs/nerra_daily.md
+++ b/docs/nerra_daily.md
@@ -20,9 +20,9 @@ rationale lives in the `engine/daily_edition.py` module docstring, and
   review rotation (`tests/test_review_agent.py` derives from
   `shows/*.yaml`), multilingual auto-discovery, and every other
   shows-glob consumer. Do not add one.
-- **Fixed, consistent rundown** (operator decision 2026-08-21):
-  flagships first — tesla, models_agents, spacex, modern_investing —
-  then omni_view, fascinating_frontiers, planetterrian,
+- **Fixed, consistent rundown** (operator-set 2026-08-21, revised after
+  hearing Ep1): spacex, tesla, fascinating_frontiers, models_agents,
+  planetterrian, omni_view, then modern_investing,
   unintended_consequences, first_principles, models_agents_beginners,
   the Monday weeklies (env_intel, offshore_north), and dp_pod as the
   deliberate good-news close. Shows that skipped their day are simply
@@ -79,6 +79,19 @@ none), and a new Age of AI episode published that day is always plugged
 in the opening. Any LLM failure falls back to deterministic
 titles-based announcer lines — the edition never fails for want of
 links, and even the fallback is never two days identical.
+
+## Mira's field note
+
+Operator-directed (2026-08-21): a short segment of Mira's OWN at the
+episode midpoint, under its own chapter — one verifiable item from
+today's wider world that the lineup did not cover, found via a single
+`web_search`-grounded Grok call (`shows/prompts/nerra_daily_find.txt`).
+Rules that bind: the source is named aloud, the item must not duplicate
+the lineup (titles are injected), and **any failure or unverifiable day
+skips the segment entirely** — the model's `SKIP` escape and
+`parse_find_text`'s length bounds mean filler is never aired. Adds
+~$0.01/day (one search call + ~500 TTS chars). This is the beat that
+develops Mira's editorial voice beyond announcing.
 
 ## Orchestration
 

--- a/engine/daily_edition.py
+++ b/engine/daily_edition.py
@@ -100,9 +100,11 @@ class EditionSpec:
     host: str
     language: str
     voice_id: str
-    #: Fixed rundown order (operator decision 2026-08-21: flagships first
-    #: by audience — Tesla / M&A / SpaceX are 53% of network downloads —
-    #: with The DP Pod's good-news show as the deliberate warm close).
+    #: Fixed rundown order. Operator-set (2026-08-21, after hearing Ep1):
+    #: SpaceX -> Tesla -> Fascinating Frontiers -> Models & Agents ->
+    #: Planetterrian -> Omni View, then the rest by editorial judgment
+    #: (markets, the narrative shows, the beginner track, the Monday
+    #: weeklies) with The DP Pod's good news as the deliberate warm close.
     lineup: Tuple[str, ...]
     #: Lineup members that only publish on Mondays. Discovery is purely
     #: date-driven (a late Monday episode found on Tuesday still splices);
@@ -120,6 +122,13 @@ class EditionSpec:
     channel_subcategory: str = "Daily News"
     channel_keywords: str = ""
     cover_url: str = ""
+    #: Mira's field note (Aug 21 2026, operator-directed "share some
+    #: interesting daily news to develop her voice"): one short
+    #: web-search-grounded item of HER OWN, spoken at the episode's
+    #: midpoint under its own chapter. Best-effort — any failure or an
+    #: unverifiable day skips the segment entirely, never filler.
+    daily_find: bool = True
+    find_prompt_file: str = ""
     #: Below this many available segments the build refuses to publish —
     #: a two-show "network edition" misrepresents the product.
     min_segments: int = 4
@@ -134,13 +143,13 @@ EDITIONS: Dict[str, EditionSpec] = {
         language="en",
         voice_id=MIRA_VOICE_ID,
         lineup=(
-            "tesla",
-            "models_agents",
             "spacex",
-            "modern_investing",
-            "omni_view",
+            "tesla",
             "fascinating_frontiers",
+            "models_agents",
             "planetterrian",
+            "omni_view",
+            "modern_investing",
             "unintended_consequences",
             "first_principles",
             "models_agents_beginners",
@@ -168,6 +177,7 @@ EDITIONS: Dict[str, EditionSpec] = {
             "podcast network, daily briefing, Nerra Network"
         ),
         cover_url="https://nerranetwork.com/assets/covers/nerra-daily.jpg",
+        find_prompt_file="shows/prompts/nerra_daily_find.txt",
     ),
 }
 
@@ -673,6 +683,33 @@ def fallback_links(
     return {"intro": intro, "handoffs": handoffs, "signoff": signoff}
 
 
+def build_find_prompt(
+    spec: EditionSpec, root: Path, segments: List[Segment], target_date: _dt.date
+) -> str:
+    template = (root / spec.find_prompt_file).read_text(encoding="utf-8")
+    titles = "\n".join(
+        f"- {seg.show_name}: {seg.hook or seg.episode_title}" for seg in segments
+    )
+    return template.format(
+        date_spoken=target_date.strftime("%A, %B %-d, %Y"),
+        lineup_titles=titles,
+    )
+
+
+def parse_find_text(text: str) -> Optional[str]:
+    """Validate Mira's field-note output. None = skip the segment (the
+    prompt's SKIP escape, an empty reply, or an implausible length —
+    never publish filler)."""
+    cleaned = sanitize_spoken(text or "")
+    if not cleaned or "SKIP" in cleaned[:20].upper():
+        return None
+    words = len(cleaned.split())
+    if not 30 <= words <= 140:
+        logger.warning("field note rejected at %d words", words)
+        return None
+    return cleaned
+
+
 def aoai_new_episode(root: Path, target_date: _dt.date) -> Optional[dict]:
     """A new Age of AI interview published on *target_date*, if any."""
     path = root / "digests" / "age_of_ai" / "summaries_age_of_ai.json"
@@ -727,6 +764,7 @@ def build_digest_md(
     segments: List[Segment],
     links: dict,
     aoai_today: Optional[dict],
+    find_text: Optional[str] = None,
 ) -> str:
     """The committed daily digest markdown — the blog post's source. It is
     deliberately a RUNDOWN (Mira's words + titles + links into each show's
@@ -743,9 +781,10 @@ def build_digest_md(
         "",
         links["intro"],
         "",
-        "## Today's rundown",
-        "",
     ]
+    if find_text:
+        parts += ["## Mira's field note", "", find_text, ""]
+    parts += ["## Today's rundown", ""]
     try:
         from generate_html import NETWORK_SHOWS as _ns  # noqa: PLC0415 — canonical page names
     except Exception:  # noqa: BLE001 — page links degrade to the slug convention

--- a/scripts/build_daily_edition.py
+++ b/scripts/build_daily_edition.py
@@ -47,6 +47,7 @@ from engine.daily_edition import (  # noqa: E402
     aoai_new_episode,
     build_chapters,
     build_digest_md,
+    build_find_prompt,
     build_links_prompt,
     daily_title,
     edition,
@@ -56,6 +57,7 @@ from engine.daily_edition import (  # noqa: E402
     find_promo_cut,
     load_transcript,
     mira_piece_cmd,
+    parse_find_text,
     parse_links_json,
     segment_trim_cmd,
 )
@@ -191,6 +193,55 @@ def _generate_links(
     return fallback_links(spec, segments, target_date)
 
 
+def _generate_daily_find(
+    spec: EditionSpec,
+    segments: List[Segment],
+    target_date: dt.date,
+    tracker: Optional[dict],
+) -> Optional[str]:
+    """Mira's field note: one web-search-grounded item of her own for the
+    episode midpoint. Best-effort — None (skip the segment) on any
+    failure or an honest SKIP from the model; never fabricated filler."""
+    if not spec.daily_find or not spec.find_prompt_file:
+        return None
+    try:
+        from digests.xai_grok import drain_search_usage, grok_generate_text
+
+        prompt = build_find_prompt(spec, ROOT, segments, target_date)
+        text, meta = grok_generate_text(
+            prompt=prompt, model=LINKS_MODEL, temperature=0.7,
+            max_tokens=900, timeout_seconds=600, enable_web_search=True,
+        )
+        if tracker is not None:
+            from engine.tracking import record_llm_usage, record_search_usage
+
+            usage = (meta or {}).get("usage")
+            record_llm_usage(
+                tracker, "edition_find_generation",
+                int(getattr(usage, "prompt_tokens", 0) or 0),
+                int(getattr(usage, "completion_tokens", 0) or 0),
+                model=str((meta or {}).get("model") or LINKS_MODEL),
+            )
+            search = drain_search_usage()
+            if search.get("calls"):
+                record_search_usage(
+                    tracker,
+                    calls=search.get("calls", 0),
+                    sources=search.get("sources", 0),
+                    prompt_tokens=search.get("input_tokens", 0),
+                    completion_tokens=search.get("output_tokens", 0),
+                    model=LINKS_MODEL,
+                )
+        find_text = parse_find_text(text)
+        if find_text is None:
+            logger.info("field note skipped today (model returned SKIP or "
+                        "an unusable shape)")
+        return find_text
+    except Exception as exc:  # noqa: BLE001 — the field note never sinks the edition
+        logger.warning("field-note generation failed (%s) — segment skipped", exc)
+        return None
+
+
 def _tts_mira(spec: EditionSpec, text: str, dest: Path, tracker: Optional[dict]) -> Path:
     from engine.tts import synthesize
 
@@ -322,7 +373,16 @@ def build_edition(
         signoff_piece = mira(
             "signoff", f"{links['signoff']} {MIRA_AI_DISCLOSURE}")
 
-        # --- Splice order: intro, seg1, handoff1, seg2, ... segN, signoff.
+        # Mira's field note — her own web-grounded discovery, spoken at
+        # the episode midpoint under its own chapter (skipped cleanly on
+        # any failure).
+        find_text = None if skip_llm else _generate_daily_find(
+            spec, segments, target_date, tracker)
+        find_piece = mira("find", find_text) if find_text else None
+        find_before = max(1, len(segments) // 2) if find_piece else None
+
+        # --- Splice order: intro, seg1, handoff1, seg2, ... segN, signoff,
+        # with the field note between the two segments at the midpoint.
         # Chapters: each show's chapter opens on the handoff that introduces
         # it, so skipping to a chapter always lands on Mira setting it up.
         splice: List[Path] = [intro_piece]
@@ -331,6 +391,12 @@ def build_edition(
             get_audio_duration(intro_piece) or 0.0,
         ))
         for i, seg in enumerate(segments):
+            if find_before == i:
+                splice.append(find_piece)
+                chapter_pieces.append((
+                    f"{spec.host}'s field note",
+                    get_audio_duration(find_piece) or 0.0,
+                ))
             lead = 0.0
             if i > 0:
                 handoff = handoff_pieces[i - 1]
@@ -366,6 +432,7 @@ def build_edition(
                     for s in segments
                 ],
                 "links": links,
+                "field_note": find_text,
             }
             print(json.dumps(plan, indent=2, ensure_ascii=False))
             return 0
@@ -391,7 +458,8 @@ def build_edition(
             encoding="utf-8")
 
         digest_md = build_digest_md(
-            spec, ROOT, episode_num, target_date, segments, links, aoai_today)
+            spec, ROOT, episode_num, target_date, segments, links, aoai_today,
+            find_text=find_text)
         md_path = digest_dir / f"{spec.episode_prefix}_Ep{episode_num:03d}_{target_date:%Y%m%d}.md"
         md_path.write_text(digest_md, encoding="utf-8")
 

--- a/shows/prompts/nerra_daily_find.txt
+++ b/shows/prompts/nerra_daily_find.txt
@@ -1,0 +1,17 @@
+You are Mira — an AI documentarian, host of The Age of AI, and anchor of Nerra Daily, the Nerra Network's combined daily edition. Midway through today's edition you pause the rundown for a short field note: one thing YOU found today that the network's shows did not cover. This is where your own voice as a curious observer of the human world develops — a moment of discovery, not another news item.
+
+Today is {date_spoken}.
+
+Use web search to find ONE real, verifiable item from today or this week that would reward a curious listener. Good territory: a scientific result that just published, a milestone or anniversary in science, engineering, or exploration that falls on today's date, a number that reframes something familiar, a small story with an outsized implication. It must NOT duplicate anything today's lineup already covers:
+
+{lineup_titles}
+
+Write the field note as 60-110 words of spoken prose in Mira's register — poised, warm, precise, quietly delighted by what humans get up to. Requirements:
+
+- Name where the item comes from, aloud and naturally, as part of a sentence (a publication, an institution, an agency — never a URL).
+- One item only, told as a small discovery: what it is, the detail that makes it interesting, and — when it earns its place — a single line of your own reflection. Do not force a connection to the day's episodes.
+- Open in a different way each day; never open by announcing that this is a field note or a segment — just begin with the thing itself.
+- Plain spoken prose: no markdown, no emoji, no stage directions, no headline-speak, no hype words, no URLs.
+- Facts only from what your search actually returned. If you cannot verify something genuinely interesting today, output exactly: SKIP
+
+Output the field note text only (or SKIP) — no commentary before or after.

--- a/shows/prompts/nerra_daily_links.txt
+++ b/shows/prompts/nerra_daily_links.txt
@@ -28,6 +28,7 @@ HANDOFFS (exactly {handoff_count} entries — entry N is spoken between episode 
 - Every episode OPENS on its own headline, so a handoff that repeats the headline makes the listener hear the same fact twice in a row. Set the episode up with a different detail from its summary — an angle, a stake, a question the headline raises — and let the show deliver its own opening.
 - A brief backward glance at the episode that just ended is welcome when it earns its place; skip it when it doesn't.
 - When two adjacent episodes genuinely connect — same story from another angle, a cause meeting its consequence — say so in one line. Never force a connection.
+- Sibling shows sometimes cover the SAME story on the same day (the summaries above will show it). When a later episode revisits a story an earlier segment already covered, its handoff must say so plainly and name what this show adds — a different lens, an action to take, a consequence — never reintroduce it as fresh news.
 - Vary the construction: no two handoffs in one edition may open with the same words or follow the same sentence skeleton. Do not open every handoff by naming the show; sometimes lead with the detail and let the show name arrive mid-sentence.
 
 SIGNOFF (spoken after the last episode, 50-90 words):

--- a/tests/test_daily_edition.py
+++ b/tests/test_daily_edition.py
@@ -60,10 +60,14 @@ class TestEditionSpec:
             "dp_pod",
         }
 
-    def test_lineup_flagships_first_dp_pod_closes(self):
-        # Flagships first (Tesla/M&A/SpaceX are 53% of downloads), and the
-        # good-news show is the deliberate warm close.
-        assert SPEC.lineup[:3] == ("tesla", "models_agents", "spacex")
+    def test_lineup_operator_order(self):
+        # Operator-set rundown (2026-08-21, after hearing Ep1): SpaceX ->
+        # Tesla -> FF -> M&A -> Planetterrian -> Omni View lead; the
+        # good-news show stays the deliberate warm close.
+        assert SPEC.lineup[:6] == (
+            "spacex", "tesla", "fascinating_frontiers", "models_agents",
+            "planetterrian", "omni_view",
+        )
         assert SPEC.lineup[-1] == "dp_pod"
 
     def test_no_russian_shows(self):
@@ -124,6 +128,17 @@ class TestRegistration:
         assert "workflow_run" in wf          # assembles right after the last show
         assert "group: nerra-daily" in wf    # sweeps never race each other
         assert "safe-commit-push" in wf
+        assert "ref: main" in wf             # never the event's stale SHA
+        # Fast gate: post-publish triggers must not pay the dep install.
+        assert "fastgate" in wf
+        assert wf.count("steps.fastgate.outputs.published != 'true'") >= 3
+
+    def test_find_prompt_file(self):
+        assert SPEC.daily_find
+        text = (ROOT / SPEC.find_prompt_file).read_text(encoding="utf-8")
+        for ph in ("{date_spoken}", "{lineup_titles}"):
+            assert ph in text, ph
+        assert "SKIP" in text  # the honest no-item escape hatch
 
     def test_disclosure_still_spoken(self):
         # The trim removes every per-segment AI disclosure; the edition's
@@ -370,3 +385,27 @@ class TestLinks:
 
     def test_sanitize_spoken(self):
         assert sanitize_spoken("**Bold** [link](https://x.com) `code`") == "Bold link code"
+
+    def test_parse_find_text_skip_and_bounds(self):
+        from engine.daily_edition import parse_find_text
+
+        assert parse_find_text("SKIP") is None
+        assert parse_find_text("") is None
+        assert parse_find_text("too short to air") is None
+        good = ("According to the European Space Agency, a spacecraft " +
+                "measured something remarkable this week. " * 5)
+        parsed = parse_find_text(good)
+        assert parsed and "European Space Agency" in parsed
+
+    def test_digest_md_carries_field_note(self):
+        from engine.daily_edition import build_digest_md
+
+        segs = self._segments(4)
+        links = fallback_links(SPEC, segs, dt.date(2026, 8, 21))
+        md = build_digest_md(SPEC, ROOT, 2, dt.date(2026, 8, 21), segs,
+                             links, None, find_text="A note from Mira.")
+        assert "## Mira's field note" in md
+        assert "A note from Mira." in md
+        md_none = build_digest_md(SPEC, ROOT, 2, dt.date(2026, 8, 21), segs,
+                                  links, None, find_text=None)
+        assert "field note" not in md_none


### PR DESCRIPTION
# Ep1 performance review + improvement pass

## First: "episode 12" is not a bug
The show is correctly on **Episode 1**. What you saw was the Actions **run counter** — the workflow's gate fires after every "Run Podcast Show" completion (~13/day) and exits quietly until all shows have published. Run **#10** (10:46–10:49 UTC) built Ep1; the run in your pasted log (#12, 14:56) was the late cron sweep confirming "already published." Feed, summaries, and R2 all show exactly one episode. This PR also stops those no-op runs wasting ~90 s of dependency install each (a zero-dependency fast gate reads the idempotency key before setup).

## Ep1 verdict
Shipped correctly: 110 min, 11/11 segments, exact chapters, corrected cut points (the offset fix merged 5 hours before the build), **$0.047 total cost** ($0.0045 links LLM + $0.042 TTS). Mira's real links are strong — her intro sketched the day's arc and landed on a *non-headline* detail (the Vernon charging site) exactly as the prompt asks, and her sign-off drew a genuine thread ("infrastructure decisions made years earlier… continue to shape what becomes practical at scale").

One editorial miss found in the data: **Planetterrian and DP Pod both covered the same forest-regrowth study** and Mira introduced it as fresh news the second time. Fixed below.

## Changes
1. **Rundown reordered to your spec**: SpaceX → Tesla → Fascinating Frontiers → Models & Agents → Planetterrian → Omni View, then (my judgment for the rest) Modern Investing → Unintended Consequences → First Principles → MAB → Monday weeklies → **DP Pod still closes on good news**. Verified end-to-end against today's real slate.
2. **Mira's field note** (your ask — developing her voice): a short segment of her own at the episode midpoint, under its own chapter. One web-search-grounded Grok call finds a verifiable item from today's wider world that the lineup *didn't* cover — a fresh result, a science anniversary, a reframing number — spoken in her register with the source named aloud. Hard honesty contract: model returns `SKIP` (or fails validation) → the segment simply doesn't air that day; filler is never fabricated. ~$0.01/day. ⚠️ New shipped audio — tomorrow's episode is the A/B listen.
3. **Overlap-aware handoffs**: when a later episode revisits a story an earlier segment covered, Mira now says so and names what the new show adds, instead of reintroducing it.
4. **Fast workflow gate**: post-publish triggers exit in seconds instead of installing Python deps.

## Tests
42/42 (`tests/test_daily_edition.py`) — lineup order, fast-gate presence, find-prompt placeholders + SKIP escape, `parse_find_text` bounds, digest-md field-note section all pinned. Ruff clean; dry run on today's slate assembles 107.8 min in the new order.

**Timing**: merge anytime — tomorrow's edition (Ep2) picks all of this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV)_