### PR TITLE
Daily audit: cross-check every schedule against the cron

### DIFF
--- a/review_episodes.py
+++ b/review_episodes.py
@@ -264,7 +264,14 @@ SHOW_REGISTRY = {
         "max_audio_s": 1200,
         "required_sections": [],
         "narrative": True,   # topic-queue show — fetches no articles by design
-        "schedule": "weekday",
+        # DAILY, not weekday. The cron is "1 9 * * *" with no day gate and
+        # the show ships all seven days (3 Saturdays + 3 Sundays in the
+        # last 21 episodes). While this said "weekday" the audit treated
+        # UC as not-due at weekends, so a MISSED Saturday or Sunday
+        # episode raised nothing — under-alerting, the quiet direction of
+        # the same bug env_intel had loudly. Found 2026-08-21 by
+        # cross-checking every registry schedule against the cron.
+        "schedule": "daily",
     },
     # Added 2026-08-21. Both shows had been publishing with NO quality
     # review at all — dp_pod daily since 2026-07-04, offshore_north since

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2721,14 +2721,56 @@ class TestAuditRegistryCoversEveryShow:
             assert slug not in mod.SHOW_REGISTRY, (
                 f"{slug} is both registered and exempt")
 
-    def test_added_shows_have_the_schedule_the_cron_actually_uses(self):
-        # A wrong schedule is the other way an audit lies: it invents
-        # "missed episode" criticals on days the show never runs, which
-        # is what the env_intel odd_weekday bug did.
+    def test_every_registry_schedule_matches_the_cron(self):
+        """The audit must believe the schedule the runner actually uses.
+
+        A wrong schedule breaks the missed-episode check in whichever
+        direction it errs. Too broad invents criticals on days a show
+        never runs — the env_intel ``odd_weekday`` bug, which also
+        auto-dispatched off-schedule episodes. Too narrow is quieter and
+        worse: ``unintended_consequences`` was registered ``weekday``
+        while its cron runs daily and it ships every day, so a missed
+        Saturday or Sunday raised nothing at all.
+
+        Checking the pair mechanically is the only way to keep them
+        honest — reading either one alone looks fine.
+        """
+        import re
         mod = self._mod()
-        cron = (_ROOT / ".github/workflows/run-show.yml").read_text(
+        cron_src = (_ROOT / ".github/workflows/run-show.yml").read_text(
             encoding="utf-8")
-        assert '"46 9 * * *":       ("dp_pod",                   None)' in cron
-        assert mod.SHOW_REGISTRY["dp_pod"]["schedule"] == "daily"
-        assert '"1 10 * * 1":       ("offshore_north",          "monday")' in cron
-        assert mod.SHOW_REGISTRY["offshore_north"]["schedule"] == "monday"
+        pairs = re.findall(
+            r'"(\S+ \S+ \S+ \S+ \S+)":\s*\("(\w+)",\s*(None|"[a-z_]+")\)',
+            cron_src)
+        assert pairs, "could not parse the runner's CRON_MAP"
+
+        checked = 0
+        for expression, slug, gate in pairs:
+            entry = mod.SHOW_REGISTRY.get(slug)
+            if entry is None:
+                continue  # covered by the registry-coverage test above
+            day_of_week = expression.split()[4]
+            if day_of_week == "*" and gate == "None":
+                expected = "daily"
+            elif day_of_week == "1" and gate == '"monday"':
+                expected = "monday"
+            else:
+                # A cadence shape this check does not model yet. Fail
+                # rather than skip silently — an unmodelled shape is
+                # exactly where a mismatch would hide.
+                raise AssertionError(
+                    f"{slug}: unmodelled cron shape {expression!r} "
+                    f"with gate {gate} — teach this guard the shape "
+                    "rather than leaving it unchecked."
+                )
+            assert entry["schedule"] == expected, (
+                f"{slug}: cron {expression!r} (gate {gate}) means "
+                f"{expected!r}, but the audit registry says "
+                f"{entry['schedule']!r}. A schedule the runner does not "
+                "use makes the missed-episode check lie."
+            )
+            checked += 1
+        assert checked >= 15, (
+            f"only cross-checked {checked} shows — the CRON_MAP parse "
+            "probably drifted"
+        )


### PR DESCRIPTION
Re-opens work that **#1059 did not actually merge.** That PR took only its first commit (`4c07644c`, the dp_pod/offshore_north registry entries); the second commit landed on the branch moments before the merge and was left behind. Verified against `main`: `unintended_consequences` still reads `"schedule": "weekday"` and `test_every_registry_schedule_matches_the_cron` is absent.

Same content, cherry-picked onto current `main` and re-verified.

## `unintended_consequences` is registered `weekday` and ships daily

Its cron is `1 9 * * *` with no day gate, and it publishes **all seven days** — 3 Saturdays and 3 Sundays in the last 21 episodes. At weekends the audit treats it as not-due, so a **missed Saturday or Sunday episode raises nothing at all**.

That's the quiet direction of the bug `env_intel` had loudly:

| | Too broad | Too narrow |
|---|---|---|
| `env_intel` (`odd_weekday`) | invented criticals on days it never ran, and auto-dispatched off-schedule episodes | — |
| `unintended_consequences` (`weekday`) | — | stops asking at weekends; silence looks identical to health |

## Why the guard is mechanical

The version in #1059 pinned the two shows I'd just added, by hand. It would have passed forever while UC stayed wrong — a guard that only checks the thing you were already thinking about.

This one cross-checks the **whole registry** against the runner's `CRON_MAP`. Reading either side alone looks correct in both failure modes above; only the pair is checkable, so the guard checks the pair.

An unmodelled cron shape **fails** rather than being skipped — a shape the guard doesn't understand is exactly where the next mismatch would hide.

## Verification

Negative control, reverting UC's schedule:

```
AssertionError: unintended_consequences: cron '1 9 * * *' (gate None) means 'daily',
but the audit registry says 'weekday'. A schedule the runner does not use makes the
missed-episode check lie.
```

- `tests/test_mit_benchmark_integrity.py` — **204 passed**
- Full suite: 26 failures, **identical to the baseline** on a clean tree

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_