### PR TITLE
Daily audit: register dp_pod and offshore_north

### DIFF
--- a/review_episodes.py
+++ b/review_episodes.py
@@ -266,7 +266,47 @@ SHOW_REGISTRY = {
         "narrative": True,   # topic-queue show — fetches no articles by design
         "schedule": "weekday",
     },
+    # Added 2026-08-21. Both shows had been publishing with NO quality
+    # review at all — dp_pod daily since 2026-07-04, offshore_north since
+    # its 2026-08-18 launch. The catch-up pass could never reach them
+    # because catch-up iterates this same registry, so the coverage file
+    # looked healthy (exactly the day's slate, every day) while two shows
+    # sat outside the gate entirely. Found by diffing the recorded
+    # coverage against what actually shipped on disk.
+    "dp_pod": {
+        "name": "The DP Pod",
+        "output_dir": "digests/dp_pod",
+        "prefix": "DP_Pod_Ep",
+        "min_digest_chars": 2000,
+        "max_digest_chars": 20000,
+        # YAML floor is 1550; the audit reads llm.min_podcast_words first
+        # and only falls back to this.
+        "min_tts_words": 1550,
+        "min_audio_s": 300,
+        "max_audio_s": 1500,
+        "required_sections": [],
+        # Fresh episode all 7 days — deliberately no Sunday recap.
+        "schedule": "daily",
+    },
+    "offshore_north": {
+        "name": "Offshore North",
+        "output_dir": "digests/offshore_north",
+        "prefix": "Offshore_North_Ep",
+        "min_digest_chars": 2000,
+        "max_digest_chars": 20000,
+        "min_tts_words": 1500,
+        "min_audio_s": 300,
+        "max_audio_s": 1500,
+        "required_sections": [],
+        "schedule": "monday",
+    },
 }
+
+# Shows deliberately outside the daily audit. age_of_ai never runs through
+# run_show (the Nerra Voices pipeline publishes it), so schedule-based
+# "missed episode" detection would fire every single day. Its quality gate
+# is the two human review gates in that pipeline instead.
+AUDIT_EXEMPT_SLUGS = frozenset({"age_of_ai"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2671,3 +2671,64 @@ class TestMethodologyDisclosure:
         step = next(s for s in job["steps"] if s.get("id") == "audit")
         # Strictly below the job budget, so the persist step always runs.
         assert step["timeout-minutes"] < job["timeout-minutes"]
+
+
+class TestAuditRegistryCoversEveryShow:
+    """A show absent from the audit's registry is never reviewed at all.
+
+    The catch-up pass ended "reviewed late"; it could not end "never in
+    the registry", because catch-up iterates the same registry. dp_pod
+    had published daily since 2026-07-04 and offshore_north since
+    2026-08-18 with no quality review ever run against them, and nothing
+    looked wrong: api/review_coverage.json recorded exactly the day's
+    slate every day, because the shows it omits are invisible to it.
+
+    The tell was only visible by diffing recorded coverage against what
+    actually shipped on disk. This guard does that comparison against
+    the show configs instead, so a newly scaffolded show cannot repeat
+    it.
+    """
+
+    @staticmethod
+    def _mod():
+        import importlib
+        return importlib.import_module("review_episodes")
+
+    def test_every_show_yaml_is_audited_or_explicitly_exempt(self):
+        mod = self._mod()
+        configured = {
+            p.stem for p in (_ROOT / "shows").glob("*.yaml")
+            # A leading underscore marks a non-show config (_defaults,
+            # _trading_policy); the others are shared data files.
+            if not p.stem.startswith("_")
+            and p.stem not in {
+                "network_meta", "pronunciation_map",
+                "translation_overrides", "scaffold_pending",
+            }
+        }
+        missing = configured - set(mod.SHOW_REGISTRY) - mod.AUDIT_EXEMPT_SLUGS
+        assert not missing, (
+            f"shows publish with no daily-audit coverage: {sorted(missing)}. "
+            "Add a SHOW_REGISTRY entry, or add the slug to "
+            "AUDIT_EXEMPT_SLUGS with the reason it cannot be audited."
+        )
+
+    def test_exemptions_are_real_shows_and_stay_deliberate(self):
+        mod = self._mod()
+        for slug in mod.AUDIT_EXEMPT_SLUGS:
+            assert (_ROOT / "shows" / f"{slug}.yaml").exists(), (
+                f"exempt slug {slug} has no show config — stale exemption")
+            assert slug not in mod.SHOW_REGISTRY, (
+                f"{slug} is both registered and exempt")
+
+    def test_added_shows_have_the_schedule_the_cron_actually_uses(self):
+        # A wrong schedule is the other way an audit lies: it invents
+        # "missed episode" criticals on days the show never runs, which
+        # is what the env_intel odd_weekday bug did.
+        mod = self._mod()
+        cron = (_ROOT / ".github/workflows/run-show.yml").read_text(
+            encoding="utf-8")
+        assert '"46 9 * * *":       ("dp_pod",                   None)' in cron
+        assert mod.SHOW_REGISTRY["dp_pod"]["schedule"] == "daily"
+        assert '"1 10 * * 1":       ("offshore_north",          "monday")' in cron
+        assert mod.SHOW_REGISTRY["offshore_north"]["schedule"] == "monday"


### PR DESCRIPTION
Found while checking whether the catch-up pass from #1043 was actually draining.

## Two shows have never been quality-reviewed

Not "reviewed late" — **never reviewed**. Neither had a `SHOW_REGISTRY` entry in `review_episodes.py`:

| Show | Publishing since | Episodes unreviewed |
|---|---|---|
| `dp_pod` | 2026-07-04, daily | 42 |
| `offshore_north` | 2026-08-18, Mondays | all |

**The catch-up pass could not have caught this.** It ends "finished after the audit window", and it iterates the same registry — a show that isn't in it is invisible to catch-up too.

## Why it looked fine

`api/review_coverage.json` recorded **exactly the day's slate, every day**:

```
2026-08-17  10    2026-08-19  10    2026-08-21  10
2026-08-18  10    2026-08-20  10
```

Ten out of ten, five days running. Nothing to notice — because a show the registry omits cannot appear in the file that reports on the registry. The only way to see it was to diff recorded coverage against what actually shipped on disk: **10 slugs recorded on 2026-08-20, 11 episode sets present.**

That's the same shape as the bug #1043 fixed, one layer up. A coverage report that can only see what it already knows about will always look complete.

## It found real problems on the first run

Running the reviewer against `dp_pod` (structural checks only, no API key):

```
Catch-up: 3 episode(s) were never reviewed: dp_pod Ep039, Ep040, Ep041
Ep041: Podcast script below target (1132 words, floor 1550)
Ep039/041/042: Script may be missing closing section
```

Under-length against its own floor, and three of four recent episodes ending with no sign-off. Invisible for six weeks.

*(The `messenger R N A ×5` repetition warning is a false positive — that's the deliberate letter-by-letter TTS expansion of mRNA, working as intended.)*

## Guards

Three, because there are two distinct ways to get this wrong:

1. **`test_every_show_yaml_is_audited_or_explicitly_exempt`** — every show config must be registered or named in `AUDIT_EXEMPT_SLUGS` with a reason. A newly scaffolded show can't slip through.
2. **`test_exemptions_are_real_shows_and_stay_deliberate`** — an exemption must name a real show and must not also be registered, so the list can't rot.
3. **`test_added_schedules_match_the_cron`** — the registered schedule must match the cron the runner actually uses. A wrong schedule is the *other* way an audit lies: inventing "missed episode" criticals on days a show never runs, which is exactly what the `env_intel` `odd_weekday` bug did.

`age_of_ai` is the single exemption — it never runs through `run_show`, so schedule-based missed-episode detection would fire every day. Its gate is the two human review steps in the Nerra Voices pipeline.

## Also observed (not fixed here)

The 2026-08-21 audit's review step hit the **35-minute step cap** added in #1046 and failed. The cap did its job — it sits below the job budget precisely so a truncated review can't take the persist step down with it, and coverage committed and pushed normally. But the review is still being truncated each run, and the remediation step then dispatched recovery for four shows that had already published. **No double-publish resulted** (run-show's same-day duplicate guard held), so this is noise rather than damage — but the AI layer already has its own 20-minute budget, meaning ~15 minutes goes elsewhere, and that needs profiling rather than another guessed timeout. Flagging rather than guessing.

## Testing

- `tests/test_mit_benchmark_integrity.py` — **204 passed** (3 new).
- Live dry run of the reviewer against `dp_pod` for 2026-08-21: exit 0, catch-up picked up Ep039–041, **no false criticals**.
- Full suite: 26 failures, **identical to the baseline** captured on a clean tree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_