### PR TITLE
Nerra Personal: one-account membership, personalized Mira feeds, donations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -850,6 +850,39 @@ any failure logs a warning and ships the exact legacy render.
   `broll_clips_used`, `thumbnail_base`, `thumbnail_variant_urls`. Drift
   guards: `tests/test_visual_reuse.py`.
 
+### Nerra Personal — accounts, personalized feeds, donations (Aug 2026)
+
+The member surface (operator-directed). **One identity**: a "Nerra
+account" IS the gallery Worker's existing JWT/Buttondown identity —
+every newsletter signup (footer + `/join.html` both POST the Worker's
+`/api/subscribe`, `list:"member"`; the Buttondown-direct embed form is
+GONE) creates an account that unlocks gallery downloads, per-show
+newsletter tags (closed `SHOW_NEWSLETTER_TAGS` set in
+`workers/gallery/src/handlers.ts`), and member perks
+(`MEMBER_BOOK_CODE` book discount). **Paid tier**: a private daily feed
+of the subscriber's chosen shows in THEIR order, Mira anchoring by name
+($4.99/mo; +city morning brief $8.99/mo — Open-Meteo weather +
+one web-search call under the field-note honesty rules).
+`engine/personal_edition.py` (closed vocabulary = the EN edition lineup;
+kept in sync with the Worker's copy by a drift test) +
+`scripts/build_personal_feeds.py` (segments trimmed ONCE/day into a
+shared cache — per-user marginal cost ~$0.05-0.07/day; **PII rules: runs
+on a PRIVATE host only, specs carry token/name/city never email, logs
+truncate tokens**) + Worker endpoints in
+`workers/gallery/src/personal.ts` (KV member records, Stripe webhook
+mints/revokes feed tokens — cancel = feed 404s immediately; feeds served
+Worker-gated from R2 `nerra-personal`, `itunes:block` on).
+**Donations**: `/support.html` (cost-transparency pitch + Stripe links);
+every feed's `podcast:funding` tag now points THERE (was `/#newsletter`)
+— it renders as the Support button in 2.0 apps. Pages
+(`join/account/support.html`) regenerate with `--network`/`--all`;
+Stripe URLs flow from env (`STRIPE_LINK_*`), unset = honest
+"launching soon" states. Everything Worker-side degrades to 503 until
+the operator provisions KV + the `nerra-personal` bucket + secrets
+(checklist: [`docs/nerra_personal.md`](docs/nerra_personal.md)). Drift
+guards: `tests/test_nerra_personal.py`,
+`workers/gallery/test/personal.test.ts`.
+
 ### Cost-efficiency pass (July 29 2026)
 
 Six changes that cut spend without touching what a listener gets. The

--- a/account.html
+++ b/account.html
@@ -3,27 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta name="description" content="Manage your Nerra account: your personal feed lineup, newsletter, gallery access and member perks.">
     
-    
-    <title>Data & Dashboards | Nerra Network</title>
-    <meta name="theme-color" content="#6B47FF">
+    <meta name="keywords" content="Nerra Network membership, personalized podcast, Nerra Personal, support Nerra Network">
+    <title>Your account | Nerra Network</title>
+    <meta name="theme-color" content="#00D4FF">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Data & Dashboards | Nerra Network">
-    <meta property="og:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta property="og:title" content="Your account | Nerra Network">
+    <meta property="og:description" content="Manage your Nerra account: your personal feed lineup, newsletter, gallery access and member perks.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://nerranetwork.com/assets/og-default.png">
-    <meta property="og:url" content="https://nerranetwork.com/data.html">
+    <meta property="og:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
+    <meta property="og:url" content="https://nerranetwork.com/account.html">
     <meta property="og:site_name" content="Nerra Network">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Data & Dashboards | Nerra Network">
-    <meta name="twitter:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
-    <meta name="twitter:image" content="https://nerranetwork.com/assets/og-default.png">
+    <meta name="twitter:title" content="Your account | Nerra Network">
+    <meta name="twitter:description" content="Manage your Nerra account: your personal feed lineup, newsletter, gallery access and member perks.">
+    <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
 
-    <link rel="canonical" href="https://nerranetwork.com/data.html">
+    <link rel="canonical" href="https://nerranetwork.com/account.html">
     
     
     
@@ -60,32 +60,24 @@
     <link rel="stylesheet" href="styles/main.css">
 
     
-<style>
-  .dh-hero { position:relative; overflow:hidden;
-    background:
-      radial-gradient(1100px 520px at 50% -10%, rgba(107,71,255,0.22), transparent 60%),
-      linear-gradient(180deg, #060812 0%, #0c1020 60%, #0a0e1c 100%);
-    border-bottom:1px solid rgba(140,140,255,0.14); }
-  .dh-container { max-width:1120px; margin:0 auto; padding:calc(var(--nav-height) + 2.6rem) 1.25rem 2rem; position:relative; z-index:1; }
-  .dh-kicker { display:inline-flex; align-items:center; gap:8px; font-size:0.78rem; letter-spacing:0.14em; text-transform:uppercase; color:#9b8cff; font-weight:700; margin-bottom:0.5rem; }
-  .dh-h1 { font-size:clamp(1.9rem,4vw,2.9rem); line-height:1.05; margin:0 0 0.5rem; font-weight:800; letter-spacing:-0.02em; color:#fff; }
-  .dh-sub { color:#b9c0e0; font-size:1.04rem; max-width:64ch; margin:0 0 0.4rem; }
-
-  .dh-grid { max-width:1120px; margin:1.8rem auto; padding:0 1.25rem; display:grid; gap:1.2rem; grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
-  @media (max-width:760px){ .dh-grid{ grid-template-columns:minmax(0,1fr); } }
-  .dh-card { display:block; text-decoration:none; color:inherit; border-radius:18px; padding:1.4rem 1.5rem;
-    border:1px solid rgba(140,140,255,0.16); background:var(--nn-surface,#0f1326);
-    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease; position:relative; overflow:hidden; }
-  .dh-card:hover { transform:translateY(-3px); border-color:var(--accent,#6B47FF); box-shadow:0 14px 40px rgba(0,0,0,0.4); }
-  .dh-card::before { content:""; position:absolute; inset:0 auto 0 0; width:5px; background:var(--accent,#6B47FF); }
-  .dh-card h2 { margin:0 0 0.3rem; font-size:1.3rem; color:#fff; letter-spacing:-0.01em; }
-  .dh-card .dh-tag { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--accent,#9b8cff); font-weight:700; }
-  .dh-card p { color:#aeb6d8; font-size:0.94rem; margin:0.5rem 0 0.9rem; line-height:1.5; }
-  .dh-metrics { display:flex; flex-wrap:wrap; gap:8px; margin-top:0.4rem; }
-  .dh-chip { font-size:0.74rem; color:#cdd4f0; background:rgba(140,140,255,0.10); border:1px solid rgba(140,140,255,0.18); border-radius:999px; padding:3px 10px; }
-  .dh-go { display:inline-flex; align-items:center; gap:6px; margin-top:1rem; color:var(--accent,#9b8cff); font-weight:700; font-size:0.92rem; }
-  .dh-note { max-width:1120px; margin:0 auto 2.4rem; padding:0 1.25rem; color:#8b91b4; font-size:0.82rem; }
-</style>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        .nn-account { max-width: 760px; margin: 0 auto; padding: calc(var(--nav-height) + var(--sp-10)) var(--sp-6) var(--sp-12); }
+        .nn-account h1 { font-family: var(--font-heading); }
+        .nn-card { border: 1px solid var(--nn-border); border-radius: 14px; background: var(--nn-surface); padding: var(--sp-5); margin-bottom: var(--sp-5); }
+        .nn-card h2 { margin: 0 0 var(--sp-3); font-size: 1.1rem; font-family: var(--font-heading); }
+        .nn-account input[type=email], .nn-account input[type=text] { width: 100%; padding: 0.7rem 0.9rem; border-radius: 10px; border: 1px solid var(--nn-border); background: var(--nn-bg, transparent); color: inherit; }
+        .nn-account button { padding: 0.65rem 1.4rem; border-radius: 10px; border: none; background: var(--nn-gradient); color: #fff; font-weight: 600; cursor: pointer; }
+        .nn-account button.ghost { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-lineup-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.2rem; border-bottom: 1px dashed var(--nn-border); }
+        .nn-lineup-row .movers { margin-left: auto; display: flex; gap: 0.25rem; }
+        .nn-lineup-row .movers button { padding: 0.15rem 0.55rem; font-size: 0.9rem; }
+        .nn-feedurl { font-family: var(--font-mono, monospace); font-size: 0.8rem; word-break: break-all; background: var(--nn-bg, rgba(0,0,0,0.15)); padding: 0.6rem 0.8rem; border-radius: 8px; }
+        .nn-perk { display: flex; justify-content: space-between; gap: 1rem; padding: 0.5rem 0; border-bottom: 1px dashed var(--nn-border); }
+        .nn-muted { color: var(--nn-text-muted); font-size: 0.9rem; }
+        #nn-status { min-height: 1.2rem; font-size: 0.9rem; }
+        [hidden] { display: none !important; }
+    </style>
 
 
     
@@ -553,88 +545,183 @@
 
     <main id="main-content">
     
-<div class="dh-hero">
-  <div class="dh-container">
-    <div class="dh-kicker"><span>◆</span> Nerra Data</div>
-    <h1 class="dh-h1">Data &amp; Dashboards</h1>
-    <p class="dh-sub">Live, continuously-updated data behind the shows — launch countdowns, market prices, fleet records, and simulated-portfolio performance. Real numbers from public sources, refreshed every pipeline run; curated history is operator-maintained and clearly labelled.</p>
-  </div>
+<div class="nn-account">
+    <h1>Your Nerra account</h1>
+    <p id="nn-status" class="nn-muted">Loading…</p>
+
+    <!-- Signed-out: magic-link request -->
+    <div class="nn-card" id="nn-signin" hidden>
+        <h2>Sign in</h2>
+        <p class="nn-muted">No passwords here — enter the email you joined with
+           and we'll send you a sign-in link.</p>
+        <form onsubmit="NN.login(this);return false;" style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+            <input type="email" name="email" placeholder="you@example.com" required style="flex:1;min-width:220px;">
+            <button type="submit">Email me a link</button>
+        </form>
+        <p class="nn-muted" style="margin-top:0.75rem;">New here?
+            <a href="join.html">Create your free account →</a></p>
+    </div>
+
+    <div id="nn-member" hidden>
+        <!-- Personal feed -->
+        <div class="nn-card">
+            <h2>Your personal daily show</h2>
+            <div id="nn-feed-active" hidden>
+                <p>Mira builds your edition every morning. Add this private
+                   feed to any podcast app — it's yours alone; sharing the
+                   URL shares your subscription.</p>
+                <p class="nn-feedurl" id="nn-feed-url"></p>
+                <button class="ghost" onclick="NN.copyFeed()">Copy feed URL</button>
+            </div>
+            <div id="nn-feed-upsell" hidden>
+                <p>Pick your shows and order below, then start your
+                   subscription — your feed exists within a day.</p>
+                
+                <p class="nn-muted">Personal feeds are launching soon — your
+                   saved lineup will be ready on day one.</p>
+                
+            </div>
+        </div>
+
+        <!-- Lineup + preferences -->
+        <div class="nn-card">
+            <h2>Your lineup</h2>
+            <p class="nn-muted">Choose at least two shows; order them the way
+               you want your morning to run. Mira handles the rest.</p>
+            <div id="nn-lineup"></div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-top:var(--sp-4);">
+                <label>First name <span class="nn-muted">(Mira greets you by it)</span>
+                    <input type="text" id="nn-name" maxlength="40" placeholder="Optional"></label>
+                <label>City <span class="nn-muted">(for the local brief tier)</span>
+                    <input type="text" id="nn-city" maxlength="80" placeholder="Optional"></label>
+            </div>
+            <p style="margin-top:var(--sp-4);"><button onclick="NN.save()">Save preferences</button>
+               <span id="nn-save-status" class="nn-muted"></span></p>
+        </div>
+
+        <!-- Member perks -->
+        <div class="nn-card">
+            <h2>Member perks</h2>
+            <div class="nn-perk"><span>Newsletter</span>
+                <span class="nn-muted">You're on the list — manage shows in any email's footer</span></div>
+            <div class="nn-perk"><span>Image gallery downloads</span>
+                <a href="gallery.html">Browse the gallery →</a></div>
+            <div class="nn-perk"><span>Book discount</span>
+                <span id="nn-book-perk" class="nn-muted">—</span></div>
+            <div class="nn-perk"><span>Support the network</span>
+                <a href="support.html">Donate →</a></div>
+        </div>
+    </div>
 </div>
 
-<div class="dh-grid">
-  <a class="dh-card" href="spacex-dashboard.html" style="--accent:#00D4FF;">
-    <span class="dh-tag">SpaceX Daily</span>
-    <h2>SpaceX Launch Dashboard</h2>
-    <p>Next-launch countdown, watch-live links, launch cadence, mass to orbit, the booster-reuse record watch, the Starship flight-test tracker, and live SPCX price.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live countdown</span>
-      <span class="dh-chip">Booster records</span>
-      <span class="dh-chip">Starship tracker</span>
-      <span class="dh-chip">SPCX price</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
+<script>
+var NN = (function () {
+  var API = 'https://api.nerranetwork.com';
+  var state = { shows: [], all: [], names: {} };
+  var SHOW_NAMES = {"dp_pod": "The DP Pod: The Do Positive Podcast", "env_intel": "Environmental Intelligence", "fascinating_frontiers": "Fascinating Frontiers", "first_principles": "First Principles Daily", "models_agents": "Models \u0026 Agents", "models_agents_beginners": "Models \u0026 Agents for Beginners", "modern_investing": "Modern Investing Techniques", "offshore_north": "Offshore North", "omni_view": "Omni View", "planetterrian": "Planetterrian Daily", "spacex": "SpaceX Daily", "tesla": "Tesla Shorts Time", "unintended_consequences": "Unintended Consequences"};
 
-  <a class="dh-card" href="tesla-dashboard.html" style="--accent:#E31937;">
-    <span class="dh-tag">Tesla Shorts Time</span>
-    <h2>Tesla Dashboard</h2>
-    <p>Live TSLA price with a 1-year chart and 52-week range, quarterly production &amp; deliveries, Supercharger network growth, energy-storage deployments, and milestones.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live TSLA</span>
-      <span class="dh-chip">Quarterly P&amp;D</span>
-      <span class="dh-chip">Supercharger growth</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
+  function el(id) { return document.getElementById(id); }
 
-  <a class="dh-card" href="modern-investing-performance.html" style="--accent:#10b981;">
-    <span class="dh-tag">Modern Investing Techniques</span>
-    <h2>Performance &amp; Recursive Learning</h2>
-    <p>The simulated practice portfolio's cumulative return, monthly P&amp;L, win/loss split, sector breakdown, recent trades, and the operating principles the model derives from its own results. Education only.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Equity curve</span>
-      <span class="dh-chip">Monthly P&amp;L</span>
-      <span class="dh-chip">Alpha vs NASDAQ</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
+  function renderLineup() {
+    var box = el('nn-lineup');
+    box.innerHTML = '';
+    var chosen = state.shows.slice();
+    var rest = state.all.filter(function (s) { return chosen.indexOf(s) === -1; });
+    chosen.concat(rest).forEach(function (slug) {
+      var idx = chosen.indexOf(slug);
+      var row = document.createElement('div');
+      row.className = 'nn-lineup-row';
+      var cb = document.createElement('input');
+      cb.type = 'checkbox'; cb.checked = idx !== -1;
+      cb.onchange = function () {
+        if (cb.checked) { state.shows.push(slug); }
+        else { state.shows = state.shows.filter(function (s) { return s !== slug; }); }
+        renderLineup();
+      };
+      var label = document.createElement('span');
+      label.textContent = (idx !== -1 ? (idx + 1) + '. ' : '') + (SHOW_NAMES[slug] || slug);
+      row.appendChild(cb); row.appendChild(label);
+      if (idx !== -1) {
+        var movers = document.createElement('span');
+        movers.className = 'movers';
+        [['↑', -1], ['↓', 1]].forEach(function (m) {
+          var b = document.createElement('button');
+          b.className = 'ghost'; b.textContent = m[0]; b.type = 'button';
+          b.onclick = function () {
+            var j = idx + m[1];
+            if (j < 0 || j >= state.shows.length) return;
+            state.shows.splice(idx, 1);
+            state.shows.splice(j, 0, slug);
+            renderLineup();
+          };
+          movers.appendChild(b);
+        });
+        row.appendChild(movers);
+      }
+      box.appendChild(row);
+    });
+  }
 
-  <a class="dh-card" href="gallery.html" style="--accent:#6B47FF;">
-    <span class="dh-tag">Network</span>
-    <h2>Image Gallery</h2>
-    <p>Every AI-generated visual produced for the shows — filterable by show and date, free to download under CC BY-SA 4.0 with attribution.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Filter by show</span>
-      <span class="dh-chip">CC BY-SA 4.0</span>
-    </div>
-    <span class="dh-go">Browse gallery →</span>
-  </a>
+  function load() {
+    fetch(API + '/api/account', { credentials: 'include' })
+      .then(function (r) { if (!r.ok) throw new Error(r.status); return r.json(); })
+      .then(function (data) {
+        el('nn-status').textContent = '';
+        el('nn-member').hidden = false;
+        state.all = data.shows || [];
+        var prefs = (data.member && data.member.preferences) || {};
+        state.shows = prefs.shows || [];
+        el('nn-name').value = prefs.first_name || '';
+        el('nn-city').value = prefs.city || '';
+        renderLineup();
+        var feedUrl = data.member && data.member.feed_url;
+        el('nn-feed-active').hidden = !feedUrl;
+        el('nn-feed-upsell').hidden = !!feedUrl;
+        if (feedUrl) { el('nn-feed-url').textContent = feedUrl; }
+        var code = data.perks && data.perks.book_discount_code;
+        el('nn-book-perk').innerHTML = code
+          ? 'Use code <strong>' + code + '</strong> at the book store — '
+            + '<a href="books.html">see the books →</a>'
+          : 'Member codes appear here as new volumes launch';
+      })
+      .catch(function () {
+        el('nn-status').textContent = '';
+        el('nn-signin').hidden = false;
+      });
+  }
 
-  <a class="dh-card" href="tesla-narrative.html" style="--accent:#E31937;">
-    <span class="dh-tag">Story Trackers</span>
-    <h2>Longitudinal Chronicles</h2>
-    <p>Follow major programs across episodes — Tesla's Story Tracker, plus Models &amp; Agents, Fascinating Frontiers, Planetterrian, and SpaceX.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Tesla</span>
-      <span class="dh-chip">SpaceX</span>
-      <span class="dh-chip">AI</span>
-      <span class="dh-chip">Science</span>
-    </div>
-    <span class="dh-go">Open Tesla tracker →</span>
-  </a>
-</div>
-
-<p class="dh-note" style="margin-top:-1rem;">
-  More story trackers:
-  <a href="models-agents-narrative.html" style="color:#9b8cff;">Models &amp; Agents</a> ·
-  <a href="fascinating-frontiers-narrative.html" style="color:#9b8cff;">Fascinating Frontiers</a> ·
-  <a href="planetterrian-narrative.html" style="color:#9b8cff;">Planetterrian</a> ·
-  <a href="spacex-narrative.html" style="color:#9b8cff;">SpaceX</a>
-</p>
-
-<p class="dh-note">
-  Sources: launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:#9b8cff;">The Space Devs</a> Launch Library 2, active-satellite counts from <a href="https://celestrak.org/" target="_blank" rel="noopener" style="color:#9b8cff;">CelesTrak</a>, and market quotes from Yahoo Finance — each refreshed on every pipeline run, with the last good value kept on a fetch hiccup. Estimated figures (mass to orbit, satellites deployed) use public per-vehicle averages and are labelled as estimates. Nothing here is financial advice.
-</p>
+  return {
+    login: function (form) {
+      var btn = form.querySelector('button');
+      btn.disabled = true; btn.textContent = 'Sending…';
+      fetch(API + '/api/login?email=' + encodeURIComponent(form.email.value))
+        .then(function () { btn.textContent = 'Check your inbox'; })
+        .catch(function () { btn.textContent = 'Try again'; btn.disabled = false; });
+    },
+    save: function () {
+      el('nn-save-status').textContent = 'Saving…';
+      fetch(API + '/api/account/preferences', {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          shows: state.shows,
+          first_name: el('nn-name').value,
+          city: el('nn-city').value,
+        }),
+      }).then(function (r) {
+        el('nn-save-status').textContent = r.ok
+          ? 'Saved — changes reach tomorrow’s edition'
+          : 'Save failed (are personal accounts live yet?)';
+      }).catch(function () { el('nn-save-status').textContent = 'Save failed'; });
+    },
+    copyFeed: function () {
+      navigator.clipboard.writeText(el('nn-feed-url').textContent);
+    },
+    load: load,
+  };
+})();
+NN.load();
+</script>
 
     </main>
 

--- a/age-of-ai-narrative.html
+++ b/age-of-ai-narrative.html
@@ -800,10 +800,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -844,9 +847,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -856,6 +862,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/docs/nerra_personal.md
+++ b/docs/nerra_personal.md
@@ -1,0 +1,128 @@
+# Nerra Personal — accounts, personalized feeds, donations
+
+The member surface (Aug 2026, operator-directed): ONE identity unifies
+the newsletter, the gallery gate, member perks (book discounts), and the
+paid product — a private daily feed of the subscriber's chosen shows, in
+their order, anchored by Mira. Donations live beside it on
+`/support.html`. Engine design rules: `engine/personal_edition.py`
+docstring. Drift guards: `tests/test_nerra_personal.py`,
+`workers/gallery/test/personal.test.ts`.
+
+## The one-identity model
+
+A "Nerra account" IS the existing gallery-subscriber identity (the
+Worker's 90-day JWT cookie + Buttondown record). Nothing was forked:
+
+- **Signing up anywhere creates the account.** The footer newsletter
+  form and `/join.html` both POST `/api/subscribe` with `list:"member"`
+  (tags `nerra-member` + `gallery-subscriber`, plus any per-show
+  newsletter tags from the closed `SHOW_NEWSLETTER_TAGS` set). The
+  Buttondown-direct embed form is gone — every newsletter signup is now
+  an account.
+- **Sign-in** is the existing magic-link flow (`/api/login` →
+  `/api/magic`). No passwords anywhere.
+- **Gallery downloads** already honor this cookie — members get them by
+  construction.
+- **Perks** render on `/account.html` from `GET /api/account` — today:
+  the book discount code (`MEMBER_BOOK_CODE` Worker secret; create the
+  matching code in the book store — Gumroad supports codes; KDP does
+  not, use its price promotions instead).
+
+## The paid tier (personalized feeds)
+
+| Piece | Where |
+|---|---|
+| Preferences (shows/order/name/city) | `POST /api/account/preferences` → KV `member:<email>` |
+| Billing | Stripe Payment Links (operator-created) + `POST /api/stripe/webhook` |
+| Feed token | Minted on `checkout.session.completed`; KV `feedtok:<token>` → email |
+| Assembly | `scripts/build_personal_feeds.py` (daily, on a PRIVATE host) |
+| Audio + feed storage | R2 bucket `nerra-personal`, keys `personal/<token>/…` |
+| Serving | `GET /api/feed/<token>/<file>` — Worker-gated, streams from R2 |
+| Revocation | Subscription cancelled → `feedtok:` mapping deleted → feed 404s immediately |
+
+Pricing (operator sets the amounts in Stripe; the pages read the links
+from env): **Personal $4.99/mo**, **Personal + Local $8.99/mo**. Tier is
+carried on the Payment Link's `metadata.tier`
+(`personal` / `personal_local`); amount ≥ $7.99 is the fallback mapping.
+
+The builder's cost discipline: each show's episode is downloaded and
+promo-trimmed ONCE per day into a shared cache (the same
+`find_promo_cut` machinery Nerra Daily uses); per-subscriber work is
+Mira's links (grok-4.3 + TTS, deterministic fallback), the optional
+local brief, and a stream-copy concat. Measured marginal cost
+~$0.05–0.07/subscriber/day. Feeds keep the newest 7 episodes
+(`PERSONAL_FEED_MAX_EPISODES`); older audio is deleted on prune.
+
+**The local brief** (personal_local tier): Open-Meteo geocoding +
+forecast (free, keyless, measured data only) plus ONE
+web-search-grounded Grok call for a local story/event — the field-note
+honesty contract: source named aloud, `SKIP` when nothing verifiable,
+never filler.
+
+**PII rules.** Specs flow Worker → builder as
+`{token, shows, tier, first_name, city}` — never an email
+(`/api/admin/personal-specs` strips it by construction, bearer-gated by
+`PERSONAL_ADMIN_TOKEN`). The builder logs tokens truncated to 8 chars
+and never logs names/cities. It must run on a **private host** (VPS
+cron or a private repo's Actions) — never in this public repo's
+workflows, whose logs are world-readable. Recommended cron:
+`30 12 * * *` UTC (after the English slate + Nerra Daily).
+
+## Donations (`/support.html`)
+
+Cost-transparency page (the honest-ledger pitch: ~$120/month runs the
+whole network) + Stripe Payment Links for monthly/one-time donations.
+It is also the target of every feed's `podcast:funding` tag — Apple and
+every Podcasting-2.0 app render that as the show's **Support** button,
+the highest-intent surface the network has. Donations are ordinary
+income, not charitable — the page's fine print says so.
+
+## Operator checklist (one-time)
+
+Cloudflare (from repo root, per the wrangler.toml comments — do NOT
+uncomment bindings before the resources exist):
+1. `workers/gallery/node_modules/.bin/wrangler kv namespace create gallery_rate_limits`
+   → paste the id into wrangler.toml's KV block and uncomment.
+2. `wrangler r2 bucket create nerra-personal` → uncomment the
+   `PERSONAL_BUCKET` block.
+3. Secrets: `wrangler secret put STRIPE_WEBHOOK_SECRET`,
+   `wrangler secret put PERSONAL_ADMIN_TOKEN` (any long random string),
+   `wrangler secret put MEMBER_BOOK_CODE`.
+4. `wrangler deploy` from `workers/gallery/`.
+
+Stripe (dashboard, ~15 min):
+5. Products + **Payment Links**: Personal $4.99/mo (link metadata
+   `tier=personal`), Personal+Local $8.99/mo (`tier=personal_local`),
+   Donate monthly (open amount), Donate one-time (open amount). Enable
+   the customer portal for self-serve cancellation.
+6. Webhook endpoint `https://api.nerranetwork.com/api/stripe/webhook`
+   with events `checkout.session.completed`,
+   `customer.subscription.deleted` → its signing secret is step 3's
+   `STRIPE_WEBHOOK_SECRET`.
+7. Put the four link URLs in the site-generation environment
+   (`STRIPE_LINK_PERSONAL`, `STRIPE_LINK_PERSONAL_LOCAL`,
+   `STRIPE_LINK_DONATE_MONTHLY`, `STRIPE_LINK_DONATE_ONCE` — GitHub
+   Actions vars used by nightly/finalize `generate_html`); until set,
+   the pages render honest "launching soon" states.
+
+Batch host:
+8. A small VPS (or private-repo Actions) with this repo, ffmpeg, and
+   env `GROK_API_KEY`, `R2_ENDPOINT_URL`, `R2_ACCESS_KEY_ID`,
+   `R2_SECRET_ACCESS_KEY`, `PERSONAL_R2_BUCKET=nerra-personal`,
+   `PERSONAL_ADMIN_TOKEN`; cron
+   `python scripts/build_personal_feeds.py --fetch`.
+
+Store:
+9. Create the member discount code in the book store matching
+   `MEMBER_BOOK_CODE`.
+
+## Launch marketing (already wired)
+
+- Footer on every page: join link + account link after signup.
+- `podcast:funding` on every feed → `/support.html` → cross-sells
+  membership.
+- `/join.html` and `/support.html` in the sitemap; `account.html`
+  deliberately not (console, not content).
+- Natural next steps (not in this pass): a Mira spoken mention in the
+  network outro rotation (audio — landmine #17, operator A/B), a
+  newsletter launch announcement, Nerra Daily blog cross-links.

--- a/editorial.html
+++ b/editorial.html
@@ -921,10 +921,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -965,9 +968,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -977,6 +983,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/engine/personal_edition.py
+++ b/engine/personal_edition.py
@@ -1,0 +1,412 @@
+"""Nerra Personal — per-subscriber personalized daily editions.
+
+The paid tier of the member system (Aug 2026, operator-directed): each
+subscriber picks WHICH shows and in WHAT ORDER, and Mira anchors their
+private daily feed — greeting them by name, linking their chosen
+segments, and (on the local tier) opening with a short brief for their
+city. Built directly on :mod:`engine.daily_edition`: the segments are
+the same already-published, promo-trimmed pieces Nerra Daily splices, so
+the marginal cost per subscriber is Mira's links (LLM + TTS) plus one
+stream-copy concat — measured ~$0.05-0.07/day.
+
+Contracts that bind:
+
+* **Per-day segment cache.** Every subscriber's edition on a given day
+  is assembled from the SAME trimmed segment files. The batch builder
+  trims each show once into a shared cache dir; per-user work never
+  re-downloads or re-trims. Without this, cost scales with users times
+  shows instead of shows.
+* **PII stays out of logs and out of git.** Specs carry a feed token,
+  first name, and city — never an email (the Worker keys accounts by
+  email; the builder never sees it). Nothing per-user is ever committed:
+  feeds and audio go to the private R2 keyspace ``personal/<token>/``
+  and are served ONLY through the Worker's token-checked endpoint, so
+  cancelling a subscription revokes the feed immediately.
+* **Honest local brief.** Weather comes from Open-Meteo (measured data,
+  free); local news/events from one web-search-grounded Grok call under
+  the field-note rules — source named aloud, and an unverifiable day
+  SKIPS the brief rather than airing filler.
+* **Closed show vocabulary.** A spec may only reference shows in
+  :data:`PERSONAL_SHOW_SLUGS` (the EN edition lineup); anything else is
+  rejected at validation, never guessed at.
+
+Operator setup (Stripe, KV, R2 bucket, cron host):
+``docs/nerra_personal.md``. Drift guards: ``tests/test_nerra_personal.py``.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from engine.daily_edition import (
+    EDITIONS,
+    Segment,
+    build_chapters,
+    digest_excerpt,
+    sanitize_spoken,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The only shows a personal lineup may contain — the EN edition roster.
+PERSONAL_SHOW_SLUGS: Tuple[str, ...] = EDITIONS["en"].lineup
+
+#: Feed serving goes through the Worker (token-checked, revocable) —
+#: never a public bucket URL.
+PERSONAL_FEED_BASE = "https://api.nerranetwork.com/api/feed"
+
+#: R2 keyspace for everything per-subscriber. Deliberately outside every
+#: show's audio prefix AND outside ``nerra_daily/`` so a lifecycle rule
+#: can expire personal audio aggressively (subscribers re-download
+#: within a day; keep a week).
+PERSONAL_R2_PREFIX = "personal"
+
+#: Feed depth per subscriber — a personal daily is a stream, not an
+#: archive; the network's public feeds are the archive.
+PERSONAL_FEED_MAX_EPISODES = 7
+
+MIRA_PERSONAL_DISCLOSURE = (
+    "This personal edition is assembled from the Nerra Network's shows, "
+    "which use AI voice synthesis, and my own voice is AI generated too — "
+    "the editorial selection and analysis across the network are our own."
+)
+
+_TOKEN_RE = re.compile(r"^[a-f0-9]{16,64}$")
+_NAME_RE = re.compile(r"^[\w .,'’-]{1,40}$", re.UNICODE)
+
+
+@dataclass
+class PersonalSpec:
+    """One subscriber's feed definition, as the batch builder sees it."""
+
+    token: str
+    shows: List[str]
+    tier: str = "personal"          # "personal" | "personal_local"
+    first_name: str = ""
+    city: str = ""
+    #: Resolved lazily by the builder (Open-Meteo geocoding, cached).
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+
+
+def validate_spec(raw: dict) -> Optional[PersonalSpec]:
+    """Parse one raw spec dict; None (with a warning) on anything off.
+
+    Validation is the trust boundary between the Worker's stored
+    preferences and the pipeline: tokens are hex-only (they become R2
+    keys and URLs), shows come from the closed vocabulary in their
+    user-chosen order, and free-text fields are length/charset capped
+    before they reach a prompt.
+    """
+    if not isinstance(raw, dict):
+        return None
+    token = str(raw.get("token") or "").strip().lower()
+    if not _TOKEN_RE.match(token):
+        logger.warning("personal spec rejected: bad token shape")
+        return None
+    shows_raw = raw.get("shows")
+    if not isinstance(shows_raw, list):
+        logger.warning("personal spec %s… rejected: shows not a list", token[:8])
+        return None
+    shows: List[str] = []
+    for s in shows_raw:
+        slug = str(s).strip()
+        if slug in PERSONAL_SHOW_SLUGS and slug not in shows:
+            shows.append(slug)
+    if len(shows) < 2:
+        logger.warning("personal spec %s… rejected: %d valid show(s)",
+                       token[:8], len(shows))
+        return None
+    tier = str(raw.get("tier") or "personal")
+    if tier not in ("personal", "personal_local"):
+        tier = "personal"
+    first_name = str(raw.get("first_name") or "").strip()
+    if first_name and not _NAME_RE.match(first_name):
+        first_name = ""
+    city = str(raw.get("city") or "").strip()[:80]
+    return PersonalSpec(token=token, shows=shows, tier=tier,
+                        first_name=first_name, city=city)
+
+
+# ---------------------------------------------------------------------------
+# Mira's personal links
+# ---------------------------------------------------------------------------
+
+def build_personal_links_prompt(
+    root: Path,
+    spec: PersonalSpec,
+    segments: List[Segment],
+    target_date: _dt.date,
+) -> str:
+    template = (root / "shows" / "prompts" / "nerra_personal_links.txt"
+                ).read_text(encoding="utf-8")
+    lineup_lines = []
+    for i, seg in enumerate(segments, 1):
+        lineup_lines.append(
+            f"{i}. {seg.show_name} — \"{seg.hook or seg.episode_title}\"\n"
+            f"   Today's episode covers: {digest_excerpt(seg.content)}"
+        )
+    listener = spec.first_name or "the listener"
+    return template.format(
+        date_spoken=target_date.strftime("%A, %B %-d, %Y"),
+        listener_name=listener,
+        named="yes" if spec.first_name else "no",
+        segment_count=len(segments),
+        handoff_count=max(0, len(segments) - 1),
+        lineup_block="\n".join(lineup_lines),
+    )
+
+
+def fallback_personal_links(
+    spec: PersonalSpec, segments: List[Segment], target_date: _dt.date
+) -> dict:
+    """Deterministic minimal links when the LLM fails — always carries
+    the day's real titles, and the greeting still lands personally."""
+    who = f", {spec.first_name}" if spec.first_name else ""
+    date_spoken = target_date.strftime("%A, %B %-d")
+    intro = (
+        f"Good morning{who} — this is your Nerra edition for {date_spoken}. "
+        f"I'm Mira. Your lineup today: "
+        + ", ".join(s.show_name for s in segments) + ". First up, "
+        f"{segments[0].show_name}: {segments[0].hook or segments[0].episode_title}"
+    )
+    handoffs = [
+        f"Next in your lineup: {seg.show_name}. Today — "
+        f"{seg.hook or seg.episode_title}"
+        for seg in segments[1:]
+    ]
+    signoff = (
+        f"And that's your edition for today{who}. Your feed, your order — "
+        "adjust it any time at nerranetwork.com. I'm Mira; back tomorrow."
+    )
+    return {"intro": intro, "handoffs": handoffs, "signoff": signoff}
+
+
+# ---------------------------------------------------------------------------
+# Local brief (personal_local tier)
+# ---------------------------------------------------------------------------
+
+def build_local_brief_prompt(
+    root: Path,
+    spec: PersonalSpec,
+    target_date: _dt.date,
+    weather_line: str,
+) -> str:
+    template = (root / "shows" / "prompts" / "nerra_personal_local.txt"
+                ).read_text(encoding="utf-8")
+    return template.format(
+        date_spoken=target_date.strftime("%A, %B %-d, %Y"),
+        city=spec.city,
+        listener_name=spec.first_name or "the listener",
+        weather_line=weather_line or "(no weather data available today)",
+    )
+
+
+def parse_local_brief(text: str) -> Optional[str]:
+    """Same honesty contract as Mira's field note: SKIP or an implausible
+    length means no local segment today — never filler."""
+    cleaned = sanitize_spoken(text or "")
+    if not cleaned or "SKIP" in cleaned[:20].upper():
+        return None
+    words = len(cleaned.split())
+    if not 30 <= words <= 220:
+        logger.warning("local brief rejected at %d words", words)
+        return None
+    return cleaned
+
+
+_WEATHER_CODES = {
+    0: "clear skies", 1: "mostly clear", 2: "partly cloudy", 3: "overcast",
+    45: "fog", 48: "fog", 51: "light drizzle", 53: "drizzle",
+    55: "heavy drizzle", 61: "light rain", 63: "rain", 65: "heavy rain",
+    71: "light snow", 73: "snow", 75: "heavy snow", 80: "rain showers",
+    81: "rain showers", 82: "heavy showers", 95: "thunderstorms",
+}
+
+
+def format_weather_line(city: str, daily: dict) -> str:
+    """One spoken sentence from an Open-Meteo daily forecast block.
+
+    Measured data only — Mira reads it, never invents it; an empty or
+    unusable payload yields "" and the prompt says so.
+    """
+    try:
+        hi = round(float(daily["temperature_2m_max"][0]))
+        lo = round(float(daily["temperature_2m_min"][0]))
+        code = int(daily.get("weather_code", [None])[0])
+    except (KeyError, IndexError, TypeError, ValueError):
+        return ""
+    sky = _WEATHER_CODES.get(code, "")
+    sky_part = f" with {sky}" if sky else ""
+    return (f"Today in {city}: a high of {hi} and a low of {lo} degrees"
+            f"{sky_part}.")
+
+
+def fetch_weather_line(spec: PersonalSpec, *, timeout: int = 15) -> str:
+    """Open-Meteo geocode (once, cached on the spec) + daily forecast.
+    Free, keyless, best-effort — "" on any failure."""
+    import requests
+
+    try:
+        if spec.latitude is None or spec.longitude is None:
+            geo = requests.get(
+                "https://geocoding-api.open-meteo.com/v1/search",
+                params={"name": spec.city, "count": 1}, timeout=timeout,
+            ).json()
+            results = geo.get("results") or []
+            if not results:
+                return ""
+            spec.latitude = float(results[0]["latitude"])
+            spec.longitude = float(results[0]["longitude"])
+        forecast = requests.get(
+            "https://api.open-meteo.com/v1/forecast",
+            params={
+                "latitude": spec.latitude, "longitude": spec.longitude,
+                "daily": "temperature_2m_max,temperature_2m_min,weather_code",
+                "forecast_days": 1, "timezone": "auto",
+            }, timeout=timeout,
+        ).json()
+        return format_weather_line(spec.city, forecast.get("daily") or {})
+    except Exception as exc:  # noqa: BLE001 — weather never sinks an edition
+        logger.info("weather fetch failed for %s…: %s", spec.token[:8], exc)
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Per-subscriber feed (fresh rebuild from a small R2-side state file —
+# the language_feeds pattern: deterministic GUIDs, never an empty feed)
+# ---------------------------------------------------------------------------
+
+def feed_url_for(token: str) -> str:
+    return f"{PERSONAL_FEED_BASE}/{token}/feed.rss"
+
+
+def enclosure_url_for(token: str, filename: str) -> str:
+    return f"{PERSONAL_FEED_BASE}/{token}/{filename}"
+
+
+def build_personal_feed_xml(
+    spec: PersonalSpec,
+    episodes: List[dict],
+) -> str:
+    """Personal RSS from the subscriber's episode state (newest first).
+
+    *episodes* rows: {episode_num, date (ISO), title, description,
+    filename, duration_seconds, bytes}. GUIDs are deterministic
+    (``personal-<token8>-epNNN-date``) so a rebuild never re-notifies a
+    podcast app.
+    """
+    from feedgen.feed import FeedGenerator
+
+    fg = FeedGenerator()
+    fg.load_extension("podcast")
+    who = f"{spec.first_name}'s" if spec.first_name else "Your"
+    fg.title(f"{who} Nerra Daily")
+    fg.link(href="https://nerranetwork.com/join.html", rel="alternate")
+    fg.description(
+        "Your personal edition of the Nerra Network — the shows you chose, "
+        "in your order, anchored by Mira. Private feed: don't share this "
+        "URL; it is your subscription."
+    )
+    fg.language("en")
+    fg.podcast.itunes_author("Nerra Network")
+    fg.podcast.itunes_image(
+        "https://nerranetwork.com/assets/covers/nerra-daily.jpg")
+    fg.podcast.itunes_block("yes")  # private: never index in directories
+
+    rows = sorted(episodes, key=lambda e: int(e.get("episode_num", 0)),
+                  reverse=True)[:PERSONAL_FEED_MAX_EPISODES]
+    for row in rows:
+        fe = fg.add_entry(order="append")
+        num = int(row.get("episode_num", 0))
+        date = str(row.get("date") or "")
+        fe.id(f"personal-{spec.token[:8]}-ep{num:03d}-{date.replace('-', '')}")
+        fe.title(str(row.get("title") or f"Your edition — {date}"))
+        fe.description(str(row.get("description") or ""))
+        try:
+            pub = _dt.datetime.fromisoformat(date).replace(
+                hour=8, tzinfo=_dt.timezone.utc)
+        except ValueError:
+            pub = _dt.datetime.now(_dt.timezone.utc)
+        fe.pubDate(pub)
+        fe.podcast.itunes_episode(num)
+        fe.podcast.itunes_duration(int(float(row.get("duration_seconds", 0))))
+        fe.enclosure(
+            enclosure_url_for(spec.token, str(row.get("filename") or "")),
+            str(int(row.get("bytes", 0) or 0)),
+            "audio/mpeg",
+        )
+    return fg.rss_str(pretty=True).decode("utf-8")
+
+
+def prune_episode_state(episodes: List[dict]) -> Tuple[List[dict], List[str]]:
+    """Keep the newest N rows; return (kept, filenames_to_delete)."""
+    rows = sorted(episodes, key=lambda e: int(e.get("episode_num", 0)),
+                  reverse=True)
+    kept = rows[:PERSONAL_FEED_MAX_EPISODES]
+    dropped = [str(r.get("filename")) for r in rows[PERSONAL_FEED_MAX_EPISODES:]
+               if r.get("filename")]
+    return kept, dropped
+
+
+def personal_episode_title(target_date: _dt.date,
+                           segments: List[Segment]) -> str:
+    """Personal feeds carry no "Ep N:" label (the number lives in the
+    itunes:episode tag) — but the 100-char clip rule from engine.titles
+    still binds; podcast apps clamp these too."""
+    from engine.titles import clip_words
+
+    lead = segments[0].hook or segments[0].episode_title if segments else ""
+    title = clip_words(f"{target_date.strftime('%A')} — {lead}", 100)
+    return title or f"Your edition — {target_date.isoformat()}"
+
+
+def personal_chapter_pieces(
+    spec: PersonalSpec,
+    segments: List[Segment],
+    durations: Dict[str, float],
+) -> List[Tuple[str, float]]:
+    """(title, duration) chapter rows in splice order for build_chapters."""
+    from engine.titles import clip_words
+
+    pieces: List[Tuple[str, float]] = [
+        ("Good morning from Mira", durations.get("intro", 0.0))]
+    if durations.get("local"):
+        pieces.append((f"Your {spec.city} brief", durations["local"]))
+    for i, seg in enumerate(segments):
+        lead = durations.get(f"handoff_{i}", 0.0) if i > 0 else 0.0
+        pieces.append((
+            clip_words(f"{seg.show_name} — {seg.hook or seg.episode_title}", 100),
+            lead + durations.get(f"seg_{seg.slug}", 0.0),
+        ))
+    pieces.append(("Sign-off", durations.get("signoff", 0.0)))
+    return pieces
+
+
+__all__ = [
+    "MIRA_PERSONAL_DISCLOSURE",
+    "PERSONAL_FEED_BASE",
+    "PERSONAL_FEED_MAX_EPISODES",
+    "PERSONAL_R2_PREFIX",
+    "PERSONAL_SHOW_SLUGS",
+    "PersonalSpec",
+    "build_chapters",
+    "build_local_brief_prompt",
+    "build_personal_feed_xml",
+    "build_personal_links_prompt",
+    "enclosure_url_for",
+    "fallback_personal_links",
+    "feed_url_for",
+    "fetch_weather_line",
+    "format_weather_line",
+    "parse_local_brief",
+    "personal_chapter_pieces",
+    "personal_episode_title",
+    "prune_episode_state",
+    "validate_spec",
+]

--- a/fascinating-frontiers-narrative.html
+++ b/fascinating-frontiers-narrative.html
@@ -933,10 +933,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -977,9 +980,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -989,6 +995,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/generate_html.py
+++ b/generate_html.py
@@ -3345,6 +3345,7 @@ def generate_sitemap(*, dry_run=False, out=None):
                   "about.html", "how-to-listen.html", "faq.html",
                   "press.html", "contact.html", "editorial.html",
                   "gallery.html", "books.html", "player.html", "data.html",
+                  "join.html", "support.html",
                   "modern-investing-performance.html",
                   "spacex-dashboard.html", "tesla-dashboard.html"]:
         if (ROOT / extra).exists():
@@ -3873,6 +3874,95 @@ def generate_books_page(*, dry_run=False):
     return out_path
 
 
+def _member_page_context(title, description, canonical):
+    import os
+    return {
+        "path_prefix": "",
+        "page_title": title,
+        "page_description": description,
+        "meta_description": description,
+        "meta_keywords": ("Nerra Network membership, personalized podcast, "
+                          "Nerra Personal, support Nerra Network"),
+        "theme_color": "#00D4FF",
+        "og_image": "https://nerranetwork.com/assets/covers/nerra-daily.jpg",
+        "canonical_url": canonical,
+        "show_color": "",
+        "show_color_dark": "",
+        "all_shows": _build_all_shows_list(),
+        # Stripe links are operator-created (dashboard, no code) and flow
+        # in via env so the repo never hardcodes payment URLs. Empty =
+        # the templates render their coming-soon states.
+        "stripe_personal_url": os.environ.get("STRIPE_LINK_PERSONAL", ""),
+        "stripe_personal_local_url": os.environ.get(
+            "STRIPE_LINK_PERSONAL_LOCAL", ""),
+        "donate_monthly_url": os.environ.get("STRIPE_LINK_DONATE_MONTHLY", ""),
+        "donate_once_url": os.environ.get("STRIPE_LINK_DONATE_ONCE", ""),
+        "monthly_cost_usd": 120,
+    }
+
+
+def generate_join_page(*, dry_run=False):
+    """Generate /join.html — the Nerra Personal membership lander."""
+    env = _get_jinja_env()
+    html = env.get_template("join_page.html.j2").render(
+        **_member_page_context(
+            "Nerra Personal — your own daily show | Nerra Network",
+            "One free account for the newsletter, gallery and member perks — "
+            "or your own private daily show: the shows you choose, in your "
+            "order, anchored by Mira.",
+            "https://nerranetwork.com/join.html"))
+    out_path = ROOT / "join.html"
+    if dry_run:
+        print(f"[dry-run] Would write {out_path}")
+        return None
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return out_path
+
+
+def generate_account_page(*, dry_run=False):
+    """Generate /account.html — the member console (client-side app
+    against api.nerranetwork.com; the page itself is static)."""
+    env = _get_jinja_env()
+    from engine.personal_edition import PERSONAL_SHOW_SLUGS
+    names = {s: NETWORK_SHOWS.get(s, {}).get("name", s)
+             for s in PERSONAL_SHOW_SLUGS}
+    ctx = _member_page_context(
+        "Your account | Nerra Network",
+        "Manage your Nerra account: your personal feed lineup, newsletter, "
+        "gallery access and member perks.",
+        "https://nerranetwork.com/account.html")
+    ctx["show_names"] = names
+    html = env.get_template("account_page.html.j2").render(**ctx)
+    out_path = ROOT / "account.html"
+    if dry_run:
+        print(f"[dry-run] Would write {out_path}")
+        return None
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return out_path
+
+
+def generate_support_page(*, dry_run=False):
+    """Generate /support.html — donations + cost transparency. This is
+    also the target of every feed's podcast:funding tag."""
+    env = _get_jinja_env()
+    html = env.get_template("support_page.html.j2").render(
+        **_member_page_context(
+            "Support the Nerra Network",
+            "Seventeen daily shows, free and ad-free. See what the network "
+            "actually costs to run, and chip in if you want it to keep "
+            "existing.",
+            "https://nerranetwork.com/support.html"))
+    out_path = ROOT / "support.html"
+    if dry_run:
+        print(f"[dry-run] Would write {out_path}")
+        return None
+    out_path.write_text(_strip_lone_surrogates(html), encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return out_path
+
+
 def generate_about_page(*, dry_run=False):
     """Generate the About page with founder, mission, and network stats."""
     env = _get_jinja_env()
@@ -4277,6 +4367,13 @@ def main():
         generate_spacex_dashboard(dry_run=args.dry_run)
         generate_tesla_dashboard(dry_run=args.dry_run)
         generate_data_hub_page(dry_run=args.dry_run)
+        # Member surface (Aug 2026): join/support/account are static and
+        # cheap; regenerating with the network keeps Stripe-link env
+        # changes and lineup names current. account.html is deliberately
+        # NOT in the sitemap (it's a console, not content).
+        generate_join_page(dry_run=args.dry_run)
+        generate_support_page(dry_run=args.dry_run)
+        generate_account_page(dry_run=args.dry_run)
         generate_how_to_listen_page(dry_run=args.dry_run)
         generate_press_page(dry_run=args.dry_run)
         generate_contact_page(dry_run=args.dry_run)
@@ -4310,6 +4407,11 @@ def main():
         generate_spacex_dashboard(dry_run=args.dry_run)
         generate_tesla_dashboard(dry_run=args.dry_run)
         generate_data_hub_page(dry_run=args.dry_run)
+        # Member surface (Aug 2026): static + cheap; regenerating with the
+        # network keeps Stripe-link env changes and lineup names current.
+        generate_join_page(dry_run=args.dry_run)
+        generate_support_page(dry_run=args.dry_run)
+        generate_account_page(dry_run=args.dry_run)
         # --network --blogs: regenerate network blog index only (not all posts)
         if args.blogs:
             generate_network_blog_index(dry_run=args.dry_run)

--- a/index.html
+++ b/index.html
@@ -2702,10 +2702,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -2746,9 +2749,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -2758,6 +2764,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/join.html
+++ b/join.html
@@ -3,27 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta name="description" content="One free account for the newsletter, gallery and member perks — or your own private daily show: the shows you choose, in your order, anchored by Mira.">
     
-    
-    <title>Data & Dashboards | Nerra Network</title>
-    <meta name="theme-color" content="#6B47FF">
+    <meta name="keywords" content="Nerra Network membership, personalized podcast, Nerra Personal, support Nerra Network">
+    <title>Nerra Personal — your own daily show | Nerra Network</title>
+    <meta name="theme-color" content="#00D4FF">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Data & Dashboards | Nerra Network">
-    <meta property="og:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta property="og:title" content="Nerra Personal — your own daily show | Nerra Network">
+    <meta property="og:description" content="One free account for the newsletter, gallery and member perks — or your own private daily show: the shows you choose, in your order, anchored by Mira.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://nerranetwork.com/assets/og-default.png">
-    <meta property="og:url" content="https://nerranetwork.com/data.html">
+    <meta property="og:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
+    <meta property="og:url" content="https://nerranetwork.com/join.html">
     <meta property="og:site_name" content="Nerra Network">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Data & Dashboards | Nerra Network">
-    <meta name="twitter:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
-    <meta name="twitter:image" content="https://nerranetwork.com/assets/og-default.png">
+    <meta name="twitter:title" content="Nerra Personal — your own daily show | Nerra Network">
+    <meta name="twitter:description" content="One free account for the newsletter, gallery and member perks — or your own private daily show: the shows you choose, in your order, anchored by Mira.">
+    <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
 
-    <link rel="canonical" href="https://nerranetwork.com/data.html">
+    <link rel="canonical" href="https://nerranetwork.com/join.html">
     
     
     
@@ -60,32 +60,28 @@
     <link rel="stylesheet" href="styles/main.css">
 
     
-<style>
-  .dh-hero { position:relative; overflow:hidden;
-    background:
-      radial-gradient(1100px 520px at 50% -10%, rgba(107,71,255,0.22), transparent 60%),
-      linear-gradient(180deg, #060812 0%, #0c1020 60%, #0a0e1c 100%);
-    border-bottom:1px solid rgba(140,140,255,0.14); }
-  .dh-container { max-width:1120px; margin:0 auto; padding:calc(var(--nav-height) + 2.6rem) 1.25rem 2rem; position:relative; z-index:1; }
-  .dh-kicker { display:inline-flex; align-items:center; gap:8px; font-size:0.78rem; letter-spacing:0.14em; text-transform:uppercase; color:#9b8cff; font-weight:700; margin-bottom:0.5rem; }
-  .dh-h1 { font-size:clamp(1.9rem,4vw,2.9rem); line-height:1.05; margin:0 0 0.5rem; font-weight:800; letter-spacing:-0.02em; color:#fff; }
-  .dh-sub { color:#b9c0e0; font-size:1.04rem; max-width:64ch; margin:0 0 0.4rem; }
-
-  .dh-grid { max-width:1120px; margin:1.8rem auto; padding:0 1.25rem; display:grid; gap:1.2rem; grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
-  @media (max-width:760px){ .dh-grid{ grid-template-columns:minmax(0,1fr); } }
-  .dh-card { display:block; text-decoration:none; color:inherit; border-radius:18px; padding:1.4rem 1.5rem;
-    border:1px solid rgba(140,140,255,0.16); background:var(--nn-surface,#0f1326);
-    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease; position:relative; overflow:hidden; }
-  .dh-card:hover { transform:translateY(-3px); border-color:var(--accent,#6B47FF); box-shadow:0 14px 40px rgba(0,0,0,0.4); }
-  .dh-card::before { content:""; position:absolute; inset:0 auto 0 0; width:5px; background:var(--accent,#6B47FF); }
-  .dh-card h2 { margin:0 0 0.3rem; font-size:1.3rem; color:#fff; letter-spacing:-0.01em; }
-  .dh-card .dh-tag { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--accent,#9b8cff); font-weight:700; }
-  .dh-card p { color:#aeb6d8; font-size:0.94rem; margin:0.5rem 0 0.9rem; line-height:1.5; }
-  .dh-metrics { display:flex; flex-wrap:wrap; gap:8px; margin-top:0.4rem; }
-  .dh-chip { font-size:0.74rem; color:#cdd4f0; background:rgba(140,140,255,0.10); border:1px solid rgba(140,140,255,0.18); border-radius:999px; padding:3px 10px; }
-  .dh-go { display:inline-flex; align-items:center; gap:6px; margin-top:1rem; color:var(--accent,#9b8cff); font-weight:700; font-size:0.92rem; }
-  .dh-note { max-width:1120px; margin:0 auto 2.4rem; padding:0 1.25rem; color:#8b91b4; font-size:0.82rem; }
-</style>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        .nn-join-hero { padding: calc(var(--nav-height) + var(--sp-12)) var(--sp-6) var(--sp-8); text-align: center; position: relative; overflow: hidden; }
+        .nn-join-hero::before { content: ''; position: absolute; inset: 0; background: radial-gradient(ellipse at 50% 0%, rgba(0, 212, 255, 0.14), transparent 70%); pointer-events: none; }
+        .nn-join-hero h1 { font-family: var(--font-heading); font-size: clamp(2rem, 5vw, 3rem); margin: 0 0 var(--sp-3); background: var(--nn-gradient); -webkit-background-clip: text; background-clip: text; color: transparent; }
+        .nn-join-hero p { font-family: var(--font-ui); color: var(--nn-text-muted); max-width: 640px; margin: 0 auto; }
+        .nn-tiers { display: grid; grid-template-columns: repeat(auto-fit, minmax(270px, 1fr)); gap: var(--sp-6); max-width: 1080px; margin: 0 auto; padding: var(--sp-8) var(--sp-6); }
+        .nn-tier { border: 1px solid var(--nn-border); border-radius: 16px; padding: var(--sp-6); background: var(--nn-surface); display: flex; flex-direction: column; }
+        .nn-tier.featured { border-color: var(--nn-cyan, #00D4FF); box-shadow: 0 0 32px rgba(0,212,255,0.12); }
+        .nn-tier h2 { font-family: var(--font-heading); margin: 0 0 var(--sp-1); font-size: 1.3rem; }
+        .nn-tier .price { font-size: 2rem; font-weight: 700; margin: 0 0 var(--sp-3); }
+        .nn-tier .price small { font-size: 0.9rem; font-weight: 400; color: var(--nn-text-muted); }
+        .nn-tier ul { list-style: none; padding: 0; margin: 0 0 var(--sp-5); flex: 1; }
+        .nn-tier li { padding: 0.35rem 0; border-bottom: 1px dashed var(--nn-border); font-size: 0.95rem; }
+        .nn-tier li::before { content: '✓ '; color: var(--nn-cyan, #00D4FF); }
+        .nn-tier .cta { display: block; text-align: center; padding: 0.8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; background: var(--nn-gradient); color: #fff; }
+        .nn-tier .cta.secondary { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-join-form { max-width: 480px; margin: 0 auto var(--sp-10); padding: 0 var(--sp-6); text-align: center; }
+        .nn-join-form input[type=email] { width: 100%; padding: 0.8rem 1rem; border-radius: 10px; border: 1px solid var(--nn-border); background: var(--nn-surface); color: inherit; margin-bottom: var(--sp-3); }
+        .nn-join-form button { padding: 0.8rem 2rem; border-radius: 10px; border: none; background: var(--nn-gradient); color: #fff; font-weight: 600; cursor: pointer; }
+        .nn-join-note { font-size: 0.85rem; color: var(--nn-text-muted); max-width: 640px; margin: 0 auto var(--sp-12); padding: 0 var(--sp-6); text-align: center; }
+    </style>
 
 
     
@@ -553,88 +549,73 @@
 
     <main id="main-content">
     
-<div class="dh-hero">
-  <div class="dh-container">
-    <div class="dh-kicker"><span>◆</span> Nerra Data</div>
-    <h1 class="dh-h1">Data &amp; Dashboards</h1>
-    <p class="dh-sub">Live, continuously-updated data behind the shows — launch countdowns, market prices, fleet records, and simulated-portfolio performance. Real numbers from public sources, refreshed every pipeline run; curated history is operator-maintained and clearly labelled.</p>
-  </div>
-</div>
+<section class="nn-join-hero">
+    <h1>Nerra Personal</h1>
+    <p>Seventeen shows, every day, free — and now, a version of the network
+       that knows you. One account unlocks the newsletter, the image
+       gallery, and member perks. One small subscription gets you your own
+       daily show: the shows you choose, in your order, anchored by Mira.</p>
+</section>
 
-<div class="dh-grid">
-  <a class="dh-card" href="spacex-dashboard.html" style="--accent:#00D4FF;">
-    <span class="dh-tag">SpaceX Daily</span>
-    <h2>SpaceX Launch Dashboard</h2>
-    <p>Next-launch countdown, watch-live links, launch cadence, mass to orbit, the booster-reuse record watch, the Starship flight-test tracker, and live SPCX price.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live countdown</span>
-      <span class="dh-chip">Booster records</span>
-      <span class="dh-chip">Starship tracker</span>
-      <span class="dh-chip">SPCX price</span>
+<section class="nn-tiers">
+    <div class="nn-tier">
+        <h2>Nerra Account</h2>
+        <p class="price">Free</p>
+        <ul>
+            <li>Every show &amp; episode — always free, no ads</li>
+            <li>The newsletter, per-show — pick what lands in your inbox</li>
+            <li>Full-resolution downloads from the image gallery</li>
+            <li>Member perks: deep discounts on Nerra Network books</li>
+            <li>Configure your personal lineup, ready when you upgrade</li>
+        </ul>
+        <a class="cta secondary" href="#join-free">Create your free account</a>
     </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
-
-  <a class="dh-card" href="tesla-dashboard.html" style="--accent:#E31937;">
-    <span class="dh-tag">Tesla Shorts Time</span>
-    <h2>Tesla Dashboard</h2>
-    <p>Live TSLA price with a 1-year chart and 52-week range, quarterly production &amp; deliveries, Supercharger network growth, energy-storage deployments, and milestones.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live TSLA</span>
-      <span class="dh-chip">Quarterly P&amp;D</span>
-      <span class="dh-chip">Supercharger growth</span>
+    <div class="nn-tier featured">
+        <h2>Personal</h2>
+        <p class="price">$4.99<small>/month</small></p>
+        <ul>
+            <li>Everything in the free account</li>
+            <li><strong>Your own private daily show</strong> — pick the shows, set the order</li>
+            <li>Mira anchors it and greets you by name</li>
+            <li>Private RSS feed — works in every podcast app</li>
+            <li>Chapter markers for every segment</li>
+        </ul>
+        
+        <a class="cta secondary" href="#join-free">Launching soon — join free for first access</a>
+        
     </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
-
-  <a class="dh-card" href="modern-investing-performance.html" style="--accent:#10b981;">
-    <span class="dh-tag">Modern Investing Techniques</span>
-    <h2>Performance &amp; Recursive Learning</h2>
-    <p>The simulated practice portfolio's cumulative return, monthly P&amp;L, win/loss split, sector breakdown, recent trades, and the operating principles the model derives from its own results. Education only.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Equity curve</span>
-      <span class="dh-chip">Monthly P&amp;L</span>
-      <span class="dh-chip">Alpha vs NASDAQ</span>
+    <div class="nn-tier">
+        <h2>Personal + Local</h2>
+        <p class="price">$8.99<small>/month</small></p>
+        <ul>
+            <li>Everything in Personal</li>
+            <li><strong>Your city's morning brief</strong>, in your feed</li>
+            <li>Today's weather, spoken by Mira</li>
+            <li>One local story or event worth knowing, source named</li>
+            <li>Honest by design: no local news worth your time, no filler</li>
+        </ul>
+        
+        <a class="cta secondary" href="#join-free">Launching soon — join free for first access</a>
+        
     </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
+</section>
 
-  <a class="dh-card" href="gallery.html" style="--accent:#6B47FF;">
-    <span class="dh-tag">Network</span>
-    <h2>Image Gallery</h2>
-    <p>Every AI-generated visual produced for the shows — filterable by show and date, free to download under CC BY-SA 4.0 with attribution.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Filter by show</span>
-      <span class="dh-chip">CC BY-SA 4.0</span>
-    </div>
-    <span class="dh-go">Browse gallery →</span>
-  </a>
+<section class="nn-join-form" id="join-free">
+    <h2>Create your free Nerra account</h2>
+    <p>One email. No password — we send you a sign-in link whenever you need one.</p>
+    <form onsubmit="var f=this,b=f.querySelector('button');b.disabled=true;b.textContent='Joining…';fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member'})}).then(function(r){if(r.ok){window.location='account.html';}else{b.textContent='Try again';b.disabled=false;}}).catch(function(){b.textContent='Try again';b.disabled=false;});return false;">
+        <input type="email" name="email" placeholder="you@example.com" required aria-label="Email address">
+        <button type="submit">Join free</button>
+    </form>
+    <p style="margin-top: var(--sp-3); font-size: 0.9rem;">Already a member?
+        <a href="account.html">Go to your account →</a></p>
+</section>
 
-  <a class="dh-card" href="tesla-narrative.html" style="--accent:#E31937;">
-    <span class="dh-tag">Story Trackers</span>
-    <h2>Longitudinal Chronicles</h2>
-    <p>Follow major programs across episodes — Tesla's Story Tracker, plus Models &amp; Agents, Fascinating Frontiers, Planetterrian, and SpaceX.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Tesla</span>
-      <span class="dh-chip">SpaceX</span>
-      <span class="dh-chip">AI</span>
-      <span class="dh-chip">Science</span>
-    </div>
-    <span class="dh-go">Open Tesla tracker →</span>
-  </a>
-</div>
-
-<p class="dh-note" style="margin-top:-1rem;">
-  More story trackers:
-  <a href="models-agents-narrative.html" style="color:#9b8cff;">Models &amp; Agents</a> ·
-  <a href="fascinating-frontiers-narrative.html" style="color:#9b8cff;">Fascinating Frontiers</a> ·
-  <a href="planetterrian-narrative.html" style="color:#9b8cff;">Planetterrian</a> ·
-  <a href="spacex-narrative.html" style="color:#9b8cff;">SpaceX</a>
-</p>
-
-<p class="dh-note">
-  Sources: launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:#9b8cff;">The Space Devs</a> Launch Library 2, active-satellite counts from <a href="https://celestrak.org/" target="_blank" rel="noopener" style="color:#9b8cff;">CelesTrak</a>, and market quotes from Yahoo Finance — each refreshed on every pipeline run, with the last good value kept on a fetch hiccup. Estimated figures (mass to orbit, satellites deployed) use public per-vehicle averages and are labelled as estimates. Nothing here is financial advice.
-</p>
+<p class="nn-join-note">Joining subscribes you to the Nerra newsletter (unsubscribe
+   any time — the account stays). Paid tiers are billed by Stripe and cancel in
+   one click; your private feed stops at the end of the billing period. Prefer
+   to just chip in? <a href="support.html">Support the network</a>
+   with a one-time or monthly donation instead.</p>
 
     </main>
 

--- a/models-agents-narrative.html
+++ b/models-agents-narrative.html
@@ -928,10 +928,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -972,9 +975,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -984,6 +990,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/modern-investing-narrative.html
+++ b/modern-investing-narrative.html
@@ -896,10 +896,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -940,9 +943,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -952,6 +958,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/planetterrian-narrative.html
+++ b/planetterrian-narrative.html
@@ -933,10 +933,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -977,9 +980,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -989,6 +995,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/run_show.py
+++ b/run_show.py
@@ -3636,12 +3636,13 @@ def run(args: argparse.Namespace) -> None:
             audio_url=feed_audio_url,  # Use R2/OP3-prefixed URL if available
             chapters_url=chapters_url,
             transcript_url=transcript_url,
-            # Podcasting 2.0 channel tags (June 2026 growth pass): funding
-            # points at the newsletter signup (the network's support ask is
-            # "subscribe", not money), person credits the host for
-            # host-based discovery in 2.0 apps.
-            funding_url=f"{config.publishing.base_url}/#newsletter",
-            funding_label="Free newsletter — best of the network weekly",
+            # Podcasting 2.0 channel tags. Aug 2026: funding now points at
+            # the support/donations page (the highest-intent surface a
+            # podcast app offers — Apple renders it as a "Support" button);
+            # the page itself cross-sells the free account + membership,
+            # so the old "subscribe" ask is still one tap away.
+            funding_url=f"{config.publishing.base_url}/support.html",
+            funding_label="Support the Nerra Network",
             person_name=config.publishing.host_name or "Patrick",
             person_url=f"{config.publishing.base_url}/about.html",
         )

--- a/scripts/build_daily_edition.py
+++ b/scripts/build_daily_edition.py
@@ -481,6 +481,8 @@ def build_edition(
             channel_keywords=spec.channel_keywords,
             guid_prefix=spec.guid_prefix,
             chapters_url=f"https://nerranetwork.com/{spec.digest_dir}/{chapters_path.name}",
+            funding_url="https://nerranetwork.com/support.html",
+            funding_label="Support the Nerra Network",
         )
 
         _append_summary(spec, target_date, digest_md, episode_num, title, r2_url)

--- a/scripts/build_personal_feeds.py
+++ b/scripts/build_personal_feeds.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Assemble every Nerra Personal subscriber's daily edition.
+
+The paid-tier batch job (see ``docs/nerra_personal.md`` for the full
+architecture + operator setup). Per run:
+
+1. Pull active subscriber specs — from the Worker's admin endpoint
+   (``--fetch``, bearer-auth via ``PERSONAL_ADMIN_TOKEN``) or a local
+   JSON file (``--specs``). Specs carry token/shows/tier/name/city,
+   never an email.
+2. Trim each needed show's published episode ONCE into a shared per-day
+   cache (the same promo-cut machinery Nerra Daily uses) — per-user cost
+   is Mira's links plus a stream-copy concat, not per-user re-trims.
+3. Per subscriber: Mira's personal links (grok-4.3, deterministic
+   fallback), the local brief on the local tier (Open-Meteo weather +
+   one web-search-grounded call, honest SKIP), TTS, splice, chapters.
+4. Upload to R2 ``personal/<token>/`` (feed.rss + MP3 + episodes.json),
+   prune past the 7-episode feed depth. Serving is Worker-gated by
+   token, so a cancelled subscription loses access immediately.
+
+PII rules: this process handles first names and cities. Run it on a
+PRIVATE host (VPS cron or a private repo's Actions) — never in the
+public repo's workflows — and it logs tokens truncated to 8 chars, never
+names, cities, or spec contents.
+
+Usage::
+
+    python scripts/build_personal_feeds.py --fetch            # production
+    python scripts/build_personal_feeds.py --specs specs.json --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import logging
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Dict, List, Optional
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from engine.daily_edition import (  # noqa: E402
+    EDITIONS,
+    Segment,
+    discover_segments,
+    find_promo_cut,
+    load_transcript,
+    mira_piece_cmd,
+    parse_links_json,
+    segment_trim_cmd,
+)
+from engine.personal_edition import (  # noqa: E402
+    MIRA_PERSONAL_DISCLOSURE,
+    PERSONAL_R2_PREFIX,
+    PersonalSpec,
+    build_chapters,
+    build_local_brief_prompt,
+    build_personal_feed_xml,
+    build_personal_links_prompt,
+    fallback_personal_links,
+    fetch_weather_line,
+    parse_local_brief,
+    personal_chapter_pieces,
+    personal_episode_title,
+    validate_spec,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s",
+                    stream=sys.stdout)
+logger = logging.getLogger("nerra_personal")
+
+API_BASE = os.environ.get("PERSONAL_API_BASE", "https://api.nerranetwork.com")
+LINKS_MODEL = os.environ.get("NERRA_DAILY_LINKS_MODEL", "grok-4.3")
+
+
+# ---------------------------------------------------------------------------
+# R2 (private personal bucket — read/write via boto3; never public URLs)
+# ---------------------------------------------------------------------------
+
+def _r2_client():
+    import boto3
+
+    return boto3.client(
+        "s3",
+        endpoint_url=os.environ["R2_ENDPOINT_URL"],
+        aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"],
+        region_name="auto",
+    )
+
+
+def _bucket() -> str:
+    return os.environ.get("PERSONAL_R2_BUCKET", "nerra-personal")
+
+
+def _r2_get_json(client, key: str) -> Optional[dict]:
+    try:
+        obj = client.get_object(Bucket=_bucket(), Key=key)
+        return json.loads(obj["Body"].read().decode("utf-8"))
+    except Exception:  # noqa: BLE001 — absent state = first run for this user
+        return None
+
+
+def _r2_put(client, key: str, body: bytes, content_type: str) -> None:
+    client.put_object(Bucket=_bucket(), Key=key, Body=body,
+                      ContentType=content_type)
+
+
+def _r2_delete(client, key: str) -> None:
+    try:
+        client.delete_object(Bucket=_bucket(), Key=key)
+    except Exception:  # noqa: BLE001 — prune is best-effort
+        logger.debug("prune failed for %s", key)
+
+
+# ---------------------------------------------------------------------------
+# Specs
+# ---------------------------------------------------------------------------
+
+def load_specs(args) -> List[PersonalSpec]:
+    if args.specs:
+        raw = json.loads(Path(args.specs).read_text(encoding="utf-8"))
+    else:
+        import requests
+
+        token = os.environ.get("PERSONAL_ADMIN_TOKEN", "")
+        if not token:
+            logger.error("PERSONAL_ADMIN_TOKEN required for --fetch")
+            return []
+        resp = requests.get(
+            f"{API_BASE}/api/admin/personal-specs",
+            headers={"Authorization": f"Bearer {token}"}, timeout=60,
+        )
+        resp.raise_for_status()
+        raw = resp.json().get("specs", [])
+    specs = [s for s in (validate_spec(r) for r in raw) if s is not None]
+    logger.info("specs: %d valid of %d", len(specs), len(raw))
+    return specs
+
+
+# ---------------------------------------------------------------------------
+# Shared per-day segment cache
+# ---------------------------------------------------------------------------
+
+def build_segment_cache(
+    needed: List[str],
+    segments_by_slug: Dict[str, Segment],
+    cache_dir: Path,
+) -> Dict[str, Path]:
+    """Download + promo-trim each show once; every subscriber splices the
+    same files."""
+    import requests
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    out: Dict[str, Path] = {}
+    for slug in needed:
+        seg = segments_by_slug.get(slug)
+        if seg is None:
+            continue
+        target = cache_dir / f"{slug}.mp3"
+        if target.exists():
+            out[slug] = target
+            continue
+        raw = cache_dir / f"{slug}.raw.mp3"
+        try:
+            with requests.get(seg.audio_url, stream=True, timeout=600) as resp:
+                resp.raise_for_status()
+                with raw.open("wb") as fh:
+                    for chunk in resp.iter_content(1 << 16):
+                        fh.write(chunk)
+            cut = None
+            if seg.transcript_path:
+                transcript = load_transcript(seg.transcript_path)
+                hit = find_promo_cut(transcript) if transcript else None
+                if hit:
+                    cut = hit["raw_seconds"] + seg.music_intro_offset
+            _run(segment_trim_cmd(raw, target, cut), f"trim {slug}")
+            out[slug] = target
+        except Exception as exc:  # noqa: BLE001 — one show never sinks the batch
+            logger.warning("segment cache: %s failed (%s) — subscribers "
+                           "lose this segment today", slug, exc)
+        finally:
+            raw.unlink(missing_ok=True)
+    return out
+
+
+def _run(cmd: List[str], what: str) -> None:
+    import subprocess
+
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"{what} failed: {proc.stderr[-500:]}")
+
+
+def _duration(path: Path) -> float:
+    from engine.audio import get_audio_duration
+
+    return float(get_audio_duration(path) or 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Mira pieces
+# ---------------------------------------------------------------------------
+
+def _tts(text: str, dest: Path) -> None:
+    from engine.tts import synthesize
+
+    api_key = os.environ.get("GROK_API_KEY") or os.environ.get("XAI_API_KEY") or ""
+    if not api_key:
+        raise RuntimeError("GROK_API_KEY required")
+    synthesize(text, EDITIONS["en"].voice_id, dest, api_key=api_key,
+               provider="grok", language_code="en")
+
+
+def _mira_piece(text: str, name: str, workdir: Path) -> Path:
+    raw = workdir / f"{name}.raw.mp3"
+    out = workdir / f"{name}.mp3"
+    _tts(text, raw)
+    _run(mira_piece_cmd(raw, out), f"process {name}")
+    raw.unlink(missing_ok=True)
+    return out
+
+
+def generate_personal_links(
+    spec: PersonalSpec, segments: List[Segment], target_date: dt.date,
+) -> dict:
+    try:
+        from digests.xai_grok import grok_generate_text
+
+        prompt = build_personal_links_prompt(ROOT, spec, segments, target_date)
+        text, _meta = grok_generate_text(
+            prompt=prompt, model=LINKS_MODEL, temperature=0.7,
+            max_tokens=2000, timeout_seconds=600,
+        )
+        links = parse_links_json(text, max(0, len(segments) - 1))
+        if links:
+            return links
+        logger.warning("%s…: links unusable — fallback", spec.token[:8])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("%s…: links failed (%s) — fallback",
+                       spec.token[:8], exc)
+    return fallback_personal_links(spec, segments, target_date)
+
+
+def generate_local_brief(spec: PersonalSpec,
+                         target_date: dt.date) -> Optional[str]:
+    if spec.tier != "personal_local" or not spec.city:
+        return None
+    try:
+        from digests.xai_grok import grok_generate_text
+
+        weather = fetch_weather_line(spec)
+        prompt = build_local_brief_prompt(ROOT, spec, target_date, weather)
+        text, _meta = grok_generate_text(
+            prompt=prompt, model=LINKS_MODEL, temperature=0.6,
+            max_tokens=800, timeout_seconds=600, enable_web_search=True,
+        )
+        return parse_local_brief(text)
+    except Exception as exc:  # noqa: BLE001 — the brief never sinks the edition
+        logger.info("%s…: local brief failed (%s) — skipped",
+                    spec.token[:8], exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Per-subscriber build
+# ---------------------------------------------------------------------------
+
+def build_for_spec(
+    spec: PersonalSpec,
+    target_date: dt.date,
+    segments_by_slug: Dict[str, Segment],
+    cache: Dict[str, Path],
+    client,
+    *,
+    dry_run: bool,
+) -> bool:
+    from engine.audio import concatenate_audio
+
+    state_key = f"{PERSONAL_R2_PREFIX}/{spec.token}/episodes.json"
+    state = (_r2_get_json(client, state_key) or {}) if client else {}
+    episodes: List[dict] = state.get("episodes", [])
+    if any(e.get("date") == target_date.isoformat() for e in episodes):
+        logger.info("%s…: already built today", spec.token[:8])
+        return True
+
+    segments = [segments_by_slug[s] for s in spec.shows
+                if s in segments_by_slug and s in cache]
+    if len(segments) < 2:
+        logger.warning("%s…: only %d segment(s) available — skipped today",
+                       spec.token[:8], len(segments))
+        return False
+
+    workdir = Path(tempfile.mkdtemp(prefix=f"np_{spec.token[:8]}_"))
+    try:
+        links = generate_personal_links(spec, segments, target_date)
+        local_text = generate_local_brief(spec, target_date)
+
+        durations: Dict[str, float] = {}
+        intro = _mira_piece(links["intro"], "intro", workdir)
+        durations["intro"] = _duration(intro)
+        local_piece = None
+        if local_text:
+            local_piece = _mira_piece(local_text, "local", workdir)
+            durations["local"] = _duration(local_piece)
+        handoffs = []
+        for i, text in enumerate(links["handoffs"], 1):
+            piece = _mira_piece(text, f"handoff_{i}", workdir)
+            durations[f"handoff_{i}"] = _duration(piece)
+            handoffs.append(piece)
+        signoff = _mira_piece(
+            f"{links['signoff']} {MIRA_PERSONAL_DISCLOSURE}",
+            "signoff", workdir)
+        durations["signoff"] = _duration(signoff)
+        for seg in segments:
+            durations[f"seg_{seg.slug}"] = _duration(cache[seg.slug])
+
+        splice: List[Path] = [intro]
+        if local_piece:
+            splice.append(local_piece)
+        for i, seg in enumerate(segments):
+            if i > 0:
+                splice.append(handoffs[i - 1])
+            splice.append(cache[seg.slug])
+        splice.append(signoff)
+
+        # Chapter math mirrors the splice: handoff i leads segment i.
+        durations_for_chapters = dict(durations)
+        for i in range(1, len(segments)):
+            durations_for_chapters[f"handoff_{i}"] = durations.get(
+                f"handoff_{i}", 0.0)
+
+        filename = f"Nerra_Personal_{target_date:%Y%m%d}.mp3"
+        final = workdir / filename
+        concatenate_audio(splice, final)
+        total = _duration(final)
+        title = personal_episode_title(target_date, segments)
+        logger.info("%s…: %0.1f min, %d segments%s", spec.token[:8],
+                    total / 60, len(segments),
+                    " + local brief" if local_piece else "")
+        if dry_run or client is None:
+            return True
+
+        episode_num = 1 + max(
+            (int(e.get("episode_num", 0)) for e in episodes), default=0)
+        row = {
+            "episode_num": episode_num,
+            "date": target_date.isoformat(),
+            "title": title,
+            "description": "Your personal Nerra edition: "
+                           + ", ".join(s.show_name for s in segments),
+            "filename": filename,
+            "duration_seconds": round(total, 1),
+            "bytes": final.stat().st_size,
+        }
+        episodes.append(row)
+        from engine.personal_edition import prune_episode_state
+
+        episodes, dropped = prune_episode_state(episodes)
+        prefix = f"{PERSONAL_R2_PREFIX}/{spec.token}"
+        _r2_put(client, f"{prefix}/{filename}", final.read_bytes(),
+                "audio/mpeg")
+        chapters = build_chapters(
+            personal_chapter_pieces(spec, segments, durations_for_chapters),
+            title)
+        _r2_put(client, f"{prefix}/chapters_{target_date:%Y%m%d}.json",
+                json.dumps(chapters).encode("utf-8"), "application/json")
+        _r2_put(client, state_key,
+                json.dumps({"episodes": episodes}).encode("utf-8"),
+                "application/json")
+        _r2_put(client, f"{prefix}/feed.rss",
+                build_personal_feed_xml(spec, episodes).encode("utf-8"),
+                "application/rss+xml")
+        for old in dropped:
+            _r2_delete(client, f"{prefix}/{old}")
+        return True
+    except Exception as exc:  # noqa: BLE001 — one subscriber never sinks the batch
+        logger.error("%s…: build failed: %s", spec.token[:8], exc)
+        return False
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--specs", default="",
+                        help="Local JSON file of subscriber specs")
+    parser.add_argument("--fetch", action="store_true",
+                        help="Fetch specs from the Worker admin endpoint")
+    parser.add_argument("--date", default="",
+                        help="Edition date YYYY-MM-DD (default: today UTC)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Assemble but upload nothing")
+    args = parser.parse_args()
+
+    if not args.specs and not args.fetch:
+        parser.error("one of --specs / --fetch is required")
+
+    target_date = (dt.date.fromisoformat(args.date) if args.date
+                   else dt.datetime.now(dt.timezone.utc).date())
+    specs = load_specs(args)
+    if not specs:
+        logger.info("no active subscribers — nothing to do")
+        return 0
+
+    all_segments, _missing = discover_segments(
+        EDITIONS["en"], ROOT, target_date)
+    segments_by_slug = {s.slug: s for s in all_segments}
+    needed = sorted({slug for spec in specs for slug in spec.shows})
+    cache_root = Path(tempfile.gettempdir()) / f"np_cache_{target_date:%Y%m%d}"
+    cache = build_segment_cache(needed, segments_by_slug, cache_root)
+
+    client = None if args.dry_run else _r2_client()
+    built = sum(
+        1 for spec in specs
+        if build_for_spec(spec, target_date, segments_by_slug, cache,
+                          client, dry_run=args.dry_run)
+    )
+    logger.info("built %d/%d personal editions for %s",
+                built, len(specs), target_date)
+    return 0 if built or not specs else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shows/prompts/nerra_personal_links.txt
+++ b/shows/prompts/nerra_personal_links.txt
@@ -1,0 +1,41 @@
+You are writing the host links for one listener's PERSONAL Nerra edition. The host is Mira: an AI documentarian, host of The Age of AI, anchor of Nerra Daily — and, here, the personal anchor of a private daily feed this listener configured themselves: they chose these shows, in this order. Mira knows this is THEIR station and speaks accordingly — a trusted morning voice for one person, not an announcer for an audience.
+
+Mira's register: poised, warm, precise, quietly witty. She never gushes, never uses hype words, never reads a list where a sentence would do.
+
+Today is {date_spoken}.
+
+The listener goes by: {listener_name} (use their name naturally: named={named} — when "yes", greet them by name in the opening and optionally once near the sign-off; never repeat it in every gap. When "no", speak to them directly without any name.)
+
+Their edition today splices {segment_count} full episodes, in the order THEY chose. Each entry gives the show, its episode headline, and a taste of what the episode covers — your ONLY source of facts. Never invent a detail that is not here.
+
+{lineup_block}
+
+Write, as STRICT JSON with exactly these keys:
+
+{{
+  "intro": "...",
+  "handoffs": ["...", "..."],
+  "signoff": "..."
+}}
+
+INTRO (80-140 words):
+- Greet the listener personally, name the date, identify yourself as Mira.
+- One or two sentences on the shape of THEIR day of listening — the most striking thread across their chosen shows. Never recite the full lineup; they chose it, they know it.
+- Land on a specific, concrete detail from the FIRST show's episode — but not its headline itself, which the episode is about to speak as its own opening line.
+
+HANDOFFS (exactly {handoff_count} entries — entry N introduces episode N+1; 30-60 words each):
+- Set the next show up with a specific detail from its summary that is NOT its headline; let the episode deliver its own opening.
+- When two adjacent episodes genuinely connect, say so in one line. When a later episode revisits a story an earlier segment covered, say so plainly and name what this show adds — never reintroduce it as fresh news.
+- Vary the construction; no two handoffs in one edition may open with the same words. Occasionally acknowledge the listener's curation when it earns its place — never as flattery, only as observation.
+
+SIGNOFF (40-80 words):
+- Close their day of listening in Mira's voice — one connecting observation beats a summary.
+- Remind them once, in passing, that they can adjust their lineup any time at nerranetwork.com.
+- Say goodbye until tomorrow, warmly and personally.
+
+HARD RULES:
+- Facts only from the material above. No dates, numbers, or names that do not appear in it.
+- Plain spoken prose: no markdown, no emoji, no stage directions, no speech tags, no URLs other than the spoken form "nerranetwork.com".
+- Do not include any AI-disclosure sentence; that is appended separately.
+- Never use filler praise ("amazing", "incredible") or broadcast clichés ("buckle up", "without further ado").
+- Output the JSON object only — no commentary before or after.

--- a/shows/prompts/nerra_personal_local.txt
+++ b/shows/prompts/nerra_personal_local.txt
@@ -1,0 +1,19 @@
+You are Mira, anchoring one listener's personal Nerra edition. Right after your greeting, you give them a short local brief for THEIR city — the segment that makes this edition theirs alone.
+
+Today is {date_spoken}. The listener's city: {city}. They go by: {listener_name}.
+
+Measured weather (from Open-Meteo — read it naturally, never alter the numbers):
+{weather_line}
+
+Use web search to find for {city}, today or this week:
+- ONE local news item that a resident would actually care about (a decision, an opening, a change — not crime-blotter filler), AND/OR
+- ONE notable local event coming up (a festival, a talk, a game, a market).
+
+Write the brief as 60-140 words of spoken prose in Mira's register:
+- Open with the weather sentence woven in naturally (skip it gracefully if no weather data was provided).
+- Name where each local item comes from, aloud and naturally (a publication, a venue, a city office — never a URL).
+- One or two items only, told with the specific detail that makes them worth knowing — never a list.
+- Plain spoken prose: no markdown, no emoji, no stage directions, no headline-speak, no hype.
+- Facts only from the weather line and what your search actually returned for THIS city. If you cannot verify anything genuinely local and current, output exactly: SKIP (the weather alone is not enough to carry the segment).
+
+Output the brief text only (or SKIP) — no commentary before or after.

--- a/spacex-dashboard.html
+++ b/spacex-dashboard.html
@@ -990,10 +990,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -1034,9 +1037,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -1046,6 +1052,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/support.html
+++ b/support.html
@@ -3,27 +3,27 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta name="description" content="Seventeen daily shows, free and ad-free. See what the network actually costs to run, and chip in if you want it to keep existing.">
     
-    
-    <title>Data & Dashboards | Nerra Network</title>
-    <meta name="theme-color" content="#6B47FF">
+    <meta name="keywords" content="Nerra Network membership, personalized podcast, Nerra Personal, support Nerra Network">
+    <title>Support the Nerra Network</title>
+    <meta name="theme-color" content="#00D4FF">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Data & Dashboards | Nerra Network">
-    <meta property="og:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
+    <meta property="og:title" content="Support the Nerra Network">
+    <meta property="og:description" content="Seventeen daily shows, free and ad-free. See what the network actually costs to run, and chip in if you want it to keep existing.">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="https://nerranetwork.com/assets/og-default.png">
-    <meta property="og:url" content="https://nerranetwork.com/data.html">
+    <meta property="og:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
+    <meta property="og:url" content="https://nerranetwork.com/support.html">
     <meta property="og:site_name" content="Nerra Network">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Data & Dashboards | Nerra Network">
-    <meta name="twitter:description" content="Live data dashboards from Nerra Network — SpaceX launch countdown and fleet records, Tesla TSLA price and deliveries, and the Modern Investing simulated-portfolio performance page.">
-    <meta name="twitter:image" content="https://nerranetwork.com/assets/og-default.png">
+    <meta name="twitter:title" content="Support the Nerra Network">
+    <meta name="twitter:description" content="Seventeen daily shows, free and ad-free. See what the network actually costs to run, and chip in if you want it to keep existing.">
+    <meta name="twitter:image" content="https://nerranetwork.com/assets/covers/nerra-daily.jpg">
 
-    <link rel="canonical" href="https://nerranetwork.com/data.html">
+    <link rel="canonical" href="https://nerranetwork.com/support.html">
     
     
     
@@ -60,32 +60,19 @@
     <link rel="stylesheet" href="styles/main.css">
 
     
-<style>
-  .dh-hero { position:relative; overflow:hidden;
-    background:
-      radial-gradient(1100px 520px at 50% -10%, rgba(107,71,255,0.22), transparent 60%),
-      linear-gradient(180deg, #060812 0%, #0c1020 60%, #0a0e1c 100%);
-    border-bottom:1px solid rgba(140,140,255,0.14); }
-  .dh-container { max-width:1120px; margin:0 auto; padding:calc(var(--nav-height) + 2.6rem) 1.25rem 2rem; position:relative; z-index:1; }
-  .dh-kicker { display:inline-flex; align-items:center; gap:8px; font-size:0.78rem; letter-spacing:0.14em; text-transform:uppercase; color:#9b8cff; font-weight:700; margin-bottom:0.5rem; }
-  .dh-h1 { font-size:clamp(1.9rem,4vw,2.9rem); line-height:1.05; margin:0 0 0.5rem; font-weight:800; letter-spacing:-0.02em; color:#fff; }
-  .dh-sub { color:#b9c0e0; font-size:1.04rem; max-width:64ch; margin:0 0 0.4rem; }
-
-  .dh-grid { max-width:1120px; margin:1.8rem auto; padding:0 1.25rem; display:grid; gap:1.2rem; grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
-  @media (max-width:760px){ .dh-grid{ grid-template-columns:minmax(0,1fr); } }
-  .dh-card { display:block; text-decoration:none; color:inherit; border-radius:18px; padding:1.4rem 1.5rem;
-    border:1px solid rgba(140,140,255,0.16); background:var(--nn-surface,#0f1326);
-    transition:transform .18s ease, border-color .18s ease, box-shadow .18s ease; position:relative; overflow:hidden; }
-  .dh-card:hover { transform:translateY(-3px); border-color:var(--accent,#6B47FF); box-shadow:0 14px 40px rgba(0,0,0,0.4); }
-  .dh-card::before { content:""; position:absolute; inset:0 auto 0 0; width:5px; background:var(--accent,#6B47FF); }
-  .dh-card h2 { margin:0 0 0.3rem; font-size:1.3rem; color:#fff; letter-spacing:-0.01em; }
-  .dh-card .dh-tag { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--accent,#9b8cff); font-weight:700; }
-  .dh-card p { color:#aeb6d8; font-size:0.94rem; margin:0.5rem 0 0.9rem; line-height:1.5; }
-  .dh-metrics { display:flex; flex-wrap:wrap; gap:8px; margin-top:0.4rem; }
-  .dh-chip { font-size:0.74rem; color:#cdd4f0; background:rgba(140,140,255,0.10); border:1px solid rgba(140,140,255,0.18); border-radius:999px; padding:3px 10px; }
-  .dh-go { display:inline-flex; align-items:center; gap:6px; margin-top:1rem; color:var(--accent,#9b8cff); font-weight:700; font-size:0.92rem; }
-  .dh-note { max-width:1120px; margin:0 auto 2.4rem; padding:0 1.25rem; color:#8b91b4; font-size:0.82rem; }
-</style>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        .nn-support { max-width: 720px; margin: 0 auto; padding: calc(var(--nav-height) + var(--sp-10)) var(--sp-6) var(--sp-12); }
+        .nn-support h1 { font-family: var(--font-heading); background: var(--nn-gradient); -webkit-background-clip: text; background-clip: text; color: transparent; }
+        .nn-support .lede { color: var(--nn-text-muted); font-size: 1.05rem; }
+        .nn-costs { border: 1px solid var(--nn-border); border-radius: 14px; background: var(--nn-surface); padding: var(--sp-5); margin: var(--sp-6) 0; }
+        .nn-costs h2 { margin: 0 0 var(--sp-3); font-size: 1.1rem; font-family: var(--font-heading); }
+        .nn-cost-row { display: flex; justify-content: space-between; padding: 0.4rem 0; border-bottom: 1px dashed var(--nn-border); font-size: 0.95rem; }
+        .nn-donate-row { display: flex; gap: var(--sp-4); flex-wrap: wrap; margin: var(--sp-6) 0; }
+        .nn-donate-row a { flex: 1; min-width: 200px; text-align: center; padding: 0.9rem 1rem; border-radius: 12px; font-weight: 600; text-decoration: none; background: var(--nn-gradient); color: #fff; }
+        .nn-donate-row a.ghost { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-fineprint { font-size: 0.85rem; color: var(--nn-text-muted); }
+    </style>
 
 
     
@@ -553,88 +540,51 @@
 
     <main id="main-content">
     
-<div class="dh-hero">
-  <div class="dh-container">
-    <div class="dh-kicker"><span>◆</span> Nerra Data</div>
-    <h1 class="dh-h1">Data &amp; Dashboards</h1>
-    <p class="dh-sub">Live, continuously-updated data behind the shows — launch countdowns, market prices, fleet records, and simulated-portfolio performance. Real numbers from public sources, refreshed every pipeline run; curated history is operator-maintained and clearly labelled.</p>
-  </div>
+<div class="nn-support">
+    <h1>Support the Nerra Network</h1>
+    <p class="lede">Seventeen daily shows, five languages, zero ads, zero
+       paywalls. Everything we publish is free and stays free — supported by
+       listeners who want it to exist.</p>
+
+    <div class="nn-costs">
+        <h2>What it actually costs</h2>
+        <p>In the spirit of this network's honesty rules, here's the real
+           ledger — the entire operation runs on roughly
+           <strong>$120/month</strong>:</p>
+        <div class="nn-cost-row"><span>Voice synthesis (every episode, every language)</span><span>~40%</span></div>
+        <div class="nn-cost-row"><span>Writing &amp; research models</span><span>~25%</span></div>
+        <div class="nn-cost-row"><span>Artwork &amp; video imagery</span><span>~25%</span></div>
+        <div class="nn-cost-row"><span>Hosting, storage &amp; delivery</span><span>~10%</span></div>
+        <p class="nn-fineprint" style="margin-top: var(--sp-3);">A $3 monthly
+           donation covers about a day of the whole network. Every dollar past
+           costs goes to making the shows better — new formats, better
+           research, more languages.</p>
+    </div>
+
+    
+    <div class="nn-costs">
+        <h2>Donations are almost ready</h2>
+        <p>We're wiring up secure payments now. Meanwhile, the best ways to
+           support the network cost nothing: subscribe to a show, share an
+           episode, <a href="join.html">create a free
+           account</a>.</p>
+    </div>
+    
+
+    <h2>Prefer to get something back?</h2>
+    <p><a href="join.html">Nerra Personal</a> is our
+       membership: your own private daily show — the shows you pick, in your
+       order, anchored by Mira — from $4.99/month. Members also get gallery
+       downloads and deep discounts on
+       <a href="books.html">Nerra Network books</a>.</p>
+
+    <h2 style="margin-top: var(--sp-8);">The fine print</h2>
+    <p class="nn-fineprint">Donations support an independent media project and
+       are not tax-deductible charitable contributions. Payments are processed
+       by Stripe; we never see your card details. Monthly donations can be
+       cancelled any time from your Stripe receipt email. Questions:
+       reply to any Nerra newsletter.</p>
 </div>
-
-<div class="dh-grid">
-  <a class="dh-card" href="spacex-dashboard.html" style="--accent:#00D4FF;">
-    <span class="dh-tag">SpaceX Daily</span>
-    <h2>SpaceX Launch Dashboard</h2>
-    <p>Next-launch countdown, watch-live links, launch cadence, mass to orbit, the booster-reuse record watch, the Starship flight-test tracker, and live SPCX price.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live countdown</span>
-      <span class="dh-chip">Booster records</span>
-      <span class="dh-chip">Starship tracker</span>
-      <span class="dh-chip">SPCX price</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
-
-  <a class="dh-card" href="tesla-dashboard.html" style="--accent:#E31937;">
-    <span class="dh-tag">Tesla Shorts Time</span>
-    <h2>Tesla Dashboard</h2>
-    <p>Live TSLA price with a 1-year chart and 52-week range, quarterly production &amp; deliveries, Supercharger network growth, energy-storage deployments, and milestones.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Live TSLA</span>
-      <span class="dh-chip">Quarterly P&amp;D</span>
-      <span class="dh-chip">Supercharger growth</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
-
-  <a class="dh-card" href="modern-investing-performance.html" style="--accent:#10b981;">
-    <span class="dh-tag">Modern Investing Techniques</span>
-    <h2>Performance &amp; Recursive Learning</h2>
-    <p>The simulated practice portfolio's cumulative return, monthly P&amp;L, win/loss split, sector breakdown, recent trades, and the operating principles the model derives from its own results. Education only.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Equity curve</span>
-      <span class="dh-chip">Monthly P&amp;L</span>
-      <span class="dh-chip">Alpha vs NASDAQ</span>
-    </div>
-    <span class="dh-go">Open dashboard →</span>
-  </a>
-
-  <a class="dh-card" href="gallery.html" style="--accent:#6B47FF;">
-    <span class="dh-tag">Network</span>
-    <h2>Image Gallery</h2>
-    <p>Every AI-generated visual produced for the shows — filterable by show and date, free to download under CC BY-SA 4.0 with attribution.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Filter by show</span>
-      <span class="dh-chip">CC BY-SA 4.0</span>
-    </div>
-    <span class="dh-go">Browse gallery →</span>
-  </a>
-
-  <a class="dh-card" href="tesla-narrative.html" style="--accent:#E31937;">
-    <span class="dh-tag">Story Trackers</span>
-    <h2>Longitudinal Chronicles</h2>
-    <p>Follow major programs across episodes — Tesla's Story Tracker, plus Models &amp; Agents, Fascinating Frontiers, Planetterrian, and SpaceX.</p>
-    <div class="dh-metrics">
-      <span class="dh-chip">Tesla</span>
-      <span class="dh-chip">SpaceX</span>
-      <span class="dh-chip">AI</span>
-      <span class="dh-chip">Science</span>
-    </div>
-    <span class="dh-go">Open Tesla tracker →</span>
-  </a>
-</div>
-
-<p class="dh-note" style="margin-top:-1rem;">
-  More story trackers:
-  <a href="models-agents-narrative.html" style="color:#9b8cff;">Models &amp; Agents</a> ·
-  <a href="fascinating-frontiers-narrative.html" style="color:#9b8cff;">Fascinating Frontiers</a> ·
-  <a href="planetterrian-narrative.html" style="color:#9b8cff;">Planetterrian</a> ·
-  <a href="spacex-narrative.html" style="color:#9b8cff;">SpaceX</a>
-</p>
-
-<p class="dh-note">
-  Sources: launch data from <a href="https://thespacedevs.com/" target="_blank" rel="noopener" style="color:#9b8cff;">The Space Devs</a> Launch Library 2, active-satellite counts from <a href="https://celestrak.org/" target="_blank" rel="noopener" style="color:#9b8cff;">CelesTrak</a>, and market quotes from Yahoo Finance — each refreshed on every pipeline run, with the last good value kept on a fetch hiccup. Estimated figures (mass to orbit, satellites deployed) use public per-vehicle averages and are labelled as estimates. Nothing here is financial advice.
-</p>
 
     </main>
 

--- a/templates/account_page.html.j2
+++ b/templates/account_page.html.j2
@@ -1,0 +1,211 @@
+{% extends "base.html.j2" %}
+
+{% block head_extra %}
+    <link rel="stylesheet" href="{{ path_prefix }}styles/main.css">
+    <style>
+        .nn-account { max-width: 760px; margin: 0 auto; padding: calc(var(--nav-height) + var(--sp-10)) var(--sp-6) var(--sp-12); }
+        .nn-account h1 { font-family: var(--font-heading); }
+        .nn-card { border: 1px solid var(--nn-border); border-radius: 14px; background: var(--nn-surface); padding: var(--sp-5); margin-bottom: var(--sp-5); }
+        .nn-card h2 { margin: 0 0 var(--sp-3); font-size: 1.1rem; font-family: var(--font-heading); }
+        .nn-account input[type=email], .nn-account input[type=text] { width: 100%; padding: 0.7rem 0.9rem; border-radius: 10px; border: 1px solid var(--nn-border); background: var(--nn-bg, transparent); color: inherit; }
+        .nn-account button { padding: 0.65rem 1.4rem; border-radius: 10px; border: none; background: var(--nn-gradient); color: #fff; font-weight: 600; cursor: pointer; }
+        .nn-account button.ghost { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-lineup-row { display: flex; align-items: center; gap: 0.5rem; padding: 0.4rem 0.2rem; border-bottom: 1px dashed var(--nn-border); }
+        .nn-lineup-row .movers { margin-left: auto; display: flex; gap: 0.25rem; }
+        .nn-lineup-row .movers button { padding: 0.15rem 0.55rem; font-size: 0.9rem; }
+        .nn-feedurl { font-family: var(--font-mono, monospace); font-size: 0.8rem; word-break: break-all; background: var(--nn-bg, rgba(0,0,0,0.15)); padding: 0.6rem 0.8rem; border-radius: 8px; }
+        .nn-perk { display: flex; justify-content: space-between; gap: 1rem; padding: 0.5rem 0; border-bottom: 1px dashed var(--nn-border); }
+        .nn-muted { color: var(--nn-text-muted); font-size: 0.9rem; }
+        #nn-status { min-height: 1.2rem; font-size: 0.9rem; }
+        [hidden] { display: none !important; }
+    </style>
+{% endblock %}
+
+{% block content %}
+<div class="nn-account">
+    <h1>Your Nerra account</h1>
+    <p id="nn-status" class="nn-muted">Loading…</p>
+
+    <!-- Signed-out: magic-link request -->
+    <div class="nn-card" id="nn-signin" hidden>
+        <h2>Sign in</h2>
+        <p class="nn-muted">No passwords here — enter the email you joined with
+           and we'll send you a sign-in link.</p>
+        <form onsubmit="NN.login(this);return false;" style="display:flex;gap:0.5rem;flex-wrap:wrap;">
+            <input type="email" name="email" placeholder="you@example.com" required style="flex:1;min-width:220px;">
+            <button type="submit">Email me a link</button>
+        </form>
+        <p class="nn-muted" style="margin-top:0.75rem;">New here?
+            <a href="{{ path_prefix }}join.html">Create your free account →</a></p>
+    </div>
+
+    <div id="nn-member" hidden>
+        <!-- Personal feed -->
+        <div class="nn-card">
+            <h2>Your personal daily show</h2>
+            <div id="nn-feed-active" hidden>
+                <p>Mira builds your edition every morning. Add this private
+                   feed to any podcast app — it's yours alone; sharing the
+                   URL shares your subscription.</p>
+                <p class="nn-feedurl" id="nn-feed-url"></p>
+                <button class="ghost" onclick="NN.copyFeed()">Copy feed URL</button>
+            </div>
+            <div id="nn-feed-upsell" hidden>
+                <p>Pick your shows and order below, then start your
+                   subscription — your feed exists within a day.</p>
+                {% if stripe_personal_url and stripe_personal_url != '#' %}
+                <p>
+                    <a href="{{ stripe_personal_url }}"><button>Personal — $4.99/mo</button></a>
+                    {% if stripe_personal_local_url and stripe_personal_local_url != '#' %}
+                    <a href="{{ stripe_personal_local_url }}"><button class="ghost">+ Local brief — $8.99/mo</button></a>
+                    {% endif %}
+                </p>
+                <p class="nn-muted">Use the same email at checkout that you
+                   signed in with — that's how your feed finds you.</p>
+                {% else %}
+                <p class="nn-muted">Personal feeds are launching soon — your
+                   saved lineup will be ready on day one.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Lineup + preferences -->
+        <div class="nn-card">
+            <h2>Your lineup</h2>
+            <p class="nn-muted">Choose at least two shows; order them the way
+               you want your morning to run. Mira handles the rest.</p>
+            <div id="nn-lineup"></div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:0.75rem;margin-top:var(--sp-4);">
+                <label>First name <span class="nn-muted">(Mira greets you by it)</span>
+                    <input type="text" id="nn-name" maxlength="40" placeholder="Optional"></label>
+                <label>City <span class="nn-muted">(for the local brief tier)</span>
+                    <input type="text" id="nn-city" maxlength="80" placeholder="Optional"></label>
+            </div>
+            <p style="margin-top:var(--sp-4);"><button onclick="NN.save()">Save preferences</button>
+               <span id="nn-save-status" class="nn-muted"></span></p>
+        </div>
+
+        <!-- Member perks -->
+        <div class="nn-card">
+            <h2>Member perks</h2>
+            <div class="nn-perk"><span>Newsletter</span>
+                <span class="nn-muted">You're on the list — manage shows in any email's footer</span></div>
+            <div class="nn-perk"><span>Image gallery downloads</span>
+                <a href="{{ path_prefix }}gallery.html">Browse the gallery →</a></div>
+            <div class="nn-perk"><span>Book discount</span>
+                <span id="nn-book-perk" class="nn-muted">—</span></div>
+            <div class="nn-perk"><span>Support the network</span>
+                <a href="{{ path_prefix }}support.html">Donate →</a></div>
+        </div>
+    </div>
+</div>
+
+<script>
+var NN = (function () {
+  var API = 'https://api.nerranetwork.com';
+  var state = { shows: [], all: [], names: {} };
+  var SHOW_NAMES = {{ show_names | tojson }};
+
+  function el(id) { return document.getElementById(id); }
+
+  function renderLineup() {
+    var box = el('nn-lineup');
+    box.innerHTML = '';
+    var chosen = state.shows.slice();
+    var rest = state.all.filter(function (s) { return chosen.indexOf(s) === -1; });
+    chosen.concat(rest).forEach(function (slug) {
+      var idx = chosen.indexOf(slug);
+      var row = document.createElement('div');
+      row.className = 'nn-lineup-row';
+      var cb = document.createElement('input');
+      cb.type = 'checkbox'; cb.checked = idx !== -1;
+      cb.onchange = function () {
+        if (cb.checked) { state.shows.push(slug); }
+        else { state.shows = state.shows.filter(function (s) { return s !== slug; }); }
+        renderLineup();
+      };
+      var label = document.createElement('span');
+      label.textContent = (idx !== -1 ? (idx + 1) + '. ' : '') + (SHOW_NAMES[slug] || slug);
+      row.appendChild(cb); row.appendChild(label);
+      if (idx !== -1) {
+        var movers = document.createElement('span');
+        movers.className = 'movers';
+        [['↑', -1], ['↓', 1]].forEach(function (m) {
+          var b = document.createElement('button');
+          b.className = 'ghost'; b.textContent = m[0]; b.type = 'button';
+          b.onclick = function () {
+            var j = idx + m[1];
+            if (j < 0 || j >= state.shows.length) return;
+            state.shows.splice(idx, 1);
+            state.shows.splice(j, 0, slug);
+            renderLineup();
+          };
+          movers.appendChild(b);
+        });
+        row.appendChild(movers);
+      }
+      box.appendChild(row);
+    });
+  }
+
+  function load() {
+    fetch(API + '/api/account', { credentials: 'include' })
+      .then(function (r) { if (!r.ok) throw new Error(r.status); return r.json(); })
+      .then(function (data) {
+        el('nn-status').textContent = '';
+        el('nn-member').hidden = false;
+        state.all = data.shows || [];
+        var prefs = (data.member && data.member.preferences) || {};
+        state.shows = prefs.shows || [];
+        el('nn-name').value = prefs.first_name || '';
+        el('nn-city').value = prefs.city || '';
+        renderLineup();
+        var feedUrl = data.member && data.member.feed_url;
+        el('nn-feed-active').hidden = !feedUrl;
+        el('nn-feed-upsell').hidden = !!feedUrl;
+        if (feedUrl) { el('nn-feed-url').textContent = feedUrl; }
+        var code = data.perks && data.perks.book_discount_code;
+        el('nn-book-perk').innerHTML = code
+          ? 'Use code <strong>' + code + '</strong> at the book store — '
+            + '<a href="{{ path_prefix }}books.html">see the books →</a>'
+          : 'Member codes appear here as new volumes launch';
+      })
+      .catch(function () {
+        el('nn-status').textContent = '';
+        el('nn-signin').hidden = false;
+      });
+  }
+
+  return {
+    login: function (form) {
+      var btn = form.querySelector('button');
+      btn.disabled = true; btn.textContent = 'Sending…';
+      fetch(API + '/api/login?email=' + encodeURIComponent(form.email.value))
+        .then(function () { btn.textContent = 'Check your inbox'; })
+        .catch(function () { btn.textContent = 'Try again'; btn.disabled = false; });
+    },
+    save: function () {
+      el('nn-save-status').textContent = 'Saving…';
+      fetch(API + '/api/account/preferences', {
+        method: 'POST', credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          shows: state.shows,
+          first_name: el('nn-name').value,
+          city: el('nn-city').value,
+        }),
+      }).then(function (r) {
+        el('nn-save-status').textContent = r.ok
+          ? 'Saved — changes reach tomorrow’s edition'
+          : 'Save failed (are personal accounts live yet?)';
+      }).catch(function () { el('nn-save-status').textContent = 'Save failed'; });
+    },
+    copyFeed: function () {
+      navigator.clipboard.writeText(el('nn-feed-url').textContent);
+    },
+    load: load,
+  };
+})();
+NN.load();
+</script>
+{% endblock %}

--- a/templates/base.html.j2
+++ b/templates/base.html.j2
@@ -367,10 +367,13 @@
                 to action and the wrong one. Default false, so every
                 other page renders byte-for-byte as before. -#}
             {%- if not hide_footer_subscribe %}
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent={{ t.subscribe_button_loading | tojson }};setTimeout(function(){btn.textContent={{ t.subscribe_button_done | tojson }};btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent={{ t.subscribe_button_loading | tojson }};var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?{{ t.subscribe_button_done | tojson }}:{{ t.subscribe_button | tojson }};if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent={{ t.subscribe_button | tojson }};}).then(function(){btn.disabled=false;});return false;">
                     <h4>{{ t.subscribe_h4 }}</h4>
                     <p>{{ t.subscribe_subtitle }}</p>
                     <div class="nn-subscribe-tags">
@@ -388,9 +391,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="{{ t.subscribe_email_placeholder }}" required aria-label="{{ t.subscribe_email_aria }}">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">{{ t.subscribe_button }}</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="{{ path_prefix }}join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="{{ path_prefix }}account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             {%- endif %}
@@ -401,6 +407,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">{{ t.ai_notice }} <a href="{{ path_prefix }}ai-disclosure.html">{{ t.learn_more }}</a></p>
                 <div>
+                    <a href="{{ path_prefix }}support.html">Support the network</a> &middot;
                     <a href="{{ path_prefix }}privacy-policy.html">{{ t.footer_privacy }}</a> &middot;
                     <a href="{{ path_prefix }}terms-of-service.html">{{ t.footer_terms }}</a> &middot;
                     <a href="{{ path_prefix }}ai-disclosure.html">{{ t.footer_ai_disclosure }}</a>

--- a/templates/join_page.html.j2
+++ b/templates/join_page.html.j2
@@ -1,0 +1,100 @@
+{% extends "base.html.j2" %}
+
+{% block head_extra %}
+    <link rel="stylesheet" href="{{ path_prefix }}styles/main.css">
+    <style>
+        .nn-join-hero { padding: calc(var(--nav-height) + var(--sp-12)) var(--sp-6) var(--sp-8); text-align: center; position: relative; overflow: hidden; }
+        .nn-join-hero::before { content: ''; position: absolute; inset: 0; background: radial-gradient(ellipse at 50% 0%, rgba(0, 212, 255, 0.14), transparent 70%); pointer-events: none; }
+        .nn-join-hero h1 { font-family: var(--font-heading); font-size: clamp(2rem, 5vw, 3rem); margin: 0 0 var(--sp-3); background: var(--nn-gradient); -webkit-background-clip: text; background-clip: text; color: transparent; }
+        .nn-join-hero p { font-family: var(--font-ui); color: var(--nn-text-muted); max-width: 640px; margin: 0 auto; }
+        .nn-tiers { display: grid; grid-template-columns: repeat(auto-fit, minmax(270px, 1fr)); gap: var(--sp-6); max-width: 1080px; margin: 0 auto; padding: var(--sp-8) var(--sp-6); }
+        .nn-tier { border: 1px solid var(--nn-border); border-radius: 16px; padding: var(--sp-6); background: var(--nn-surface); display: flex; flex-direction: column; }
+        .nn-tier.featured { border-color: var(--nn-cyan, #00D4FF); box-shadow: 0 0 32px rgba(0,212,255,0.12); }
+        .nn-tier h2 { font-family: var(--font-heading); margin: 0 0 var(--sp-1); font-size: 1.3rem; }
+        .nn-tier .price { font-size: 2rem; font-weight: 700; margin: 0 0 var(--sp-3); }
+        .nn-tier .price small { font-size: 0.9rem; font-weight: 400; color: var(--nn-text-muted); }
+        .nn-tier ul { list-style: none; padding: 0; margin: 0 0 var(--sp-5); flex: 1; }
+        .nn-tier li { padding: 0.35rem 0; border-bottom: 1px dashed var(--nn-border); font-size: 0.95rem; }
+        .nn-tier li::before { content: '✓ '; color: var(--nn-cyan, #00D4FF); }
+        .nn-tier .cta { display: block; text-align: center; padding: 0.8rem 1rem; border-radius: 10px; font-weight: 600; text-decoration: none; background: var(--nn-gradient); color: #fff; }
+        .nn-tier .cta.secondary { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-join-form { max-width: 480px; margin: 0 auto var(--sp-10); padding: 0 var(--sp-6); text-align: center; }
+        .nn-join-form input[type=email] { width: 100%; padding: 0.8rem 1rem; border-radius: 10px; border: 1px solid var(--nn-border); background: var(--nn-surface); color: inherit; margin-bottom: var(--sp-3); }
+        .nn-join-form button { padding: 0.8rem 2rem; border-radius: 10px; border: none; background: var(--nn-gradient); color: #fff; font-weight: 600; cursor: pointer; }
+        .nn-join-note { font-size: 0.85rem; color: var(--nn-text-muted); max-width: 640px; margin: 0 auto var(--sp-12); padding: 0 var(--sp-6); text-align: center; }
+    </style>
+{% endblock %}
+
+{% block content %}
+<section class="nn-join-hero">
+    <h1>Nerra Personal</h1>
+    <p>Seventeen shows, every day, free — and now, a version of the network
+       that knows you. One account unlocks the newsletter, the image
+       gallery, and member perks. One small subscription gets you your own
+       daily show: the shows you choose, in your order, anchored by Mira.</p>
+</section>
+
+<section class="nn-tiers">
+    <div class="nn-tier">
+        <h2>Nerra Account</h2>
+        <p class="price">Free</p>
+        <ul>
+            <li>Every show &amp; episode — always free, no ads</li>
+            <li>The newsletter, per-show — pick what lands in your inbox</li>
+            <li>Full-resolution downloads from the image gallery</li>
+            <li>Member perks: deep discounts on Nerra Network books</li>
+            <li>Configure your personal lineup, ready when you upgrade</li>
+        </ul>
+        <a class="cta secondary" href="#join-free">Create your free account</a>
+    </div>
+    <div class="nn-tier featured">
+        <h2>Personal</h2>
+        <p class="price">$4.99<small>/month</small></p>
+        <ul>
+            <li>Everything in the free account</li>
+            <li><strong>Your own private daily show</strong> — pick the shows, set the order</li>
+            <li>Mira anchors it and greets you by name</li>
+            <li>Private RSS feed — works in every podcast app</li>
+            <li>Chapter markers for every segment</li>
+        </ul>
+        {% if stripe_personal_url and stripe_personal_url != '#' %}
+        <a class="cta" href="{{ stripe_personal_url }}">Start Personal</a>
+        {% else %}
+        <a class="cta secondary" href="#join-free">Launching soon — join free for first access</a>
+        {% endif %}
+    </div>
+    <div class="nn-tier">
+        <h2>Personal + Local</h2>
+        <p class="price">$8.99<small>/month</small></p>
+        <ul>
+            <li>Everything in Personal</li>
+            <li><strong>Your city's morning brief</strong>, in your feed</li>
+            <li>Today's weather, spoken by Mira</li>
+            <li>One local story or event worth knowing, source named</li>
+            <li>Honest by design: no local news worth your time, no filler</li>
+        </ul>
+        {% if stripe_personal_local_url and stripe_personal_local_url != '#' %}
+        <a class="cta" href="{{ stripe_personal_local_url }}">Start Personal + Local</a>
+        {% else %}
+        <a class="cta secondary" href="#join-free">Launching soon — join free for first access</a>
+        {% endif %}
+    </div>
+</section>
+
+<section class="nn-join-form" id="join-free">
+    <h2>Create your free Nerra account</h2>
+    <p>One email. No password — we send you a sign-in link whenever you need one.</p>
+    <form onsubmit="var f=this,b=f.querySelector('button');b.disabled=true;b.textContent='Joining…';fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member'})}).then(function(r){if(r.ok){window.location='{{ path_prefix }}account.html';}else{b.textContent='Try again';b.disabled=false;}}).catch(function(){b.textContent='Try again';b.disabled=false;});return false;">
+        <input type="email" name="email" placeholder="you@example.com" required aria-label="Email address">
+        <button type="submit">Join free</button>
+    </form>
+    <p style="margin-top: var(--sp-3); font-size: 0.9rem;">Already a member?
+        <a href="{{ path_prefix }}account.html">Go to your account →</a></p>
+</section>
+
+<p class="nn-join-note">Joining subscribes you to the Nerra newsletter (unsubscribe
+   any time — the account stays). Paid tiers are billed by Stripe and cancel in
+   one click; your private feed stops at the end of the billing period. Prefer
+   to just chip in? <a href="{{ path_prefix }}support.html">Support the network</a>
+   with a one-time or monthly donation instead.</p>
+{% endblock %}

--- a/templates/support_page.html.j2
+++ b/templates/support_page.html.j2
@@ -1,0 +1,70 @@
+{% extends "base.html.j2" %}
+
+{% block head_extra %}
+    <link rel="stylesheet" href="{{ path_prefix }}styles/main.css">
+    <style>
+        .nn-support { max-width: 720px; margin: 0 auto; padding: calc(var(--nav-height) + var(--sp-10)) var(--sp-6) var(--sp-12); }
+        .nn-support h1 { font-family: var(--font-heading); background: var(--nn-gradient); -webkit-background-clip: text; background-clip: text; color: transparent; }
+        .nn-support .lede { color: var(--nn-text-muted); font-size: 1.05rem; }
+        .nn-costs { border: 1px solid var(--nn-border); border-radius: 14px; background: var(--nn-surface); padding: var(--sp-5); margin: var(--sp-6) 0; }
+        .nn-costs h2 { margin: 0 0 var(--sp-3); font-size: 1.1rem; font-family: var(--font-heading); }
+        .nn-cost-row { display: flex; justify-content: space-between; padding: 0.4rem 0; border-bottom: 1px dashed var(--nn-border); font-size: 0.95rem; }
+        .nn-donate-row { display: flex; gap: var(--sp-4); flex-wrap: wrap; margin: var(--sp-6) 0; }
+        .nn-donate-row a { flex: 1; min-width: 200px; text-align: center; padding: 0.9rem 1rem; border-radius: 12px; font-weight: 600; text-decoration: none; background: var(--nn-gradient); color: #fff; }
+        .nn-donate-row a.ghost { background: transparent; border: 1px solid var(--nn-border); color: inherit; }
+        .nn-fineprint { font-size: 0.85rem; color: var(--nn-text-muted); }
+    </style>
+{% endblock %}
+
+{% block content %}
+<div class="nn-support">
+    <h1>Support the Nerra Network</h1>
+    <p class="lede">Seventeen daily shows, five languages, zero ads, zero
+       paywalls. Everything we publish is free and stays free — supported by
+       listeners who want it to exist.</p>
+
+    <div class="nn-costs">
+        <h2>What it actually costs</h2>
+        <p>In the spirit of this network's honesty rules, here's the real
+           ledger — the entire operation runs on roughly
+           <strong>${{ monthly_cost_usd }}/month</strong>:</p>
+        <div class="nn-cost-row"><span>Voice synthesis (every episode, every language)</span><span>~40%</span></div>
+        <div class="nn-cost-row"><span>Writing &amp; research models</span><span>~25%</span></div>
+        <div class="nn-cost-row"><span>Artwork &amp; video imagery</span><span>~25%</span></div>
+        <div class="nn-cost-row"><span>Hosting, storage &amp; delivery</span><span>~10%</span></div>
+        <p class="nn-fineprint" style="margin-top: var(--sp-3);">A $3 monthly
+           donation covers about a day of the whole network. Every dollar past
+           costs goes to making the shows better — new formats, better
+           research, more languages.</p>
+    </div>
+
+    {% if donate_monthly_url and donate_monthly_url != '#' %}
+    <div class="nn-donate-row">
+        <a href="{{ donate_monthly_url }}">Donate monthly</a>
+        <a class="ghost" href="{{ donate_once_url or donate_monthly_url }}">One-time donation</a>
+    </div>
+    {% else %}
+    <div class="nn-costs">
+        <h2>Donations are almost ready</h2>
+        <p>We're wiring up secure payments now. Meanwhile, the best ways to
+           support the network cost nothing: subscribe to a show, share an
+           episode, <a href="{{ path_prefix }}join.html">create a free
+           account</a>.</p>
+    </div>
+    {% endif %}
+
+    <h2>Prefer to get something back?</h2>
+    <p><a href="{{ path_prefix }}join.html">Nerra Personal</a> is our
+       membership: your own private daily show — the shows you pick, in your
+       order, anchored by Mira — from $4.99/month. Members also get gallery
+       downloads and deep discounts on
+       <a href="{{ path_prefix }}books.html">Nerra Network books</a>.</p>
+
+    <h2 style="margin-top: var(--sp-8);">The fine print</h2>
+    <p class="nn-fineprint">Donations support an independent media project and
+       are not tax-deductible charitable contributions. Payments are processed
+       by Stripe; we never see your card details. Monthly donations can be
+       cancelled any time from your Stripe receipt email. Questions:
+       reply to any Nerra newsletter.</p>
+</div>
+{% endblock %}

--- a/tesla-dashboard.html
+++ b/tesla-dashboard.html
@@ -954,10 +954,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -998,9 +1001,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -1010,6 +1016,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/tests/test_nerra_personal.py
+++ b/tests/test_nerra_personal.py
@@ -1,0 +1,219 @@
+"""Drift guards for Nerra Personal (accounts + personalized feeds +
+support surface).
+
+Pins: spec validation (the closed show vocabulary and token/name/city
+trust boundary), the private-feed XML contract (deterministic GUIDs,
+Worker-gated enclosures, itunes:block), the prune depth, the honest
+local-brief contract, the Worker/engine vocabulary sync, page + prompt
+registration, and the funding-tag repoint.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from pathlib import Path
+
+import pytest
+
+from engine.daily_edition import EDITIONS, Segment
+from engine.personal_edition import (
+    PERSONAL_FEED_MAX_EPISODES,
+    PERSONAL_SHOW_SLUGS,
+    PersonalSpec,
+    build_personal_feed_xml,
+    build_personal_links_prompt,
+    fallback_personal_links,
+    format_weather_line,
+    parse_local_brief,
+    personal_episode_title,
+    prune_episode_state,
+    validate_spec,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+TOKEN = "ab" * 16
+
+
+def _segment(slug="spacex", name="SpaceX Daily", n=76):
+    return Segment(
+        slug=slug, show_name=name, episode_num=n,
+        episode_title=f"Ep {n}: A hook for {name}", hook=f"A hook for {name}",
+        date="2026-08-21", audio_url="", content="Body text. " * 30,
+        digest_dir=Path("."), transcript_path=None, music_intro_offset=0.0)
+
+
+class TestSpecValidation:
+    def test_happy_path_preserves_user_order(self):
+        spec = validate_spec({
+            "token": TOKEN,
+            "shows": ["dp_pod", "spacex", "tesla"],
+            "tier": "personal_local",
+            "first_name": "Sam", "city": "Vancouver",
+        })
+        assert spec is not None
+        assert spec.shows == ["dp_pod", "spacex", "tesla"]  # THEIR order
+        assert spec.tier == "personal_local"
+
+    def test_unknown_shows_dropped_never_guessed(self):
+        spec = validate_spec({
+            "token": TOKEN,
+            "shows": ["tesla", "not_a_show", "spacex", "tesla"],
+        })
+        assert spec is not None
+        assert spec.shows == ["tesla", "spacex"]
+
+    def test_too_few_shows_rejected(self):
+        assert validate_spec({"token": TOKEN, "shows": ["tesla"]}) is None
+
+    def test_bad_token_rejected(self):
+        assert validate_spec({"token": "../evil", "shows": ["tesla", "spacex"]}) is None
+        assert validate_spec({"token": "ZZZZ" * 8, "shows": ["tesla", "spacex"]}) is None
+
+    def test_hostile_name_dropped_city_capped(self):
+        spec = validate_spec({
+            "token": TOKEN, "shows": ["tesla", "spacex"],
+            "first_name": "<script>x</script>", "city": "y" * 500,
+        })
+        assert spec is not None
+        assert spec.first_name == ""
+        assert len(spec.city) == 80
+
+    def test_vocabulary_is_the_en_lineup(self):
+        assert PERSONAL_SHOW_SLUGS == EDITIONS["en"].lineup
+
+    def test_worker_vocabulary_stays_in_sync(self):
+        # The Worker validates preferences against its own copy of the
+        # closed set — a drift means saved lineups silently lose shows.
+        ts = (ROOT / "workers" / "gallery" / "src" / "personal.ts"
+              ).read_text(encoding="utf-8")
+        for slug in PERSONAL_SHOW_SLUGS:
+            assert f'"{slug}"' in ts, f"{slug} missing from worker PERSONAL_SHOWS"
+
+
+class TestPersonalFeed:
+    def _spec(self):
+        return PersonalSpec(token=TOKEN, shows=["spacex", "tesla"],
+                            first_name="Sam")
+
+    def _episodes(self, n=2):
+        return [{
+            "episode_num": i, "date": f"2026-08-{10 + i:02d}",
+            "title": f"Edition {i}", "description": "d",
+            "filename": f"Nerra_Personal_202608{10 + i:02d}.mp3",
+            "duration_seconds": 3000, "bytes": 1000,
+        } for i in range(1, n + 1)]
+
+    def test_feed_contract(self):
+        xml = build_personal_feed_xml(self._spec(), self._episodes())
+        # Worker-gated enclosures: revocable, never a public bucket URL.
+        assert "https://api.nerranetwork.com/api/feed/" + TOKEN in xml
+        # Deterministic GUIDs — rebuilds never re-notify podcast apps.
+        assert f"personal-{TOKEN[:8]}-ep002-20260812" in xml
+        # Private: directories must never index a personal feed.
+        assert "<itunes:block>yes</itunes:block>" in xml
+        assert "Sam's Nerra Daily" in xml
+
+    def test_feed_depth_capped(self):
+        xml = build_personal_feed_xml(self._spec(), self._episodes(12))
+        assert xml.count("<item>") == PERSONAL_FEED_MAX_EPISODES
+
+    def test_prune_returns_filenames_to_delete(self):
+        kept, dropped = prune_episode_state(self._episodes(10))
+        assert len(kept) == PERSONAL_FEED_MAX_EPISODES
+        assert len(dropped) == 10 - PERSONAL_FEED_MAX_EPISODES
+        # Newest survive.
+        assert kept[0]["episode_num"] == 10
+        assert "Nerra_Personal_20260811.mp3" in dropped
+
+    def test_title_clipped_and_unlabeled(self):
+        seg = _segment()
+        seg.hook = "very long words " * 30
+        title = personal_episode_title(dt.date(2026, 8, 21), [seg])
+        assert len(title) <= 100
+        assert not title.startswith("Ep ")
+
+
+class TestPersonalLinks:
+    def test_prompt_carries_name_and_order(self):
+        spec = PersonalSpec(token=TOKEN, shows=["dp_pod", "spacex"],
+                            first_name="Sam")
+        segs = [_segment("dp_pod", "The DP Pod", 41), _segment()]
+        prompt = build_personal_links_prompt(ROOT, spec, segs,
+                                             dt.date(2026, 8, 21))
+        assert "Sam" in prompt
+        assert prompt.index("The DP Pod") < prompt.index("SpaceX Daily")
+
+    def test_fallback_greets_and_covers_gaps(self):
+        spec = PersonalSpec(token=TOKEN, shows=["spacex", "tesla"],
+                            first_name="Sam")
+        segs = [_segment(), _segment("tesla", "Tesla Shorts Time", 579)]
+        links = fallback_personal_links(spec, segs, dt.date(2026, 8, 21))
+        assert "Sam" in links["intro"]
+        assert len(links["handoffs"]) == 1
+        assert "nerranetwork.com" in links["signoff"]
+
+    def test_prompt_files_registered(self):
+        for name in ("nerra_personal_links.txt", "nerra_personal_local.txt"):
+            text = (ROOT / "shows" / "prompts" / name).read_text(encoding="utf-8")
+            assert "{date_spoken}" in text
+        local = (ROOT / "shows" / "prompts" / "nerra_personal_local.txt"
+                 ).read_text(encoding="utf-8")
+        assert "SKIP" in local  # the honest no-content escape
+
+
+class TestLocalBrief:
+    def test_skip_and_bounds(self):
+        assert parse_local_brief("SKIP") is None
+        assert parse_local_brief("too short") is None
+        good = ("According to the city of Vancouver, the seawall reopens "
+                "this weekend after repairs. " * 3)
+        assert parse_local_brief(good)
+
+    def test_weather_line_is_measured_data_only(self):
+        line = format_weather_line("Vancouver", {
+            "temperature_2m_max": [21.6], "temperature_2m_min": [13.2],
+            "weather_code": [2],
+        })
+        assert "Vancouver" in line and "22" in line and "13" in line
+        assert "partly cloudy" in line
+        assert format_weather_line("Vancouver", {}) == ""
+
+
+class TestSurfaces:
+    def test_pages_registered(self):
+        import generate_html as gh
+
+        for fn in ("generate_join_page", "generate_support_page",
+                   "generate_account_page"):
+            assert hasattr(gh, fn), fn
+        src = (ROOT / "generate_html.py").read_text(encoding="utf-8")
+        assert '"join.html", "support.html"' in src  # sitemap
+
+    def test_templates_exist(self):
+        for name in ("join_page.html.j2", "account_page.html.j2",
+                     "support_page.html.j2"):
+            assert (ROOT / "templates" / name).exists(), name
+
+    def test_funding_tag_points_at_support(self):
+        # Aug 2026: podcast:funding is the donations surface now — every
+        # 2.0 app renders it as the show's Support button.
+        src = (ROOT / "run_show.py").read_text(encoding="utf-8")
+        assert 'funding_url=f"{config.publishing.base_url}/support.html"' in src
+        assert "/#newsletter\",\n            funding_label" not in src
+
+    def test_footer_newsletter_posts_to_account_worker(self):
+        # Newsletter signups create accounts: the footer form must go
+        # through /api/subscribe (list "member"), not Buttondown's embed.
+        base = (ROOT / "templates" / "base.html.j2").read_text(encoding="utf-8")
+        assert "embed-subscribe" not in base
+        assert "api.nerranetwork.com/api/subscribe" in base
+        assert "list:'member'" in base
+
+    def test_batch_builder_importable_and_piiless_logging(self):
+        src = (ROOT / "scripts" / "build_personal_feeds.py"
+               ).read_text(encoding="utf-8")
+        # Tokens are logged truncated; names/cities never logged.
+        assert "token[:8]" in src
+        assert not re.search(r'logger\.\w+\([^)]*spec\.first_name', src)
+        assert not re.search(r'logger\.\w+\([^)]*spec\.city', src)

--- a/thedppod-narrative.html
+++ b/thedppod-narrative.html
@@ -896,10 +896,13 @@
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -940,9 +943,12 @@
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -952,6 +958,7 @@
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/thedppod.html
+++ b/thedppod.html
@@ -1503,10 +1503,13 @@ Now pass it on around</div>
                 <a href="data.html">Data &amp; Dashboards</a>
                 <a href="management.html">Network Status</a>
             </div>
-            <!-- Newsletter Subscribe -->
+            <!-- Newsletter Subscribe — posts to the account Worker (Aug
+                 2026): every newsletter signup now creates a Nerra
+                 account (same identity as the gallery gate), so the
+                 member surface and the list grow together. -->
             <div class="nn-footer-subscribe">
-                <form action="https://buttondown.com/api/emails/embed-subscribe/patricknovak1" method="post" target="popupwindow" class="nn-subscribe-form"
-                      onsubmit="var btn=this.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";setTimeout(function(){btn.textContent="Check your email ✓";btn.disabled=false;},500);">
+                <form class="nn-subscribe-form"
+                      onsubmit="var f=this,btn=f.querySelector('button[type=submit]');btn.disabled=true;btn.textContent="Subscribing…";var tags=Array.prototype.map.call(f.querySelectorAll('input[name=tag]:checked'),function(c){return c.value;});fetch('https://api.nerranetwork.com/api/subscribe',{method:'POST',credentials:'include',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:f.email.value,list:'member',tags:tags})}).then(function(r){btn.textContent=r.ok?"Check your email ✓":"Subscribe";if(r.ok){var a=f.querySelector('.nn-account-link');if(a)a.style.display='inline';}}).catch(function(){btn.textContent="Subscribe";}).then(function(){btn.disabled=false;});return false;">
                     <h4>Get Show Updates</h4>
                     <p>Pick the shows you want in your inbox:</p>
                     <div class="nn-subscribe-tags">
@@ -1547,9 +1550,12 @@ Now pass it on around</div>
                     </div>
                     <div class="nn-subscribe-row">
                         <input type="email" name="email" placeholder="your@email.com" required aria-label="Email address">
-                        <input type="hidden" value="1" name="embed">
                         <button type="submit">Subscribe</button>
                     </div>
+                    <p style="margin-top:0.5rem;font-size:0.85rem;">
+                        <a href="join.html">Nerra Personal — your own daily show, gallery &amp; member perks →</a>
+                        <a class="nn-account-link" href="account.html" style="display:none;margin-left:0.75rem;">Your account →</a>
+                    </p>
                 </form>
             </div>
             <div class="nn-footer-bottom">
@@ -1559,6 +1565,7 @@ Now pass it on around</div>
             <div class="nn-footer-legal">
                 <p class="ai-notice">Nerra Network uses AI tools in content production. <a href="ai-disclosure.html">Learn more</a></p>
                 <div>
+                    <a href="support.html">Support the network</a> &middot;
                     <a href="privacy-policy.html">Privacy</a> &middot;
                     <a href="terms-of-service.html">Terms</a> &middot;
                     <a href="ai-disclosure.html">AI Disclosure</a>

--- a/workers/gallery/src/handlers.ts
+++ b/workers/gallery/src/handlers.ts
@@ -91,6 +91,11 @@ const SUBSCRIBE_LISTS: Record<string, string[]> = {
   // Same isolation rule as ru-spacex: these subscribers asked for a
   // Russian weekly («Хроника Tesla»), never the English daily sends.
   "ru-tesla": ["ru-tesla"],
+  // Aug 2026: the Nerra Account join flow (join.html). A member signup
+  // IS a newsletter signup IS a gallery unlock — one identity. The
+  // gallery tag rides along so the existing download gate recognises
+  // members without a second enrolment.
+  member: ["nerra-member", SUBSCRIBER_TAG],
 };
 const DEFAULT_LIST = "gallery";
 
@@ -107,10 +112,38 @@ const SOURCE_TAGS = new Set([
   "src-nerranetwork",
 ]);
 
-/** Resolve the client's `list` + `source` into the tags we will send. */
+// Per-show newsletter tags a member may opt into from the join/footer
+// forms (Aug 2026: the footer form moved off Buttondown's direct embed so
+// every newsletter signup creates a Nerra account). Same closed-set rule
+// as everything else here: values mirror each show YAML's
+// ``newsletter.tag`` (rendered as ``newsletter_tag`` in NETWORK_SHOWS) —
+// keep in sync when a show is added.
+const SHOW_NEWSLETTER_TAGS = new Set([
+  "Tesla Shorts Time",
+  "Omni View",
+  "Fascinating Frontiers",
+  "Planetterrian Daily",
+  "Environmental Intelligence",
+  "Models & Agents",
+  "Models & Agents for Beginners",
+  "Finansy Prosto",
+  "Privet Russian",
+  "Modern Investing Techniques",
+  "Unintended Consequences",
+  "First Principles Daily",
+  "The DP Pod: The Do Positive Podcast",
+  "SpaceX Daily",
+  "The Age of AI",
+  "Offshore North",
+  "Nerra Daily",
+]);
+
+/** Resolve the client's `list` + `source` (+ optional show newsletter
+ * `tags`) into the tags we will send. */
 export function resolveSubscribeTags(
   list: unknown,
   source: unknown,
+  showTags?: unknown,
 ): { tags: string[]; list: string } {
   const listKey =
     typeof list === "string" && Object.prototype.hasOwnProperty.call(
@@ -122,6 +155,14 @@ export function resolveSubscribeTags(
   const src = typeof source === "string" ? source.trim().toLowerCase() : "";
   if (SOURCE_TAGS.has(src) && !tags.includes(src)) {
     tags.push(src);
+  }
+  if (Array.isArray(showTags)) {
+    for (const raw of showTags.slice(0, 20)) {
+      const tag = typeof raw === "string" ? raw.trim() : "";
+      if (SHOW_NEWSLETTER_TAGS.has(tag) && !tags.includes(tag)) {
+        tags.push(tag);
+      }
+    }
   }
   return { tags, list: listKey };
 }
@@ -228,7 +269,8 @@ export async function handleSubscribe(
     return jsonResponse(request, 400, { ok: false, error: "invalid email" });
   }
 
-  const { tags, list } = resolveSubscribeTags(body?.list, body?.source);
+  const { tags, list } = resolveSubscribeTags(
+    body?.list, body?.source, body?.tags);
   const result = await deps.buttondown.subscribe(
     env.BUTTONDOWN_API_KEY,
     email,

--- a/workers/gallery/src/index.ts
+++ b/workers/gallery/src/index.ts
@@ -20,10 +20,20 @@ import {
   handleMagic,
   handleSubscribe,
 } from "./handlers";
+import {
+  handleAccount,
+  handleAdminSpecs,
+  handlePersonalFeed,
+  handlePreferences,
+  handleStripeWebhook,
+} from "./personal";
 import * as resend from "./resend";
 import type { Env, HandlerDeps } from "./types";
 
 const DEPS: HandlerDeps = { buttondown, resend };
+
+// /api/feed/<token>/<file> — the one wildcard route (private feeds).
+const FEED_PATH_RE = /^\/api\/feed\/([a-f0-9]{16,64})\/([A-Za-z0-9_.-]+)$/;
 
 
 export default {
@@ -34,6 +44,13 @@ export default {
     const url = new URL(request.url);
     const route = `${request.method} ${url.pathname}`;
     try {
+      const feedMatch = request.method === "GET"
+        ? url.pathname.match(FEED_PATH_RE)
+        : null;
+      if (feedMatch) {
+        return await handlePersonalFeed(
+          request, env, feedMatch[1], feedMatch[2]);
+      }
       switch (route) {
         case "POST /api/subscribe":
           return await handleSubscribe(request, env, DEPS);
@@ -43,6 +60,14 @@ export default {
           return await handleMagic(request, env, DEPS);
         case "GET /api/download":
           return await handleDownload(request, env, DEPS);
+        case "GET /api/account":
+          return await handleAccount(request, env);
+        case "POST /api/account/preferences":
+          return await handlePreferences(request, env);
+        case "POST /api/stripe/webhook":
+          return await handleStripeWebhook(request, env);
+        case "GET /api/admin/personal-specs":
+          return await handleAdminSpecs(request, env);
         case "GET /api/health":
           return jsonResponse(request, 200, { ok: true });
         default:

--- a/workers/gallery/src/personal.ts
+++ b/workers/gallery/src/personal.ts
@@ -1,0 +1,411 @@
+/**
+ * Nerra Personal — member accounts + personalized-feed endpoints.
+ *
+ * Extends the gallery Worker (same host, same JWT cookie: a "Nerra
+ * account" IS the existing gallery-subscriber identity, which is what
+ * unifies gallery downloads + newsletter + member perks + the paid
+ * personal feed under one sign-in). Everything here degrades to 503
+ * "not configured" until the operator provisions the KV namespace,
+ * the personal R2 bucket, and the Stripe secrets — the pre-existing
+ * gallery routes are untouched either way.
+ *
+ * Storage (all in the one KV namespace, prefix-separated like rl:/revoke:):
+ *   member:<email>   {shows, first_name, city, tier, status,
+ *                     feed_token, sub_id, updated_at}
+ *   feedtok:<token>  <email>        (deleted on cancel = instant revoke)
+ *   sub:<subId>      <email>        (Stripe subscription -> member)
+ *
+ * Endpoints:
+ *   GET  /api/account                    - member record for the cookie's email
+ *   POST /api/account/preferences        - save shows/order/name/city
+ *   POST /api/stripe/webhook             - checkout + cancel lifecycle
+ *   GET  /api/feed/<token>/<file>        - token-gated private feed/audio
+ *   GET  /api/admin/personal-specs       - batch-builder input (bearer auth;
+ *                                          tokens + prefs, NEVER emails)
+ */
+
+import { corsHeaders, jsonResponse } from "./cors";
+import { verifyJwt } from "./jwt";
+import type { Env } from "./types";
+
+// Closed show vocabulary — mirrors engine.personal_edition.PERSONAL_SHOW_SLUGS
+// (the EN edition lineup). Keep the two in sync; an unknown slug is dropped
+// server-side, never stored.
+export const PERSONAL_SHOWS = [
+  "spacex",
+  "tesla",
+  "fascinating_frontiers",
+  "models_agents",
+  "planetterrian",
+  "omni_view",
+  "modern_investing",
+  "unintended_consequences",
+  "first_principles",
+  "models_agents_beginners",
+  "env_intel",
+  "offshore_north",
+  "dp_pod",
+] as const;
+
+const COOKIE_NAME = "nn_gallery";
+const FEED_FILE_RE = /^[A-Za-z0-9_.-]+$/;
+const TOKEN_RE = /^[a-f0-9]{16,64}$/;
+const NAME_MAX = 40;
+const CITY_MAX = 80;
+
+interface MemberRecord {
+  shows: string[];
+  first_name: string;
+  city: string;
+  tier: string;          // "personal" | "personal_local"
+  status: string;        // "none" | "active" | "cancelled"
+  feed_token?: string;
+  sub_id?: string;
+  updated_at: string;
+}
+
+function notConfigured(request: Request): Response {
+  return jsonResponse(request, 503, {
+    ok: false,
+    error: "personal tier not configured",
+  });
+}
+
+async function emailFromCookie(
+  request: Request,
+  env: Env,
+): Promise<string | null> {
+  const header = request.headers.get("Cookie");
+  if (!header) return null;
+  let token: string | null = null;
+  for (const part of header.split(/;\s*/)) {
+    const eq = part.indexOf("=");
+    if (eq !== -1 && part.slice(0, eq) === COOKIE_NAME) {
+      token = decodeURIComponent(part.slice(eq + 1));
+    }
+  }
+  if (!token) return null;
+  const verify = await verifyJwt(token, env.JWT_SECRET, {
+    expectedScope: "gallery-subscriber",
+  });
+  if (!verify.ok || !verify.claims?.sub) return null;
+  return (verify.claims.sub as string).toLowerCase();
+}
+
+async function loadMember(env: Env, email: string): Promise<MemberRecord | null> {
+  if (!env.RATE_LIMIT_KV) return null;
+  const raw = await env.RATE_LIMIT_KV.get(`member:${email}`);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as MemberRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function saveMember(env: Env, email: string, rec: MemberRecord) {
+  await env.RATE_LIMIT_KV!.put(`member:${email}`, JSON.stringify(rec));
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/account
+// ---------------------------------------------------------------------------
+
+export async function handleAccount(request: Request, env: Env): Promise<Response> {
+  const email = await emailFromCookie(request, env);
+  if (!email) {
+    return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+  const member = env.RATE_LIMIT_KV ? await loadMember(env, email) : null;
+  const active = member?.status === "active" && member.feed_token;
+  return jsonResponse(request, 200, {
+    ok: true,
+    shows: PERSONAL_SHOWS,
+    member: {
+      preferences: member
+        ? {
+            shows: member.shows || [],
+            first_name: member.first_name || "",
+            city: member.city || "",
+          }
+        : null,
+      tier: member?.tier || "none",
+      status: member?.status || "none",
+      feed_url: active
+        ? `https://api.nerranetwork.com/api/feed/${member!.feed_token}/feed.rss`
+        : null,
+    },
+    perks: {
+      // Set via `wrangler secret put MEMBER_BOOK_CODE` (or a plain var) —
+      // the store-side discount code members redeem on /books.html titles.
+      book_discount_code: env.MEMBER_BOOK_CODE || null,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/account/preferences
+// ---------------------------------------------------------------------------
+
+export async function handlePreferences(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (!env.RATE_LIMIT_KV) return notConfigured(request);
+  const email = await emailFromCookie(request, env);
+  if (!email) {
+    return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse(request, 400, { ok: false, error: "invalid json" });
+  }
+  const shows: string[] = [];
+  if (Array.isArray(body?.shows)) {
+    for (const s of body.shows) {
+      const slug = String(s);
+      if ((PERSONAL_SHOWS as readonly string[]).includes(slug) &&
+          !shows.includes(slug)) {
+        shows.push(slug);
+      }
+    }
+  }
+  const firstName = String(body?.first_name ?? "").trim().slice(0, NAME_MAX);
+  const city = String(body?.city ?? "").trim().slice(0, CITY_MAX);
+
+  const existing = (await loadMember(env, email)) || {
+    shows: [], first_name: "", city: "", tier: "none", status: "none",
+    updated_at: "",
+  };
+  const rec: MemberRecord = {
+    ...existing,
+    shows,
+    first_name: firstName,
+    city,
+    updated_at: new Date().toISOString(),
+  };
+  await saveMember(env, email, rec);
+  return jsonResponse(request, 200, { ok: true, saved: {
+    shows, first_name: firstName, city,
+  } });
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/stripe/webhook
+// ---------------------------------------------------------------------------
+
+/** Verify Stripe's `t=...,v1=...` signature header (HMAC-SHA256 of
+ * `${t}.${payload}`, 5-minute tolerance). */
+export async function verifyStripeSignature(
+  payload: string,
+  header: string | null,
+  secret: string,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): Promise<boolean> {
+  if (!header) return false;
+  let t = "";
+  const v1s: string[] = [];
+  for (const part of header.split(",")) {
+    const [k, v] = part.split("=", 2);
+    if (k === "t") t = v;
+    if (k === "v1") v1s.push(v);
+  }
+  if (!t || v1s.length === 0) return false;
+  if (Math.abs(nowSeconds - parseInt(t, 10)) > 300) return false;
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC", key, new TextEncoder().encode(`${t}.${payload}`),
+  );
+  const expected = [...new Uint8Array(mac)]
+    .map((b) => b.toString(16).padStart(2, "0")).join("");
+  // Constant-time-ish compare (lengths are fixed for SHA-256 hex).
+  return v1s.some((sig) => {
+    if (sig.length !== expected.length) return false;
+    let diff = 0;
+    for (let i = 0; i < sig.length; i++) {
+      diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i);
+    }
+    return diff === 0;
+  });
+}
+
+function randomToken(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function handleStripeWebhook(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (!env.RATE_LIMIT_KV || !env.STRIPE_WEBHOOK_SECRET) {
+    return notConfigured(request);
+  }
+  const payload = await request.text();
+  const ok = await verifyStripeSignature(
+    payload, request.headers.get("Stripe-Signature"),
+    env.STRIPE_WEBHOOK_SECRET,
+  );
+  if (!ok) {
+    return jsonResponse(request, 400, { ok: false, error: "bad signature" });
+  }
+  let event: any;
+  try {
+    event = JSON.parse(payload);
+  } catch {
+    return jsonResponse(request, 400, { ok: false, error: "invalid json" });
+  }
+
+  if (event.type === "checkout.session.completed") {
+    const session = event.data?.object ?? {};
+    const email = String(
+      session.customer_details?.email || session.customer_email || "",
+    ).toLowerCase();
+    if (!email) {
+      console.warn("stripe: completed session with no email");
+      return jsonResponse(request, 200, { ok: true });
+    }
+    // Tier comes from the Payment Link's metadata (operator sets
+    // {"tier": "personal"|"personal_local"} on each link); amount is the
+    // fallback so an unmetadata'd link still activates the right tier.
+    const tier =
+      session.metadata?.tier === "personal_local" ||
+      (session.amount_total ?? 0) >= 799
+        ? "personal_local"
+        : "personal";
+    const existing = (await loadMember(env, email)) || {
+      shows: [], first_name: "", city: "", tier: "none", status: "none",
+      updated_at: "",
+    };
+    const token = existing.feed_token || randomToken();
+    const rec: MemberRecord = {
+      ...existing,
+      tier,
+      status: "active",
+      feed_token: token,
+      sub_id: String(session.subscription || existing.sub_id || ""),
+      updated_at: new Date().toISOString(),
+    };
+    await saveMember(env, email, rec);
+    await env.RATE_LIMIT_KV.put(`feedtok:${token}`, email);
+    if (rec.sub_id) {
+      await env.RATE_LIMIT_KV.put(`sub:${rec.sub_id}`, email);
+    }
+    console.log("stripe: activated", tier, "token", token.slice(0, 8));
+  } else if (event.type === "customer.subscription.deleted") {
+    const subId = String(event.data?.object?.id || "");
+    const email = subId
+      ? await env.RATE_LIMIT_KV.get(`sub:${subId}`)
+      : null;
+    if (email) {
+      const member = await loadMember(env, email);
+      if (member) {
+        if (member.feed_token) {
+          // Deleting the token mapping revokes the feed IMMEDIATELY —
+          // the R2 objects can linger for the lifecycle rule to clean.
+          await env.RATE_LIMIT_KV.delete(`feedtok:${member.feed_token}`);
+        }
+        await saveMember(env, email, {
+          ...member,
+          status: "cancelled",
+          updated_at: new Date().toISOString(),
+        });
+        console.log("stripe: cancelled sub", subId.slice(0, 12));
+      }
+    }
+  }
+  return jsonResponse(request, 200, { ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/feed/<token>/<file>
+// ---------------------------------------------------------------------------
+
+export async function handlePersonalFeed(
+  request: Request,
+  env: Env,
+  token: string,
+  file: string,
+): Promise<Response> {
+  if (!env.RATE_LIMIT_KV || !env.PERSONAL_BUCKET) return notConfigured(request);
+  if (!TOKEN_RE.test(token) || !FEED_FILE_RE.test(file) ||
+      file.includes("..")) {
+    return jsonResponse(request, 400, { ok: false, error: "bad request" });
+  }
+  const email = await env.RATE_LIMIT_KV.get(`feedtok:${token}`);
+  if (!email) {
+    return jsonResponse(request, 404, { ok: false, error: "not found" });
+  }
+  const member = await loadMember(env, email);
+  if (!member || member.status !== "active") {
+    return jsonResponse(request, 404, { ok: false, error: "not found" });
+  }
+  const object = await env.PERSONAL_BUCKET.get(`personal/${token}/${file}`);
+  if (!object) {
+    return jsonResponse(request, 404, { ok: false, error: "not found" });
+  }
+  const headers = new Headers(corsHeaders(request));
+  object.writeHttpMetadata(headers);
+  headers.set("etag", object.httpEtag);
+  if (file.endsWith(".rss")) {
+    headers.set("Content-Type", "application/rss+xml; charset=utf-8");
+  } else if (file.endsWith(".mp3")) {
+    headers.set("Content-Type", "audio/mpeg");
+  }
+  headers.set("Cache-Control", "private, max-age=300");
+  return new Response(object.body, { status: 200, headers });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/personal-specs
+// ---------------------------------------------------------------------------
+
+export async function handleAdminSpecs(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  if (!env.RATE_LIMIT_KV || !env.PERSONAL_ADMIN_TOKEN) {
+    return notConfigured(request);
+  }
+  const auth = request.headers.get("Authorization") || "";
+  if (auth !== `Bearer ${env.PERSONAL_ADMIN_TOKEN}`) {
+    return jsonResponse(request, 401, { ok: false, error: "auth required" });
+  }
+  const specs: object[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await env.RATE_LIMIT_KV.list({
+      prefix: "member:",
+      cursor,
+    });
+    for (const key of page.keys) {
+      const raw = await env.RATE_LIMIT_KV.get(key.name);
+      if (!raw) continue;
+      let rec: MemberRecord;
+      try {
+        rec = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      if (rec.status === "active" && rec.feed_token &&
+          (rec.shows?.length ?? 0) >= 2) {
+        // Deliberately NO email: the batch builder is PII-light.
+        specs.push({
+          token: rec.feed_token,
+          shows: rec.shows,
+          tier: rec.tier,
+          first_name: rec.first_name || "",
+          city: rec.city || "",
+        });
+      }
+    }
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor);
+  return jsonResponse(request, 200, { ok: true, specs });
+}

--- a/workers/gallery/src/types.ts
+++ b/workers/gallery/src/types.ts
@@ -16,8 +16,17 @@ export interface Env {
   RESEND_API_KEY: string;
   RESEND_FROM_EMAIL: string;
 
-  // KV binding for rate limiting (medium item)
+  // KV binding for rate limiting, revocation, AND (Aug 2026) member
+  // accounts — one namespace, prefix-separated (rl:/revoke:/member:/
+  // feedtok:/sub:). Every consumer degrades gracefully when absent.
   RATE_LIMIT_KV?: KVNamespace;
+
+  // --- Nerra Personal (Aug 2026) — all optional until provisioned; the
+  // personal endpoints answer 503 "not configured" without them.
+  PERSONAL_BUCKET?: R2Bucket;          // bucket: nerra-personal
+  STRIPE_WEBHOOK_SECRET?: string;      // wrangler secret put
+  PERSONAL_ADMIN_TOKEN?: string;       // wrangler secret put (batch builder)
+  MEMBER_BOOK_CODE?: string;           // member perks: book discount code
 }
 
 export interface ButtondownClient {

--- a/workers/gallery/test/personal.test.ts
+++ b/workers/gallery/test/personal.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Nerra Personal endpoint tests — Stripe signature verification, the
+ * closed show vocabulary, feed-token gating, and the PII-light admin
+ * spec export.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  PERSONAL_SHOWS,
+  handleAdminSpecs,
+  handlePersonalFeed,
+  handleStripeWebhook,
+  verifyStripeSignature,
+} from "../src/personal";
+import { resolveSubscribeTags } from "../src/handlers";
+import type { Env } from "../src/types";
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class FakeKV {
+  store = new Map<string, string>();
+  async get(key: string) { return this.store.get(key) ?? null; }
+  async put(key: string, value: string) { this.store.set(key, value); }
+  async delete(key: string) { this.store.delete(key); }
+  async list(opts: { prefix: string; cursor?: string }) {
+    const keys = [...this.store.keys()]
+      .filter((k) => k.startsWith(opts.prefix))
+      .map((name) => ({ name }));
+    return { keys, list_complete: true, cursor: undefined };
+  }
+}
+
+class FakeBucket {
+  objects = new Map<string, string>();
+  async get(key: string) {
+    const body = this.objects.get(key);
+    if (body === undefined) return null;
+    return {
+      body,
+      httpEtag: "etag",
+      writeHttpMetadata: (_h: Headers) => {},
+    };
+  }
+}
+
+function envWith(overrides: Partial<Record<string, unknown>> = {}): Env {
+  return {
+    GALLERY_BUCKET: new FakeBucket() as unknown as R2Bucket,
+    JWT_SECRET: "test-secret-test-secret-test-secret!",
+    BUTTONDOWN_API_KEY: "x",
+    RESEND_API_KEY: "x",
+    RESEND_FROM_EMAIL: "x@example.com",
+    RATE_LIMIT_KV: new FakeKV() as unknown as KVNamespace,
+    PERSONAL_BUCKET: new FakeBucket() as unknown as R2Bucket,
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    PERSONAL_ADMIN_TOKEN: "admin-token",
+    ...overrides,
+  } as unknown as Env;
+}
+
+async function stripeSig(payload: string, secret: string, t: number) {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC", key, new TextEncoder().encode(`${t}.${payload}`),
+  );
+  const hex = [...new Uint8Array(mac)]
+    .map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `t=${t},v1=${hex}`;
+}
+
+// ---------------------------------------------------------------------------
+
+describe("verifyStripeSignature", () => {
+  it("accepts a valid signature inside tolerance", async () => {
+    const now = 1_700_000_000;
+    const sig = await stripeSig("payload", "whsec_test", now);
+    expect(await verifyStripeSignature("payload", sig, "whsec_test", now))
+      .toBe(true);
+  });
+
+  it("rejects a stale timestamp", async () => {
+    const now = 1_700_000_000;
+    const sig = await stripeSig("payload", "whsec_test", now - 3600);
+    expect(await verifyStripeSignature("payload", sig, "whsec_test", now))
+      .toBe(false);
+  });
+
+  it("rejects a wrong secret", async () => {
+    const now = 1_700_000_000;
+    const sig = await stripeSig("payload", "other", now);
+    expect(await verifyStripeSignature("payload", sig, "whsec_test", now))
+      .toBe(false);
+  });
+});
+
+describe("stripe webhook lifecycle", () => {
+  async function post(env: Env, event: object) {
+    const payload = JSON.stringify(event);
+    const sig = await stripeSig(
+      payload, "whsec_test", Math.floor(Date.now() / 1000));
+    return handleStripeWebhook(
+      new Request("https://api.example.com/api/stripe/webhook", {
+        method: "POST",
+        body: payload,
+        headers: { "Stripe-Signature": sig },
+      }),
+      env,
+    );
+  }
+
+  it("activates a member and mints a feed token on checkout", async () => {
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    const res = await post(env, {
+      type: "checkout.session.completed",
+      data: { object: {
+        customer_details: { email: "Fan@Example.com" },
+        metadata: { tier: "personal_local" },
+        subscription: "sub_123",
+        amount_total: 899,
+      } },
+    });
+    expect(res.status).toBe(200);
+    const rec = JSON.parse(kv.store.get("member:fan@example.com")!);
+    expect(rec.status).toBe("active");
+    expect(rec.tier).toBe("personal_local");
+    expect(rec.feed_token).toMatch(/^[a-f0-9]{32}$/);
+    expect(kv.store.get(`feedtok:${rec.feed_token}`)).toBe("fan@example.com");
+    expect(kv.store.get("sub:sub_123")).toBe("fan@example.com");
+  });
+
+  it("cancellation revokes the feed token immediately", async () => {
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    await post(env, {
+      type: "checkout.session.completed",
+      data: { object: {
+        customer_email: "fan@example.com",
+        subscription: "sub_9",
+        amount_total: 499,
+      } },
+    });
+    const rec = JSON.parse(kv.store.get("member:fan@example.com")!);
+    await post(env, {
+      type: "customer.subscription.deleted",
+      data: { object: { id: "sub_9" } },
+    });
+    expect(kv.store.has(`feedtok:${rec.feed_token}`)).toBe(false);
+    const after = JSON.parse(kv.store.get("member:fan@example.com")!);
+    expect(after.status).toBe("cancelled");
+  });
+
+  it("rejects a bad signature outright", async () => {
+    const env = envWith();
+    const res = await handleStripeWebhook(
+      new Request("https://api.example.com/api/stripe/webhook", {
+        method: "POST", body: "{}",
+        headers: { "Stripe-Signature": "t=1,v1=deadbeef" },
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("personal feed gating", () => {
+  const token = "a".repeat(32);
+
+  function activeEnv(status = "active") {
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    kv.store.set(`feedtok:${token}`, "fan@example.com");
+    kv.store.set("member:fan@example.com", JSON.stringify({
+      shows: ["tesla", "spacex"], first_name: "", city: "",
+      tier: "personal", status, feed_token: token, updated_at: "",
+    }));
+    const bucket = env.PERSONAL_BUCKET as unknown as FakeBucket;
+    bucket.objects.set(`personal/${token}/feed.rss`, "<rss/>");
+    return env;
+  }
+
+  async function get(env: Env, tok: string, file: string) {
+    return handlePersonalFeed(
+      new Request(`https://api.example.com/api/feed/${tok}/${file}`),
+      env, tok, file,
+    );
+  }
+
+  it("serves an active member's feed", async () => {
+    const res = await get(activeEnv(), token, "feed.rss");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("rss");
+  });
+
+  it("404s an unknown token (no enumeration signal)", async () => {
+    const res = await get(activeEnv(), "b".repeat(32), "feed.rss");
+    expect(res.status).toBe(404);
+  });
+
+  it("404s a cancelled member even with a lingering mapping", async () => {
+    const res = await get(activeEnv("cancelled"), token, "feed.rss");
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects traversal-shaped file names", async () => {
+    const res = await get(activeEnv(), token, "..secrets");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("admin specs export", () => {
+  it("is bearer-gated and never includes emails", async () => {
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    kv.store.set("member:fan@example.com", JSON.stringify({
+      shows: ["tesla", "spacex"], first_name: "Sam", city: "Vancouver",
+      tier: "personal_local", status: "active",
+      feed_token: "c".repeat(32), updated_at: "",
+    }));
+    const denied = await handleAdminSpecs(
+      new Request("https://api.example.com/api/admin/personal-specs"), env);
+    expect(denied.status).toBe(401);
+
+    const res = await handleAdminSpecs(
+      new Request("https://api.example.com/api/admin/personal-specs", {
+        headers: { Authorization: "Bearer admin-token" },
+      }), env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { specs: Record<string, unknown>[] };
+    expect(body.specs).toHaveLength(1);
+    expect(body.specs[0].token).toBe("c".repeat(32));
+    expect(JSON.stringify(body)).not.toContain("fan@example.com");
+  });
+});
+
+describe("membership plumbing", () => {
+  it("member list carries the gallery tag (one identity)", () => {
+    const { tags } = resolveSubscribeTags("member", undefined);
+    expect(tags).toContain("nerra-member");
+    expect(tags).toContain("gallery-subscriber");
+  });
+
+  it("show newsletter tags pass only from the closed set", () => {
+    const { tags } = resolveSubscribeTags("member", undefined, [
+      "Tesla Shorts Time", "Not A Real Tag", "SpaceX Daily",
+    ]);
+    expect(tags).toContain("Tesla Shorts Time");
+    expect(tags).toContain("SpaceX Daily");
+    expect(tags).not.toContain("Not A Real Tag");
+  });
+
+  it("show vocabulary matches the EN edition lineup size", () => {
+    expect(PERSONAL_SHOWS).toHaveLength(13);
+  });
+});

--- a/workers/gallery/wrangler.toml
+++ b/workers/gallery/wrangler.toml
@@ -49,11 +49,27 @@ bucket_name = "nerra-gallery"
 # id = ""
 # preview_id = ""  # Optional preview namespace
 
+# Nerra Personal (Aug 2026): the private personalized-feed audio bucket.
+# COMMENTED OUT for the same reason as the KV block above — uncommenting
+# before the bucket exists blocks every wrangler command. To enable:
+#     wrangler r2 bucket create nerra-personal
+# then uncomment. The /api/feed, /api/account and Stripe endpoints answer
+# 503 "not configured" until this + the KV namespace + the secrets exist;
+# nothing else in the Worker changes behaviour.
+# [[r2_buckets]]
+# binding = "PERSONAL_BUCKET"
+# bucket_name = "nerra-personal"
+
 # Secrets are set out-of-band via:
 #   wrangler secret put JWT_SECRET
 #   wrangler secret put BUTTONDOWN_API_KEY
 #   wrangler secret put RESEND_API_KEY
 #   wrangler secret put RESEND_FROM_EMAIL
+# Nerra Personal additionally needs:
+#   wrangler secret put STRIPE_WEBHOOK_SECRET   # from the Stripe webhook endpoint
+#   wrangler secret put PERSONAL_ADMIN_TOKEN    # any long random string; the
+#                                               # batch builder presents it
+#   wrangler secret put MEMBER_BOOK_CODE        # store discount code members see
 # Do NOT commit them here.
 
 [observability]


### PR DESCRIPTION
# Nerra Personal — the unified member surface

Everything you asked for, built as **one identity** on infrastructure that already existed: the gallery Worker's magic-link login becomes *the* Nerra account, and Nerra Daily's edition engine becomes the per-subscriber builder.

## The free account (newsletter + gallery + perks, one signup)
- The footer newsletter form and the new **`/join.html`** both create an account via the Worker (`/api/subscribe`, list `member`) — **the Buttondown-direct embed form is gone**, so every newsletter signup now yields an account that also unlocks gallery downloads (same cookie, by construction), per-show newsletter picks (closed tag set, server-enforced), and member perks.
- **`/account.html`** is the member console: magic-link sign-in, lineup configuration (show picker with ordering, first name, city), private feed URL when active, and perks — including the **book discount code** (`MEMBER_BOOK_CODE`) linking to `/books.html`.

## The paid tier — your own daily show with Mira
- **Personal $4.99/mo · Personal + Local $8.99/mo** (Stripe Payment Links; tier via link metadata).
- `engine/personal_edition.py` + `scripts/build_personal_feeds.py`: per-day **shared segment cache** (each show trimmed once — marginal cost ~$0.05–0.07/subscriber/day), Mira greeting by name in the user's chosen order, deterministic fallback links, private RSS with deterministic GUIDs + `itunes:block`, 7-episode depth with pruning.
- **Local tier**: Open-Meteo weather (measured data only, keyless) + one web-search-grounded local story/event under the field-note honesty rules — source named aloud, honest SKIP over filler.
- `workers/gallery/src/personal.ts`: preferences + account endpoints, **signature-verified Stripe webhook** (checkout mints the feed token; cancellation deletes it → the feed 404s immediately), token-gated feed serving from a new `nerra-personal` R2 bucket, and a bearer-gated, **email-free** spec export for the batch builder.
- **PII discipline**: the builder sees token/name/city, never emails; logs truncate tokens; docs mandate a private host (VPS cron or private-repo Actions) — never this public repo's workflows.

## Donations
- **`/support.html`**: the honest-ledger pitch (~$120/month runs the whole network, with the breakdown) + monthly/one-time Stripe links, cross-selling membership.
- Every feed's **`podcast:funding` tag now points at it** (was `/#newsletter`) — Apple and every 2.0 app render it as the show's Support button.

## Safe-by-default rollout
Every Worker addition answers **503 "not configured"** until you provision KV, the bucket, and the secrets — the deployed gallery routes are untouched. Pages render honest "launching soon" states until the `STRIPE_LINK_*` env vars exist. Nothing per-user is ever committed to this repo.

## Your setup checklist (~30 min, in `docs/nerra_personal.md`)
1. Cloudflare: KV namespace + `nerra-personal` bucket + 3 secrets + deploy.
2. Stripe: 4 Payment Links (2 tiers, 2 donate) + the webhook endpoint.
3. The 4 `STRIPE_LINK_*` Actions vars (pages pick them up next regen).
4. A small private host cron for `build_personal_feeds.py --fetch`.
5. The book-store discount code matching `MEMBER_BOOK_CODE`.

## Tests
- Python: `tests/test_nerra_personal.py` — 21/21 (spec trust boundary, feed contract, prune, honesty gates, Worker/engine vocabulary sync, funding repoint, footer wiring, PII-less logging).
- Worker: vitest **66/66** including 14 new (Stripe signature + lifecycle, feed gating incl. cancelled-member 404 and traversal rejection, email-free admin export).
- Full python suite: 7,131 passed (the 8 local failures are the same pre-existing missing-container-deps set, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2dhTSZ3dzkxGQi7PPn8JV)_