### PR TITLE
Books: curated chapter titles + four pipeline-integrity fixes from the first store submission

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -50,7 +50,10 @@ jobs:
     runs-on: ubuntu-latest
     # A 50-chapter narration is ~50 sequential TTS calls; generous but
     # well under the 6h default.
-    timeout-minutes: 120
+    # A full seven-volume rebuild is ~23 min/volume of sequential TTS +
+    # art; 120 was not enough for planner mode. Builds are resumable
+    # (R2 audio cache), so even a timeout loses only wall clock.
+    timeout-minutes: 360
     permissions:
       contents: write
       pull-requests: write  # recovery PR if push to main exhausts
@@ -104,6 +107,23 @@ jobs:
 
       - name: Verify book integrity
         run: python -m pytest tests/test_book_compiler.py -q
+
+      - name: Verify built artifacts are live
+        # The compiler tests above pass whether or not the run built
+        # anything (they did, on the zero-output run of 2026-08-22).
+        # This step asserts what the run claims: catalog files exist and
+        # every R2 object answers 200.
+        run: |
+          NOAUDIO=""
+          if [ "${{ github.event.inputs.skip_audio }}" = "true" ]; then
+            NOAUDIO="--no-audio"
+          fi
+          VOLUME="${{ github.event.inputs.volume }}"
+          if [ -n "$VOLUME" ]; then
+            python scripts/verify_book_catalog.py --volume "$VOLUME" $NOAUDIO
+          else
+            python scripts/verify_book_catalog.py --require-all $NOAUDIO
+          fi
 
       - name: Regenerate Books page
         run: python generate_html.py --books

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1045,7 +1045,18 @@ the show's public gallery with `intended_use` `book_chapter`/
 `book_cover` — values the video scene selector must NEVER match (the
 thumbnail_variant precedent). Cost/volume ≈ $1 art + $2 TTS, gated by
 `--max-image-cost-usd` / `--max-tts-cost-usd`. Rules that bind: chapter
-titles clip via `engine.titles.BOOK_CHAPTER_TITLE_MAX`; EVERY
+titles are CURATED (`chapter_titles:` map in each volume YAML — never
+derived from the episode hook, which is a full sentence and truncated
+in every store TOC on the first submission attempt, 2026-08-22) and
+clip via `engine.titles.BOOK_CHAPTER_TITLE_MAX`; narration speaks only
+"Chapter N." (deliberately decoupled from the printed title so title
+edits re-mux, never re-narrate); planner mode builds any committed
+volume with no cataloged artifacts (not just same-run plans), a
+no-upload build never writes the catalog, narrated tracks persist to
+R2 `books/<id>/audio/` keyed by narration-text hash (true CI
+resumability + the stores' per-chapter MP3s), and
+`scripts/verify_book_catalog.py` asserts claimed artifacts answer 200
+after every workflow build; EVERY
 reader-facing link goes through `engine.funnel` `kind="book"` (campaign
 carries the VOLUME number; each chapter ends on a funnel-tagged link to
 its source episode page); artifacts to R2 keyspace `books/<id>/` ONLY

--- a/books/volumes/first_principles_vol1.yaml
+++ b/books/volumes/first_principles_vol1.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  1: "The Rocket Engine"
+  2: "The Model T"
+  3: "Desalination"
+  4: "Bessemer's Blast"
+  5: "The Nuclear Premium"
+  6: "The Shipping Container"
+  7: "The Ammonia Floor"
+  8: "The Price of Sunlight"
+  9: "The Blood Test"
+  10: "The mRNA Shortcut"
+  11: "The Transmission Queue"
+  12: "Reusable Rockets"
+  13: "Capturing Carbon"
+  14: "Napoleon's Aluminum"
+  15: "The Price of Glasses"
+  16: "The Fifty-Dollar Bulb"
+  17: "The Hearing Aid Bundle"
+  18: "Sequencing the Genome"
+  19: "The Commercial Kitchen"
+  20: "Penicillin at Scale"

--- a/books/volumes/first_principles_vol2.yaml
+++ b/books/volumes/first_principles_vol2.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  21: "Haber-Bosch"
+  22: "The Geothermal Well"
+  23: "Fabric and Wire"
+  24: "The Indoor Farm"
+  25: "The Longshore Bottleneck"
+  26: "The Recycling Ledger"
+  27: "The Price of Light"
+  28: "The Insulin Gap"
+  29: "The Printed Page"
+  30: "The Lead Service Line"
+  31: "Interchangeable Parts"
+  32: "Beating 100 Percent"
+  33: "The Atlantic Cable"
+  34: "The Two-Billion-Dollar Mile"
+  35: "Glass Beats Copper"
+  36: "The Cement Kiln"
+  37: "The Jacquard Loom"
+  38: "The Dental Filling"
+  39: "The Battery Curve"
+  40: "The Last Mile"

--- a/books/volumes/first_principles_vol3.yaml
+++ b/books/volumes/first_principles_vol3.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  41: "The Ice Machine"
+  42: "Mining the Circuit Board"
+  43: "The Quartz Watch"
+  44: "The Cost of a House"
+  45: "The Cotton Gin"
+  46: "Brewing Protein"
+  47: "The Integrated Circuit"
+  48: "The Satellite Premium"
+  49: "The Catalytic Converter"
+  50: "Rail Versus Truck"
+  51: "The Sealed Can"
+  52: "The Prosthetic Gap"
+  53: "The Free Photograph"
+  54: "The Legal Document"
+  55: "Watt's Condenser"
+  56: "The Pipe Premium"
+  57: "Float Glass"
+  58: "The Cost of Care"
+  59: "The Dwarf Wheat"
+  60: "The Price of Parking"

--- a/books/volumes/unintended_consequences_vol1.yaml
+++ b/books/volumes/unintended_consequences_vol1.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  1: "The Cobra Bounty"
+  2: "The Cane Toad Invasion"
+  3: "Leaded Gasoline"
+  4: "DDT's Long Shadow"
+  5: "Prohibition"
+  6: "The Streisand Effect"
+  7: "The Freon Miracle"
+  8: "Taming the Nile"
+  9: "The Maginot Line"
+  10: "Penicillin's Promise"
+  11: "The News Feed"
+  12: "The GPS Effect"
+  13: "The Infinite Scroll"
+  14: "The Like Button"
+  15: "The Deepfake Engine"
+  16: "The PageRank Game"
+  17: "The E-Waste Avalanche"
+  18: "The Doorbell Panopticon"
+  19: "The Encyclopedia Gap"
+  20: "The Filter Bubble"

--- a/books/volumes/unintended_consequences_vol2.yaml
+++ b/books/volumes/unintended_consequences_vol2.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  21: "Three Strikes"
+  22: "The War on Drugs"
+  23: "Cash for Clunkers"
+  24: "The One-Child Policy"
+  25: "Rent Control"
+  26: "No Child Left Behind"
+  27: "The Aid Trap"
+  28: "Daylight Saving Time"
+  29: "The SUV Loophole"
+  30: "The Cookie Banner"
+  31: "Thalidomide"
+  32: "The Lobotomy Prize"
+  33: "The Radium Girls"
+  34: "OxyContin"
+  35: "Hormone Replacement"
+  36: "The Sanitizer Paradox"
+  37: "The Biofuel Mandate"
+  38: "The Malaria Nets"
+  39: "The DES Daughters"
+  40: "The Plastic Thread"

--- a/books/volumes/unintended_consequences_vol3.yaml
+++ b/books/volumes/unintended_consequences_vol3.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  41: "The Interstate Divide"
+  42: "Pruitt-Igoe"
+  43: "The Invention of Jaywalking"
+  44: "The Congestion Charge"
+  45: "Subsidized Sprawl"
+  46: "Airline Deregulation"
+  47: "Smokey's Megafires"
+  48: "The Sparrow Campaign"
+  49: "The Peanut Paradox"
+  50: "The Password Rules"
+  51: "Three Gorges"
+  52: "Quantitative Easing"
+  53: "Yellowstone Without Wolves"
+  54: "Flood Insurance"
+  55: "The Low-Fat Decades"
+  56: "The Moderators"
+  57: "The Salmon Dams"
+  58: "Gamification"
+  59: "Kudzu"
+  60: "Scared Straight"

--- a/books/volumes/unintended_consequences_vol4.yaml
+++ b/books/volumes/unintended_consequences_vol4.yaml
@@ -32,3 +32,28 @@ buy_links:
   google_play: ''
   kobo: ''
   spotify: ''
+
+# Curated short chapter titles (printed heading + TOC + audiobook
+# chapter markers; the narration speaks only "Chapter N", so edits
+# here never invalidate audio). Keyed by episode number.
+chapter_titles:
+  61: "The Scurvy Relapse"
+  62: "The Y2K Paradox"
+  63: "Fast Fashion"
+  64: "The Emptied Waterfront"
+  65: "The Bag Ban"
+  66: "D.A.R.E."
+  67: "The Magic Mineral"
+  68: "The Face Scanners"
+  69: "The Algorithm's Wage"
+  70: "Ending Cash Bail"
+  71: "The Filter Tip"
+  72: "The Seatbelt Effect"
+  73: "The Open Office"
+  74: "Rent Control, Revisited"
+  75: "The Nile Perch"
+  76: "King Corn"
+  77: "The Testing Factory"
+  78: "The Killer Bees"
+  79: "Loved to Death"
+  80: "The MTBE Mistake"

--- a/docs/books.md
+++ b/docs/books.md
@@ -53,30 +53,59 @@ default $10). Chapter images are re-encoded to ~1000px JPEGs so a
 volume's EPUB stays ~2 MB (Amazon charges per-MB delivery on the 70%
 royalty plan).
 
-Rules that bind: chapter TITLES clip through
-`engine.titles.BOOK_CHAPTER_TITLE_MAX` (titles rule); ALL reader-facing
-links are funnel-tagged through `engine.funnel` (`kind="book"`, campaign
-`nn-<show>-en-book-ep<volume>` — every chapter ends on a link to its
-source episode's page, the strongest podcast-conversion surface in the
-book); art style guides in the series configs BAN text inside generated
-images (typography is composited separately so series branding stays
-identical across volumes while every cover's art is new).
+Rules that bind:
+
+- **Chapter titles are CURATED, never derived.** Each volume YAML
+  carries a `chapter_titles:` map (episode number → 2-5-word title,
+  e.g. `1: "The Cobra Bounty"`). The original design clipped the
+  episode hook — a full podcast sentence — and every store TOC entry
+  read "Delhi's British government paid for dead cobras to…" (the
+  2026-08-22 launch blocker). A missing title prints as bare
+  "Chapter N" with a loud build warning; the planner scaffolds empty
+  placeholders in every new volume, and
+  `tests/test_book_compiler.py::TestChapterTitles` requires full
+  coverage on committed volumes. Titles still clip through
+  `engine.titles.BOOK_CHAPTER_TITLE_MAX` (titles rule).
+- **The spoken form is decoupled from the printed title.** Narration
+  says only "Chapter N."; the curated title appears in the heading,
+  TOC, and M4B chapter markers (metadata). Editing a title therefore
+  re-muxes, never re-narrates — title polish is free after the fact.
+- ALL reader-facing links are funnel-tagged through `engine.funnel`
+  (`kind="book"`, campaign `nn-<show>-en-book-ep<volume>` — every
+  chapter ends on a link to its source episode's page, the strongest
+  podcast-conversion surface in the book).
+- Art style guides in the series configs BAN text inside generated
+  images (typography is composited separately so series branding stays
+  identical across volumes while every cover's art is new).
 
 ## Building volumes
 
 - **One volume:** Actions → **Build Book** → volume id
   (e.g. `unintended_consequences_vol2`).
 - **Planner mode:** leave the volume input empty (or let the monthly
-  cron run) — every series with ≥ `volume_size` uncollected episodes
-  gets its next volume config generated, built, uploaded, and rendered
-  onto /books.html automatically. Store submission stays manual below.
+  cron run) — plans the next volume for every series with ≥
+  `volume_size` uncollected episodes AND builds every committed volume
+  whose catalog entry has no artifacts (the 2026-08-22 fix: planner
+  mode originally built only volumes created in that same run, so the
+  first live dispatch went green having built nothing). A volume that
+  was already built is NOT rebuilt by planner mode — to rebuild one
+  (new titles, re-rolled cover), dispatch it by name.
 - **Locally without credentials** the EPUB + branded cover still build
   (text-only, flat-color cover):
   `python scripts/build_book.py --volume <id> --skip-audio --skip-images --no-upload`.
+  A build that uploads nothing never touches `books/catalog.json` —
+  the catalog records what SHIPPED.
 
 Artifacts land in `outputs/books/<id>/` (gitignored) and on R2 under
-`books/<id>/`. The workflow commits `books/catalog.json`, any new
-volume YAMLs the planner wrote, and `books.html`.
+`books/<id>/`. Narrated tracks + text-hash sidecars persist to R2 at
+`books/<id>/audio/track_NNN.mp3` — this is what makes CI re-runs
+genuinely resumable (an ephemeral runner restores the cache and only
+re-bills tracks whose narration text changed), and it doubles as the
+per-chapter MP3 delivery audiobook stores ingest. The workflow commits
+`books/catalog.json`, any new volume YAMLs the planner wrote, and
+`books.html`, then verifies every claimed artifact answers 200 on R2
+(`scripts/verify_book_catalog.py` — the original verify step passed on
+a zero-output run).
 
 **Listen and look before you ship.** The audiobook is new spoken audio
 and the cover/chapter art is fresh generation — spot-listen two

--- a/engine/audiobook.py
+++ b/engine/audiobook.py
@@ -56,7 +56,7 @@ def narration_texts(volume: BookVolume,
         ("Opening Credits", opening_credits_text(volume))
     ]
     tracks += [
-        (f"Chapter {c.number}: {c.title}", chapter_tts_text(c))
+        (c.heading, chapter_tts_text(c))
         for c in chapters
     ]
     tracks.append(("Closing Credits", closing_credits_text(volume)))
@@ -74,9 +74,16 @@ def synthesize_tracks(
 ) -> List[Tuple[str, Path]]:
     """Narrate every track to ``track_NNN.mp3`` in *out_dir*.
 
-    Idempotent per track: an existing non-empty MP3 is kept, so a run
-    interrupted at chapter 14 resumes instead of re-billing 13 chapters.
+    Idempotent per track — and SAFELY so: each MP3 gets a
+    ``track_NNN.txthash`` sidecar holding the hash of the narration text
+    it was synthesized from, and a cached MP3 is reused only when the
+    hash still matches. That is what lets the caller persist/restore
+    this directory through R2 across ephemeral CI runners without ever
+    reusing audio whose script has since changed (e.g. the 2026-08-22
+    spoken-title change invalidates every chapter open automatically).
     """
+    import hashlib
+
     from engine.tts import prepare_text_for_tts, synthesize
 
     out_dir = Path(out_dir)
@@ -84,9 +91,18 @@ def synthesize_tracks(
     produced: List[Tuple[str, Path]] = []
     for i, (title, text) in enumerate(narration_texts(volume, chapters)):
         mp3 = out_dir / f"track_{i:03d}.mp3"
-        if mp3.exists() and mp3.stat().st_size > 0:
-            logger.info("audiobook: keeping existing %s", mp3.name)
+        sidecar = out_dir / f"track_{i:03d}.txthash"
+        text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+        cached = (mp3.exists() and mp3.stat().st_size > 0
+                  and sidecar.exists()
+                  and sidecar.read_text(encoding="utf-8").strip() == text_hash)
+        if cached:
+            logger.info("audiobook: keeping existing %s (text unchanged)",
+                        mp3.name)
         else:
+            if mp3.exists():
+                logger.info("audiobook: narration text changed — "
+                            "re-synthesizing %s", mp3.name)
             logger.info("audiobook: narrating %r (%d chars)", title, len(text))
             synthesize(
                 prepare_text_for_tts(text),
@@ -98,6 +114,7 @@ def synthesize_tracks(
                 # No speech wrap: books read at an even register; the
                 # <fast> energy wrap is an episode convention.
             )
+            sidecar.write_text(text_hash, encoding="utf-8")
         produced.append((title, mp3))
     return produced
 

--- a/engine/book_compiler.py
+++ b/engine/book_compiler.py
@@ -25,7 +25,6 @@ clipped through ``engine.titles`` — never sliced here (titles rule).
 
 from __future__ import annotations
 
-import html
 import json
 import logging
 import re
@@ -58,9 +57,6 @@ _SEGMENT_RE = re.compile(
 #: chapter epigraph rather than a section.
 _HOOK_SECTION_TITLES = {"the hook", "the cold open", "cold open", "hook"}
 
-_RSS_TITLE_RE = re.compile(r"<title>\s*Ep\s+(\d+):\s*(.*?)\s*</title>", re.DOTALL)
-
-
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -82,6 +78,15 @@ class BookChapter:
             words += sum(len(p.split()) for p in paras)
         return words
 
+    @property
+    def heading(self) -> str:
+        """Printed heading / TOC entry / audiobook chapter-marker name.
+        Deliberately NEVER spoken — narration says only "Chapter N." so a
+        title edit can re-mux metadata without re-narrating audio."""
+        if self.title:
+            return f"Chapter {self.number} · {self.title}"
+        return f"Chapter {self.number}"
+
 
 @dataclass
 class BookVolume:
@@ -95,6 +100,10 @@ class BookVolume:
     description: str = ""
     language: str = "en"
     episodes: List[int] = field(default_factory=list)
+    #: Curated short chapter titles keyed by EPISODE number. Written by a
+    #: person (or reviewed in a PR); never derived from the hook — see
+    #: parse_digest_to_chapter. Missing entries print as bare "Chapter N".
+    chapter_titles: Dict[int, str] = field(default_factory=dict)
     digest_dir: str = ""             # default: digests/<show_slug>
     rss_file: str = ""               # default: <show_slug>_podcast.rss
     buy_links: Dict[str, str] = field(default_factory=dict)
@@ -196,7 +205,13 @@ def load_volume(path: str | Path) -> BookVolume:
         # loudly rather than discard.
         logger.warning("volume config %s has unknown keys (ignored): %s",
                        path, unknown)
-    return BookVolume(**{k: v for k, v in data.items() if k in known})
+    vol = BookVolume(**{k: v for k, v in data.items() if k in known})
+    # YAML may deliver chapter_titles keys as ints or strings; normalize
+    # to int so lookups by episode number always hit.
+    vol.chapter_titles = {int(k): str(v).strip()
+                          for k, v in (vol.chapter_titles or {}).items()
+                          if str(v).strip()}
+    return vol
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +276,11 @@ def plan_next_volumes(series_slug: str, *, write: bool = True) -> List[Path]:
             "series": series_slug,
             "volume_number": next_num,
             "episodes": block,
+            # Curated short titles (2-5 words) per episode — REQUIRED
+            # before store submission; empty prints as bare "Chapter N".
+            # Never paste the episode hook here: hooks are full sentences
+            # and truncate in store TOCs (the 2026-08-22 launch blocker).
+            "chapter_titles": {ep: "" for ep in block},
             "buy_links": {k: "" for k in
                           ("amazon", "apple_books", "google_play",
                            "kobo", "spotify")},
@@ -306,25 +326,6 @@ def find_digest(volume: BookVolume, episode_num: int) -> Path:
     return matches[-1]
 
 
-def episode_titles_from_rss(rss_path: Path) -> Dict[int, str]:
-    """Map episode number -> hook sentence from the feed's item titles.
-
-    The feed's titles were built by ``engine.titles.episode_title`` so
-    they are already clean ("Ep N: <hook>"); we strip the numeric prefix
-    back off. Episodes that have left the feed window simply aren't in
-    the map — callers fall back to the digest's own hook line.
-    """
-    titles: Dict[int, str] = {}
-    if not rss_path.exists():
-        return titles
-    text = rss_path.read_text(encoding="utf-8")
-    for num, title in _RSS_TITLE_RE.findall(text):
-        cleaned = html.unescape(title).strip()
-        if cleaned:
-            titles.setdefault(int(num), cleaned)
-    return titles
-
-
 def _clean_inline(text: str) -> str:
     """Markdown inline debris -> plain prose (bold/italic markers kept
     OUT of the book body; emphasis in flowing prose reads fine without
@@ -362,7 +363,7 @@ def parse_digest_to_chapter(
     *,
     number: int,
     episode_num: int,
-    rss_title: str = "",
+    title: str = "",
 ) -> BookChapter:
     """Deterministic digest-markdown -> chapter transform.
 
@@ -370,6 +371,15 @@ def parse_digest_to_chapter(
     (later episodes) and the hook living inside a "Segment 1 — The Hook"
     section (early episodes). Segment scaffolding ("Segment N —") never
     reaches the book; the editorial section titles do.
+
+    *title* is the CURATED short chapter title from the volume YAML's
+    ``chapter_titles`` map — never derived from the episode hook. The
+    hook is a full podcast sentence; clipping it produced truncated
+    "Delhi's British government paid for dead cobras to cut snake…"
+    TOC entries on the first store submission attempt (2026-08-22).
+    With no curated title the chapter prints as bare "Chapter N" (a
+    normal essay-collection convention) and the hook survives as the
+    epigraph either way.
     """
     md_text = md_text.replace("\r\n", "\n")
 
@@ -401,28 +411,35 @@ def parse_digest_to_chapter(
             "format changed? Refusing to ship an empty chapter."
         )
 
-    title_source = rss_title or epigraph or sections[0][0]
-    title = clip_words(title_source, BOOK_CHAPTER_TITLE_MAX)
-
     return BookChapter(
         number=number,
         episode_num=episode_num,
-        title=title,
+        title=clip_words(title, BOOK_CHAPTER_TITLE_MAX) if title else "",
         epigraph=epigraph,
         sections=sections,
     )
 
 
 def collect_chapters(volume: BookVolume) -> List[BookChapter]:
-    rss_titles = episode_titles_from_rss(volume.resolved_rss())
     chapters: List[BookChapter] = []
+    curated = volume.chapter_titles or {}
+    missing = [ep for ep in volume.episodes if not curated.get(ep)]
+    if missing:
+        # Loud, not fatal: bare "Chapter N" is an acceptable convention,
+        # but a planner-fresh volume should get its titles written before
+        # store submission.
+        logger.warning(
+            "volume %s: no curated chapter_titles for episode(s) %s — "
+            "those chapters print as bare 'Chapter N'",
+            volume.volume_id, missing,
+        )
     for idx, ep in enumerate(volume.episodes, start=1):
         digest = find_digest(volume, ep)
         chapter = parse_digest_to_chapter(
             digest.read_text(encoding="utf-8"),
             number=idx,
             episode_num=ep,
-            rss_title=rss_titles.get(ep, ""),
+            title=str(curated.get(ep) or "").strip(),
         )
         m = re.search(r"_(\d{4})(\d{2})(\d{2})", digest.name)
         if m:
@@ -445,7 +462,9 @@ AI_NARRATION_DISCLOSURE = (
 
 def chapter_tts_text(chapter: BookChapter) -> str:
     """Plain narration text for one chapter — no markdown, no tags."""
-    parts = [f"Chapter {chapter.number}. {chapter.title.rstrip('.…')}."]
+    # Spoken form is JUST the number — deliberately decoupled from the
+    # printed title so title edits never invalidate narrated audio.
+    parts = [f"Chapter {chapter.number}."]
     if chapter.epigraph:
         parts.append(chapter.epigraph)
     for sec_title, paras in chapter.sections:
@@ -531,10 +550,9 @@ def _episode_page_link(volume: BookVolume, chapter: BookChapter) -> str:
 
 def _chapter_xhtml(chapter: BookChapter, lang: str,
                    volume: Optional[BookVolume] = None) -> str:
-    parts = [
-        f'<p class="chapnum">Chapter {chapter.number}</p>',
-        f"<h1>{xml_escape(chapter.title)}</h1>",
-    ]
+    parts = [f'<p class="chapnum">Chapter {chapter.number}</p>']
+    if chapter.title:
+        parts.append(f"<h1>{xml_escape(chapter.title)}</h1>")
     if chapter.image_name:
         parts.append(
             f'<p class="chapart"><img src="{xml_escape(chapter.image_name)}" '
@@ -553,7 +571,7 @@ def _chapter_xhtml(chapter: BookChapter, lang: str,
             f"{chapter.episode_num} of {xml_escape(volume.show_name)}</a>, "
             "free wherever you get podcasts.</p>"
         )
-    return _xhtml(chapter.title, "\n".join(parts), lang)
+    return _xhtml(chapter.heading, "\n".join(parts), lang)
 
 
 def _title_page_xhtml(volume: BookVolume) -> str:
@@ -608,7 +626,7 @@ def _nav_xhtml(volume: BookVolume, chapters: List[BookChapter]) -> str:
     ]
     items += [
         f'<li><a href="chap_{c.number:03d}.xhtml">'
-        f"{xml_escape(c.title)}</a></li>"
+        f"{xml_escape(c.heading)}</a></li>"
         for c in chapters
     ]
     body = (

--- a/scripts/build_book.py
+++ b/scripts/build_book.py
@@ -90,6 +90,81 @@ def _have_r2() -> bool:
                ("R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID", "R2_SECRET_ACCESS_KEY"))
 
 
+def _unbuilt_volume_ids() -> list:
+    """Volume configs whose catalog entry is absent or has no files."""
+    import json
+    built = {}
+    catalog = ROOT / "books" / "catalog.json"
+    if catalog.exists():
+        for v in json.loads(catalog.read_text(encoding="utf-8")).get(
+                "volumes", []):
+            built[v.get("volume_id")] = bool(v.get("files"))
+    return [p.stem for p in sorted((ROOT / "books" / "volumes").glob("*.yaml"))
+            if not built.get(p.stem)]
+
+
+def _r2_client():
+    import boto3
+    from botocore.config import Config as BotoConfig
+    return boto3.client(
+        "s3",
+        endpoint_url=os.getenv("R2_ENDPOINT_URL", "").strip(),
+        aws_access_key_id=os.getenv("R2_ACCESS_KEY_ID", "").strip(),
+        aws_secret_access_key=os.getenv("R2_SECRET_ACCESS_KEY", "").strip(),
+        config=BotoConfig(signature_version="s3v4"),
+    )
+
+
+def _books_bucket() -> str:
+    return os.getenv("R2_BOOKS_BUCKET", "podcast-audio").strip()
+
+
+def _restore_audio_cache(volume, audio_dir: Path) -> int:
+    """Pull previously narrated tracks (and their text-hash sidecars)
+    down from R2 so a CI re-run resumes instead of re-billing TTS. The
+    hash sidecar is what makes reuse safe: engine.audiobook regenerates
+    any track whose narration text changed. Soft-fails to zero restores."""
+    if not _have_r2():
+        return 0
+    prefix = f"{R2_BOOKS_PREFIX}/{volume.volume_id}/audio/"
+    restored = 0
+    try:
+        s3 = _r2_client()
+        paginator = s3.get_paginator("list_objects_v2")
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        for page in paginator.paginate(Bucket=_books_bucket(), Prefix=prefix):
+            for obj in page.get("Contents", []):
+                name = obj["Key"].rsplit("/", 1)[-1]
+                local = audio_dir / name
+                if name.startswith("track_") and not local.exists():
+                    s3.download_file(_books_bucket(), obj["Key"], str(local))
+                    restored += 1
+    except Exception as exc:  # noqa: BLE001 — cache is never build-fatal
+        logger.warning("audio cache restore failed (continuing cold): %s",
+                       exc)
+    if restored:
+        logger.info("audio cache: restored %d object(s) from R2", restored)
+    return restored
+
+
+def _persist_audio_cache(volume, audio_dir: Path) -> None:
+    """Push narrated tracks + hash sidecars to R2. Doubles as the
+    per-chapter MP3 delivery for audiobook-store submission (Spotify's
+    ingest wants chapterized MP3s — they now live at
+    books/<id>/audio/track_NNN.mp3)."""
+    if not _have_r2() or not audio_dir.exists():
+        return
+    try:
+        for f in sorted(audio_dir.glob("track_*")):
+            ctype = "audio/mpeg" if f.suffix == ".mp3" else "text/plain"
+            _r2_upload(
+                f, f"{R2_BOOKS_PREFIX}/{volume.volume_id}/audio/{f.name}",
+                ctype)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("audio cache persist failed (tracks stay local "
+                       "only): %s", exc)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--volume",
@@ -122,10 +197,27 @@ def main() -> int:
                     len(planned))
         if args.build_planned:
             to_build.extend(p.stem for p in planned)
+    if args.build_planned:
+        # A volume config with no artifacts in the catalog is pending work
+        # regardless of WHEN it was planned. Without this, planner mode
+        # only ever built volumes created in the same run — the first
+        # live dispatch (2026-08-22) went green in 70 s having built
+        # nothing, and the monthly cron would have no-opped forever.
+        pending = _unbuilt_volume_ids()
+        if pending:
+            logger.info("planner mode: %d committed volume(s) have no "
+                        "built artifacts: %s", len(pending), pending)
+            to_build.extend(pending)
     if args.volume:
         to_build.append(args.volume)
+    # Dedup, order-preserving (a just-planned volume is also "unbuilt").
+    to_build = list(dict.fromkeys(to_build))
     if not to_build:
-        logger.info("nothing to build")
+        if args.build_planned:
+            logger.info("planner mode: every committed volume is built "
+                        "and cataloged — nothing to do")
+        else:
+            logger.info("nothing to build")
         return 0
 
     for volume_id in to_build:
@@ -142,14 +234,14 @@ def _generate_book_art(volume, chapters, out_dir, api_key, args):
     chapter_images, cover_art, generated = {}, None, 0
     if args.skip_images:
         logger.info("book art: skipped (--skip-images)")
-        return chapter_images, cover_art, generated, 0.0
+        return chapter_images, cover_art, generated, 0.0, []
     if not (volume.image_model and volume.chapter_art_style):
         logger.info("book art: no image_model/style in series config — "
                     "skipping")
-        return chapter_images, cover_art, generated, 0.0
+        return chapter_images, cover_art, generated, 0.0, []
     if not api_key:
         logger.warning("book art: no GROK_API_KEY — text-only build")
-        return chapter_images, cover_art, generated, 0.0
+        return chapter_images, cover_art, generated, 0.0, []
 
     per_image = model_cost_usd(volume.image_model)
     est = per_image * (len(chapters) + 1)
@@ -170,8 +262,12 @@ def _generate_book_art(volume, chapters, out_dir, api_key, args):
         prompt = chapter_art_prompt(volume.chapter_art_style, ch)
         raw = generate_art(prompt, api_key=api_key,
                            model=volume.image_model, size=CHAPTER_ART_SIZE)
+        if not raw:  # one retry — transient API failures are common enough
+            raw = generate_art(prompt, api_key=api_key,
+                               model=volume.image_model,
+                               size=CHAPTER_ART_SIZE)
         if not raw:
-            continue  # soft: this chapter ships without art
+            continue  # soft: this chapter ships without art (reported below)
         jpeg = to_chapter_jpeg(raw)
         cached.write_bytes(jpeg)
         chapter_images[ch.number] = jpeg
@@ -198,7 +294,14 @@ def _generate_book_art(volume, chapters, out_dir, api_key, args):
     cost = generated * per_image
     logger.info("book art: %d generated ($%.2f), %d chapters illustrated",
                 generated, cost, len(chapter_images))
-    return chapter_images, cover_art, generated, cost
+    missing = [c.number for c in chapters if c.number not in chapter_images]
+    if missing:
+        # Loud but non-fatal — the first live build shipped 19/20
+        # illustrated with zero report. The ::warning:: renders as a GitHub
+        # Actions annotation; the catalog records it durably (see caller).
+        print(f"::warning::book art: volume {volume.volume_id} chapters "
+              f"WITHOUT illustration after retry: {missing}")
+    return chapter_images, cover_art, generated, cost, missing
 
 
 def _build_one(volume_id: str, args) -> int:
@@ -217,7 +320,7 @@ def _build_one(volume_id: str, args) -> int:
 
     api_key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY")
                or "").strip()
-    chapter_images, cover_art, images_generated, images_cost = (
+    chapter_images, cover_art, images_generated, images_cost, art_missing = (
         _generate_book_art(volume, chapters, out_dir, api_key, args))
 
     cover = generate_cover(volume, out_dir / "cover.png",
@@ -252,6 +355,7 @@ def _build_one(volume_id: str, args) -> int:
         "built_date": date.today().isoformat(),
         "images": {
             "chapters_illustrated": len(chapter_images),
+            "chapters_missing_art": art_missing,
             "generated": images_generated,
             "model": volume.image_model,
             "estimated_cost_usd": round(images_cost, 2),
@@ -278,10 +382,15 @@ def _build_one(volume_id: str, args) -> int:
                              est, args.max_tts_cost_usd)
                 return 1
             voice_id = os.getenv("BOOK_VOICE_ID", "kdif6sqjcyiq").strip()
+            audio_dir = out_dir / "audio"
+            if not args.no_upload:
+                _restore_audio_cache(volume, audio_dir)
             tracks = synthesize_tracks(
-                volume, chapters, out_dir / "audio",
+                volume, chapters, audio_dir,
                 api_key=api_key, voice_id=voice_id,
             )
+            if not args.no_upload:
+                _persist_audio_cache(volume, audio_dir)
             m4b = build_m4b(volume, tracks,
                             out_dir / f"{volume.volume_id}.m4b",
                             cover_png=cover)
@@ -309,8 +418,25 @@ def _build_one(volume_id: str, args) -> int:
         logger.info("uploaded %d artifacts to R2 under %s/",
                     len(entry["files"]), prefix)
 
-    update_catalog(entry)
-    logger.info("catalog updated: books/catalog.json")
+    # A CI build that was SUPPOSED to upload but produced no files is a
+    # failure, not a green run — the "Verify book integrity" step used to
+    # pass on a zero-output run because it only exercised the compiler.
+    if not args.no_upload and _have_r2() and not entry["files"].get("epub"):
+        logger.error("build produced no uploaded EPUB for %s — failing "
+                     "instead of cataloging an empty volume",
+                     volume.volume_id)
+        return 1
+
+    if entry["files"]:
+        update_catalog(entry)
+        logger.info("catalog updated: books/catalog.json")
+    else:
+        # A build with nothing uploaded (--no-upload dry run, or missing
+        # R2 creds) must not clobber a previously published entry: the
+        # catalog records what SHIPPED, and a local rebuild of vol1 once
+        # replaced its live files block with an empty one.
+        logger.info("catalog NOT updated — no uploaded artifacts "
+                    "(local artifacts remain under outputs/books/)")
     print(json.dumps({k: entry[k] for k in
                       ("volume_id", "chapters", "word_count", "files",
                        "audiobook")}, indent=2))

--- a/scripts/verify_book_catalog.py
+++ b/scripts/verify_book_catalog.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Verify that book builds actually shipped: catalog entries carry files
+and the R2 objects answer 200.
+
+    python scripts/verify_book_catalog.py --volume <id>   # one volume
+    python scripts/verify_book_catalog.py --require-all   # every volume yaml
+
+Exists because the workflow's original "Verify book integrity" step only
+ran the compiler tests — it passed in 2 s on a run that had built
+nothing (2026-08-22, Build Book run #1: green in 70 s, zero artifacts).
+This script is the assertion that step was missing: what the catalog
+claims to have built must be reachable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def check_volume(entry: dict, *, expect_audio: bool) -> list:
+    problems = []
+    files = entry.get("files") or {}
+    if not files.get("epub"):
+        problems.append("no epub in catalog files")
+        return problems
+    for kind, url in sorted(files.items()):
+        try:
+            r = requests.head(url, timeout=30, allow_redirects=True)
+            if r.status_code != 200:
+                problems.append(f"{kind}: HTTP {r.status_code} at {url}")
+        except requests.RequestException as exc:
+            problems.append(f"{kind}: unreachable ({exc}) at {url}")
+    if expect_audio and not entry.get("audiobook"):
+        problems.append("catalog entry has no audiobook block")
+    return problems
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--volume", help="verify this volume id only")
+    g.add_argument("--require-all", action="store_true",
+                   help="every books/volumes/*.yaml must be built + live")
+    ap.add_argument("--no-audio", action="store_true",
+                    help="don't require an audiobook block (ebook-only run)")
+    args = ap.parse_args()
+
+    catalog_path = ROOT / "books" / "catalog.json"
+    entries = {}
+    if catalog_path.exists():
+        for v in json.loads(catalog_path.read_text(encoding="utf-8")).get(
+                "volumes", []):
+            entries[v.get("volume_id")] = v
+
+    targets = ([args.volume] if args.volume else
+               sorted(p.stem for p in
+                      (ROOT / "books" / "volumes").glob("*.yaml")))
+
+    failures = 0
+    for vid in targets:
+        entry = entries.get(vid)
+        if not entry:
+            print(f"::error::{vid}: not in books/catalog.json")
+            failures += 1
+            continue
+        problems = check_volume(entry, expect_audio=not args.no_audio)
+        if problems:
+            failures += 1
+            for p in problems:
+                print(f"::error::{vid}: {p}")
+        else:
+            print(f"OK {vid}: {len(entry.get('files', {}))} artifacts live")
+
+    if failures:
+        print(f"::error::book verification failed for {failures} volume(s)")
+        return 1
+    print(f"verified {len(targets)} volume(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_book_catalog.py
+++ b/scripts/verify_book_catalog.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 from pathlib import Path
 
 import requests

--- a/tests/test_book_compiler.py
+++ b/tests/test_book_compiler.py
@@ -28,7 +28,6 @@ from engine.book_compiler import (  # noqa: E402
     chapter_tts_text,
     closing_credits_text,
     collect_chapters,
-    episode_titles_from_rss,
     find_digest,
     load_volume,
     opening_credits_text,
@@ -100,20 +99,64 @@ class TestDigestParsing:
 
 
 class TestChapterTitles:
-    def test_titles_go_through_the_titles_module(self):
-        """The titles rule: books clip via engine.titles, never a slice."""
-        v = _volume()
-        for ch in collect_chapters(v)[:10]:
-            assert fits(ch.title, BOOK_CHAPTER_TITLE_MAX), (
-                f"chapter {ch.number} title over limit: {ch.title!r}"
-            )
+    """Curated titles (2026-08-22). The original derivation clipped the
+    episode hook — a full podcast sentence — so every store-TOC entry was
+    a truncated "Delhi's British government paid for dead cobras to…".
+    Titles now come ONLY from the volume YAML's ``chapter_titles`` map;
+    a missing entry prints as bare "Chapter N", never a clipped hook."""
 
-    def test_rss_titles_strip_the_ep_prefix(self):
-        titles = episode_titles_from_rss(_volume().resolved_rss())
-        if not titles:  # feed window may have rolled past early episodes
-            return
-        for num, title in titles.items():
-            assert not title.lower().startswith(f"ep {num}"), title
+    def test_titles_are_book_titles_not_truncated_hooks(self):
+        from engine.titles import ELLIPSIS
+        for vp in sorted((_ROOT / "books" / "volumes").glob("*.yaml")):
+            v = load_volume(vp)
+            for ch in collect_chapters(v):
+                assert fits(ch.title, BOOK_CHAPTER_TITLE_MAX)
+                assert not ch.title.endswith(ELLIPSIS), (
+                    f"{v.volume_id} ch{ch.number}: clipped-hook title "
+                    f"shape returned: {ch.title!r}"
+                )
+                assert len(ch.title) <= 60, (
+                    f"{v.volume_id} ch{ch.number}: {ch.title!r} reads as "
+                    "a sentence, not a title"
+                )
+
+    def test_all_current_volumes_have_full_title_coverage(self):
+        """Every committed volume must be store-ready: a curated title
+        for every episode. (Planner-fresh FUTURE volumes may run bare
+        'Chapter N' until titled — that is a warning, not an error.)"""
+        for vp in sorted((_ROOT / "books" / "volumes").glob("*.yaml")):
+            v = load_volume(vp)
+            missing = [ep for ep in v.episodes
+                       if not v.chapter_titles.get(ep)]
+            assert not missing, f"{v.volume_id}: untitled episodes {missing}"
+
+    def test_titles_are_unique_within_a_series(self):
+        by_show = {}
+        for vp in sorted((_ROOT / "books" / "volumes").glob("*.yaml")):
+            v = load_volume(vp)
+            by_show.setdefault(v.show_slug, []).extend(
+                v.chapter_titles.values())
+        for slug, titles in by_show.items():
+            dupes = {t for t in titles if titles.count(t) > 1}
+            assert not dupes, f"{slug}: duplicate chapter titles {dupes}"
+
+    def test_heading_carries_number_and_title(self):
+        ch = collect_chapters(_volume())[0]
+        assert ch.heading == f"Chapter 1 · {ch.title}"
+
+    def test_untitled_chapter_prints_bare_number(self):
+        ch = _chapter(5)  # helper passes no curated title
+        assert ch.title == ""
+        assert ch.heading == "Chapter 1"
+
+    def test_planner_template_emits_title_placeholders(self):
+        import inspect
+        from engine.book_compiler import plan_next_volumes
+        src = inspect.getsource(plan_next_volumes)
+        assert "chapter_titles" in src, (
+            "planner must scaffold the chapter_titles map so new volumes "
+            "can't silently ship hook-less AND title-less"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +252,24 @@ class TestNarrationText:
         assert text.startswith("Chapter 1.")
         for bad in ("**", "###", "](", "<fast>", "[pause]", "<emphasis>"):
             assert bad not in text
+
+    def test_spoken_form_is_decoupled_from_printed_title(self):
+        """Narration says ONLY 'Chapter N.' — the curated title is printed
+        metadata. This is what lets a title edit re-mux the M4B without
+        re-narrating (and re-billing) a single track."""
+        chapters = collect_chapters(_volume())
+        ch = chapters[0]
+        assert ch.title, "fixture needs a curated title"
+        text = chapter_tts_text(ch)
+        first_line = text.split("\n", 1)[0]
+        assert first_line == "Chapter 1."
+        assert ch.title not in first_line
+
+    def test_track_names_use_the_printed_heading(self):
+        from engine.audiobook import narration_texts
+        chapters = collect_chapters(_volume())[:1]
+        tracks = narration_texts(_volume(), chapters)
+        assert tracks[1][0] == chapters[0].heading
 
     def test_both_credits_carry_the_disclosure(self):
         v = _volume()
@@ -430,6 +491,69 @@ class TestCatalog:
         data = json.loads(path.read_text(encoding="utf-8"))
         assert len(data["volumes"]) == 1
         assert data["volumes"][0]["word_count"] == 5
+
+
+class TestBuildPipelineIntegrity:
+    """The 2026-08-22 submission attempt found three silent-failure
+    shapes around the (correct) compiler: planner mode built nothing and
+    went green; the verify step verified nothing; CI re-runs re-billed
+    narration. Pin the fixes."""
+
+    def test_planner_mode_picks_up_unbuilt_committed_volumes(self, tmp_path,
+                                                             monkeypatch):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "build_book", _ROOT / "scripts" / "build_book.py")
+        bb = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(bb)
+        # Fake repo: two volume configs, one built, one with empty files.
+        (tmp_path / "books" / "volumes").mkdir(parents=True)
+        (tmp_path / "books" / "volumes" / "a_vol1.yaml").write_text("x: 1")
+        (tmp_path / "books" / "volumes" / "b_vol1.yaml").write_text("x: 1")
+        (tmp_path / "books" / "catalog.json").write_text(json.dumps({
+            "volumes": [
+                {"volume_id": "a_vol1", "files": {"epub": "https://x/e"}},
+                {"volume_id": "b_vol1", "files": {}},
+            ]}))
+        monkeypatch.setattr(bb, "ROOT", tmp_path)
+        assert bb._unbuilt_volume_ids() == ["b_vol1"]
+
+    def test_workflow_verifies_live_artifacts_not_just_the_compiler(self):
+        wf = (_ROOT / ".github" / "workflows" / "build-book.yml").read_text(
+            encoding="utf-8")
+        assert "scripts/verify_book_catalog.py" in wf, (
+            "the verify step must assert built artifacts are live — "
+            "pytest alone passed on a zero-output run"
+        )
+
+    def test_track_cache_is_keyed_by_narration_text(self, tmp_path,
+                                                    monkeypatch):
+        """A cached MP3 is reused only while its narration text is
+        unchanged — the sidecar hash is what makes the R2-persisted
+        cache safe across script changes."""
+        import engine.audiobook as ab
+        calls = []
+
+        def fake_synth(text, voice, path, **kw):
+            calls.append(str(path))
+            Path(path).write_bytes(b"mp3")
+
+        import engine.tts as tts
+        monkeypatch.setattr(tts, "synthesize", fake_synth)
+        monkeypatch.setattr(tts, "prepare_text_for_tts", lambda t: t)
+        v = _volume()
+        chapters = collect_chapters(v)[:1]
+        out = tmp_path / "audio"
+        ab.synthesize_tracks(v, chapters, out, api_key="k", voice_id="v")
+        n_first = len(calls)
+        assert n_first == 3  # opening + 1 chapter + closing
+        # Unchanged text: full reuse.
+        ab.synthesize_tracks(v, chapters, out, api_key="k", voice_id="v")
+        assert len(calls) == n_first
+        # Text change (simulate stale cache): only that track re-runs.
+        (out / "track_001.txthash").write_text("stale")
+        ab.synthesize_tracks(v, chapters, out, api_key="k", voice_id="v")
+        assert len(calls) == n_first + 1
 
 
 class TestWiring:


### PR DESCRIPTION
## Summary

Implements the 2026-08-22 field report from the first KDP/D2D submission attempt: one customer-facing launch blocker and three silent-failure pipeline bugs.

### Issue 1 (blocking) — chapter titles were truncated podcast hooks
Every store TOC entry, chapter heading, and spoken track open was a clipped hook sentence ("Delhi's British government paid for dead cobras to cut snake…"). Fixed with **approach B, structured as the spec recommended**:
- Each volume YAML now carries a `chapter_titles:` map (episode → 2–5-word title). **All 140 titles for the seven live volumes are written in this PR** — reviewable in the diff ("The Cobra Bounty", "The Streisand Effect", "Bessemer's Blast", "The Two-Billion-Dollar Mile"…).
- A missing title prints as bare "Chapter N" (a normal essay-collection convention) with a loud build warning — never a clipped hook. The planner scaffolds empty `chapter_titles` placeholders into every future volume.
- **Spoken form is decoupled by design**: narration says only "Chapter N."; the curated title lives in the heading, TOC, and M4B chapter markers (metadata). Title edits re-mux — they never re-narrate.
- RSS hook-title derivation (`episode_titles_from_rss`) removed entirely.
- Verified: local rebuild's TOC now reads `Chapter 1 · The Cobra Bounty`, `Chapter 2 · The Cane Toad Invasion`, …

### Issue 2 — planner mode silently built nothing
`--build-planned` now also picks up **any committed volume whose catalog entry has no `files`** — confirmed against the live catalog (six of seven volumes currently pending). The monthly cron can no longer no-op forever.

### Issue 3 — verification that verifies
New `scripts/verify_book_catalog.py` (workflow step after the build): asserts catalog `files` exist and every claimed R2 object answers HTTP 200 (`--volume <id>` for named dispatches, `--require-all` for planner mode, `--no-audio` on ebook-only runs). `build_book` itself now fails a credentialed run that produced no uploaded EPUB, and **a build that uploads nothing never writes the catalog** (a local dry run clobbered vol1's live entry during development — now impossible).

### Issue 4 — narration is now genuinely resumable across CI runs
Narrated tracks + narration-text-hash sidecars persist to R2 under `books/<id>/audio/` and restore at the start of the next run; a track re-bills only when its narration text changed. The hash check is also what safely invalidates all pre-fix audio (it spoke the truncated titles). Side benefit: the per-chapter MP3s the audiobook stores ingest now live permanently on R2 — the runbook's M4B-splitting step is obsolete.

### Also
- Chapter art gets **one retry**, and unillustrated chapters are reported loudly (`::warning::` annotation + `chapters_missing_art` in the catalog) — the first live build shipped 19/20 with zero report.
- Workflow `timeout-minutes` 120 → 360 (a full-catalog build is ~23 min/volume; the old ceiling couldn't fit planner mode).

### Verification
- `tests/test_book_compiler.py` grown to **51 guards**: title-shape (no `…`, ≤60 chars, full coverage on committed volumes, uniqueness within a series), heading format, bare-Chapter-N fallback, planner placeholder scaffolding, spoken/printed decoupling, track naming, planner unbuilt-pickup logic, workflow-verifies-artifacts wiring, and hash-keyed track-cache reuse/invalidation semantics. All pass.
- Full local suite: 6,770 passed (only the known environmental files excluded; they pass in CI).
- Local vol1 rebuild inspected: fixed TOC/headings, epigraphs intact, catalog untouched by the dry run.

### Rebuild plan after merge (operator/Cowork)
1. Dispatch **Build Book** with `volume=unintended_consequences_vol1` (planner mode correctly skips built volumes, and vol1's artifacts predate the title fix — it needs one named dispatch; its audio re-narrates in full by design, ~$1.64).
2. Dispatch once with `volume` **empty** — planner mode now builds the six pending volumes in one run (or dispatch one at a time; the concurrency group holds only a single pending run, so wait for each before queuing the next).
3. The verify step will fail the run if anything claimed isn't live on R2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CP8nr1ZMbPo2bbjZd1hSr3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP8nr1ZMbPo2bbjZd1hSr3)_