### PR TITLE
Daily audit: retry dispatcher refuses stale reports (stops the daily duplicate-episode replay)

### DIFF
--- a/api/daily-review.json
+++ b/api/daily-review.json
@@ -10,7 +10,7 @@
   },
   "remediation": {
     "auto_retry_shows": [],
-    "recommendation": "No automatic retries recommended."
+    "recommendation": "Cleared 2026-08-21: this 2026-08-19 list was being replayed daily by the retry dispatcher after fresh reports failed to ship (4 duplicate episodes/day). The next successful audit rewrites this file."
   },
   "missed_and_skipped": [],
   "episodes": [
@@ -84,7 +84,7 @@
         {
           "severity": "critical",
           "title": "AI review: Repetitive",
-          "detail": "Chang\u2019e 7, Deimos collision/regolith, Tarantula composite, and Starship \u201ccovered yesterday\u201d notes are restated near-verbatim."
+          "detail": "Chang’e 7, Deimos collision/regolith, Tarantula composite, and Starship “covered yesterday” notes are restated near-verbatim."
         },
         {
           "severity": "info",
@@ -130,7 +130,7 @@
         {
           "severity": "info",
           "title": "AI quality score: 7/10",
-          "detail": "Dense, coherent recap of agent benchmarks and efficiency papers with a clear close and standard promo. Minor caveats are jargon-heavy phrasing (e.g. \u201cpass to the power of twenty\u201d) and a second pass on Thinkingbox/FlashPrefill that is structural rather than broken."
+          "detail": "Dense, coherent recap of agent benchmarks and efficiency papers with a clear close and standard promo. Minor caveats are jargon-heavy phrasing (e.g. “pass to the power of twenty”) and a second pass on Thinkingbox/FlashPrefill that is structural rather than broken."
         }
       ]
     },
@@ -217,17 +217,17 @@
         {
           "severity": "info",
           "title": "Significant story overlap with unintended_consequences",
-          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
           "title": "Significant story overlap with first_principles",
-          "detail": "Found 5 overlapping stories with first_principles. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 5 overlapping stories with first_principles. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
           "title": "Significant story overlap with unintended_consequences",
-          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
@@ -250,12 +250,12 @@
         {
           "severity": "info",
           "title": "Significant story overlap with first_principles",
-          "detail": "Found 3 overlapping stories with first_principles. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 3 overlapping stories with first_principles. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
           "title": "Significant story overlap with unintended_consequences",
-          "detail": "Found 6 overlapping stories with unintended_consequences. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 6 overlapping stories with unintended_consequences. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
@@ -301,7 +301,7 @@
         {
           "severity": "info",
           "title": "Significant story overlap with unintended_consequences",
-          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 \u2014 the cold open...'"
+          "detail": "Found 3 overlapping stories with unintended_consequences. Example: 'segment 1 — the cold open...'"
         },
         {
           "severity": "info",
@@ -360,12 +360,12 @@
         {
           "severity": "warning",
           "title": "AI review: Factual Errors",
-          "detail": "Internal contradiction on TSX close (called \u201cessentially flat\u201d then +0.9% / 0.3% from ATH); extreme 711,500% option claim is implausible as stated."
+          "detail": "Internal contradiction on TSX close (called “essentially flat” then +0.9% / 0.3% from ATH); extreme 711,500% option claim is implausible as stated."
         },
         {
           "severity": "critical",
           "title": "AI review: Incoherent",
-          "detail": "TSX flat-vs-up wording and some run-on market/options passages don\u2019t parse cleanly."
+          "detail": "TSX flat-vs-up wording and some run-on market/options passages don’t parse cleanly."
         },
         {
           "severity": "critical",
@@ -408,7 +408,7 @@
         {
           "severity": "warning",
           "title": "AI review: Factual Errors",
-          "detail": "Mykhailo Fedorov was Ukraine\u2019s digital transformation minister, not defense minister."
+          "detail": "Mykhailo Fedorov was Ukraine’s digital transformation minister, not defense minister."
         },
         {
           "severity": "critical",

--- a/scripts/dispatch_audit_retries.py
+++ b/scripts/dispatch_audit_retries.py
@@ -77,6 +77,23 @@ def main() -> None:
         print(f"Failed to parse {review_path}: {exc}")
         sys.exit(0)
 
+    # Stale-report guard (2026-08-21): when review_episodes.py dies before
+    # writing a fresh report (that day: grok-4.6 reviewer timeouts blew the
+    # job budget), this file still holds an EARLIER day's remediation list —
+    # and replaying it dispatches full duplicate episode pipelines, YouTube
+    # and R2 uploads included. The 2026-08-19 list was replayed on BOTH the
+    # 20th and 21st (4 duplicate episodes/day, 6 recovery PRs). A retry
+    # decision is only ever valid for the day it was computed.
+    today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    review_date = str(data.get("date") or "")
+    if review_date != today:
+        msg = (f"api/daily-review.json is dated {review_date or 'unknown'}, "
+               f"not {today} — refusing to dispatch retries from a stale "
+               "report (today's audit did not ship one)")
+        print(f"::warning::{msg}")
+        _post_webhook(f"⚠️ Daily audit: {msg}")
+        return
+
     shows = data.get("remediation", {}).get("auto_retry_shows", []) or []
     if not shows:
         print("No auto-retries needed")

--- a/tests/test_alerting_wiring.py
+++ b/tests/test_alerting_wiring.py
@@ -257,8 +257,12 @@ class TestAuditRetrySkipsStrandedEpisodes:
 
         mod = _load_script("dispatch_audit_retries")
         (tmp_path / "api").mkdir()
+        # date must be TODAY: the 2026-08-21 stale-report guard refuses to
+        # dispatch from any other day's report before the stranded check runs.
+        _today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
         (tmp_path / "api" / "daily-review.json").write_text(
-            _json.dumps({"remediation": {"auto_retry_shows": ["tesla"]}}),
+            _json.dumps({"date": _today,
+                         "remediation": {"auto_retry_shows": ["tesla"]}}),
             encoding="utf-8",
         )
         monkeypatch.chdir(tmp_path)  # main() reads api/daily-review.json from cwd

--- a/tests/test_audit_retry_guard.py
+++ b/tests/test_audit_retry_guard.py
@@ -1,0 +1,83 @@
+"""Drift guard: the daily audit's retry dispatcher must never act on a
+stale report.
+
+2026-08-21: review_episodes.py died before writing a fresh
+api/daily-review.json (grok-4.6 reviewer timeouts), and
+dispatch_audit_retries.py replayed the 2026-08-19 remediation list on
+BOTH following days — four full duplicate episode pipelines per day,
+YouTube/R2 uploads included, six recovery PRs. A retry decision is only
+valid for the day it was computed.
+"""
+
+from __future__ import annotations
+
+import datetime
+import importlib.util
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "dispatch_audit_retries", ROOT / "scripts" / "dispatch_audit_retries.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stale_report_dispatches_nothing(tmp_path, monkeypatch, capsys):
+    mod = _load_module()
+    review = tmp_path / "api" / "daily-review.json"
+    review.parent.mkdir(parents=True)
+    review.write_text(json.dumps({
+        "date": "2026-08-19",
+        "remediation": {"auto_retry_shows": ["fascinating_frontiers"]},
+    }))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run",
+                        lambda *a, **k: calls.append(a) or None)
+    mod.main()
+    out = capsys.readouterr().out
+    assert calls == [], "stale report must never dispatch retries"
+    assert "stale" in out
+
+
+def test_fresh_report_still_dispatches(tmp_path, monkeypatch):
+    mod = _load_module()
+    today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    review = tmp_path / "api" / "daily-review.json"
+    review.parent.mkdir(parents=True)
+    review.write_text(json.dumps({
+        "date": today,
+        "remediation": {"auto_retry_shows": ["fascinating_frontiers"]},
+    }))
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("GH_TOKEN", "test-token")
+
+    calls = []
+
+    class _Result:
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _Result()
+
+    monkeypatch.setattr(mod.subprocess, "run", _fake_run)
+    mod.main()
+    dispatched = [c for c in calls if c[:3] == ["gh", "workflow", "run"]]
+    assert len(dispatched) == 1, "fresh report must still dispatch"
+
+
+def test_committed_stale_list_is_neutralized():
+    """The stale 2026-08-19 list that caused the replay must stay cleared
+    until a fresh audit rewrites the file."""
+    data = json.loads((ROOT / "api" / "daily-review.json").read_text())
+    if data.get("date") == "2026-08-19":
+        assert data.get("remediation", {}).get("auto_retry_shows") == []


### PR DESCRIPTION
Found while cleaning up the six recovery PRs (#1045 #1047 #1052 #1054 #1056 #1057 — all closed as duplicate second episodes, not lost data):

`api/daily-review.json`'s **2026-08-19** remediation list was replayed by `dispatch_audit_retries.py` on **both** Aug 20 and Aug 21, because the fresh report failed to ship (grok-4.6 reviewer timeouts — reviewer fix already on main via "Daily audit: 4.6 reviewer at low effort + wall-clock budget"). Each replay dispatched four full duplicate episode pipelines — LLM + TTS + render + **YouTube/R2 uploads** — whose colliding pushes became the recovery PRs.

This PR is the missing defense-in-depth:
- The dispatcher now compares the report's `date` to today (UTC) and **refuses, loudly (::warning:: + webhook), to act on a stale report** — a retry decision is only valid for the day it was computed.
- The committed stale list is cleared so nothing can replay before the next audit rewrites the file.
- Drift guards: `tests/test_audit_retry_guard.py` (stale → zero dispatches; fresh → still dispatches; committed list stays neutralized).

Operator note: the duplicate runs may have published duplicate YouTube videos for FF/M&A (Aug 20 + 21) and MAB/MIT (Aug 21) — worth a quick Studio check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV)_