### PR TITLE
MIT: count methodology airings that actually reached air

### DIFF
--- a/shows/hooks/modern_investing.py
+++ b/shows/hooks/modern_investing.py
@@ -277,7 +277,7 @@ def pre_fetch(config, *, episode_num: int | None = None, today_str: str | None =
     # same way the trade review does, so it rides the save below rather
     # than risking a re-air if a later step raises.
     context["methodology_disclosure"] = _build_methodology_disclosure(
-        tracker, episode_num)
+        tracker, episode_num, output_dir=output_dir)
 
     if not readonly:
         _save_tracker(tracker, tracker_path)
@@ -2689,9 +2689,80 @@ def _weekly_hold_update(open_trades: list) -> str:
 # what the numbers mean, not how the repo is wired.
 METHODOLOGY_DISCLOSURE_EPISODES = 3
 
+# Phrases that only the methodology correction produces, used to confirm
+# it actually reached the SPOKEN script. Validated against all 147
+# committed MIT scripts: exactly one match (Ep145, the one airing that
+# genuinely happened). "Monday pick" was in an earlier draft of this set
+# and had to go — Ep100 says "The next Monday pick will target the
+# energy sector", which is ordinary show language, not the correction.
+_DISCLOSURE_MARKERS = (
+    "used to quote",
+    "could not be reproduced",
+    "cannot be reproduced",
+    "not ours to claim",
+    "restarted its track record",
+    "restarted its simulated track record",
+    "chosen after the fact",
+    "whichever session the",
+)
+
+
+def _disclosure_reached_air(output_dir: Path, episode_num: int) -> bool | None:
+    """Did the correction survive into the episode's spoken script?
+
+    Returns True/False, or None when the script cannot be read — a
+    missing file is absence of evidence, never evidence of absence, and
+    must never cost an airing.
+    """
+    try:
+        matches = sorted(output_dir.glob(f"*Ep{episode_num:03d}_*_tts.txt"))
+    except OSError:
+        return None
+    if not matches:
+        return None
+    try:
+        spoken = matches[-1].read_text(encoding="utf-8", errors="ignore").lower()
+    except OSError:
+        return None
+    return any(marker in spoken for marker in _DISCLOSURE_MARKERS)
+
+
+def _reconcile_disclosure_airings(tracker: dict, output_dir: Path) -> None:
+    """Drop stamped episodes whose script never carried the correction.
+
+    The stamp is applied at the DIGEST stage, but the podcast script is a
+    separate LLM call made much later, and it does not always carry the
+    segment through. Ep144/145/146 were all stamped; only Ep145 actually
+    said it on air. So the counter was measuring prompt injections and
+    reporting them as airings — it retired a correction that had reached
+    listeners once out of three times.
+
+    Reconciling here makes the count mean what it claims. It runs at the
+    next episode's digest stage, by which point the previous episode's
+    script is on disk, so no new hook contract is needed.
+    """
+    meta = tracker.setdefault("metadata", {})
+    aired = list(meta.get("methodology_disclosure_episodes", []))
+    if not aired:
+        return
+    confirmed = []
+    for ep in aired:
+        reached = _disclosure_reached_air(output_dir, ep)
+        if reached is False:
+            logger.warning(
+                "Methodology correction was stamped for Ep%s but never "
+                "reached the spoken script — releasing that airing so the "
+                "count reflects what listeners actually heard.", ep,
+            )
+            continue
+        confirmed.append(ep)
+    if confirmed != aired:
+        meta["methodology_disclosure_episodes"] = confirmed
+
 
 def _build_methodology_disclosure(
-    tracker: dict, episode_num: int | None = None
+    tracker: dict, episode_num: int | None = None,
+    output_dir: Path | None = None,
 ) -> str:
     """One-off on-air correction explaining why the record restarted.
 
@@ -2702,6 +2773,8 @@ def _build_methodology_disclosure(
     it) and, like every other stamp in this module, is skipped on
     read-only (test/rehearse) runs.
     """
+    if output_dir is not None and not _hooks_readonly():
+        _reconcile_disclosure_airings(tracker, output_dir)
     aired = list(
         (tracker.get("metadata") or {}).get(
             "methodology_disclosure_episodes", []

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2774,3 +2774,79 @@ class TestAuditRegistryCoversEveryShow:
             f"only cross-checked {checked} shows — the CRON_MAP parse "
             "probably drifted"
         )
+
+
+class TestDisclosureCountsAirings(TestMethodologyDisclosure):
+    """The stamp has to mean "listeners heard it", not "we asked for it".
+
+    Ep144, Ep145 and Ep146 were all stamped and the correction retired
+    itself as complete. Only **Ep145** actually said it: the stamp is
+    applied at the digest stage, but the podcast script is a separate
+    LLM call made much later, and it dropped the segment two times in
+    three. So a correction meant to run three times reached listeners
+    once, and the counter reported success either way.
+
+    That is the same failure shape as the record it was correcting — a
+    number that measures the wrong event, reported as if it measured
+    the right one.
+    """
+
+    _AIRED = "The show used to quote a cumulative alpha figure."
+    _NOT_AIRED = "The portfolio sits at two hundred dollars across fifty trades."
+
+    def _script(self, tmp_path, episode_num, text):
+        (tmp_path / f"Modern_Investing_Ep{episode_num:03d}_20260101_tts.txt"
+         ).write_text(text, encoding="utf-8")
+
+    def test_stamp_survives_when_the_script_carried_it(self, tmp_path):
+        self._script(tmp_path, 145, self._AIRED)
+        tracker = {"metadata": {"methodology_disclosure_episodes": [145]}}
+        mi._reconcile_disclosure_airings(tracker, tmp_path)
+        assert tracker["metadata"]["methodology_disclosure_episodes"] == [145]
+
+    def test_stamp_is_released_when_the_script_dropped_it(self, tmp_path):
+        self._script(tmp_path, 144, self._NOT_AIRED)
+        self._script(tmp_path, 145, self._AIRED)
+        tracker = {"metadata": {"methodology_disclosure_episodes": [144, 145]}}
+        mi._reconcile_disclosure_airings(tracker, tmp_path)
+        assert tracker["metadata"]["methodology_disclosure_episodes"] == [145]
+
+    def test_missing_script_never_costs_an_airing(self, tmp_path):
+        # Absence of evidence is not evidence of absence. A script that
+        # cannot be read (not yet written, unreadable, pruned) must leave
+        # the stamp alone rather than silently re-arming the segment.
+        tracker = {"metadata": {"methodology_disclosure_episodes": [145]}}
+        mi._reconcile_disclosure_airings(tracker, tmp_path)
+        assert tracker["metadata"]["methodology_disclosure_episodes"] == [145]
+        assert mi._disclosure_reached_air(tmp_path, 145) is None
+
+    def test_released_airing_is_offered_again(self, tmp_path, monkeypatch):
+        # The point of reconciling: an airing that never happened comes
+        # back, instead of the segment retiring on a miscount.
+        monkeypatch.setattr(mi, "_hooks_readonly", lambda: False)
+        self._script(tmp_path, 144, self._NOT_AIRED)
+        self._script(tmp_path, 145, self._AIRED)
+        self._script(tmp_path, 146, self._NOT_AIRED)
+        tracker = {"metadata": {
+            "methodology_disclosure_episodes": [144, 145, 146]}}
+        text = mi._build_methodology_disclosure(
+            tracker, episode_num=148, output_dir=tmp_path)
+        assert text, "a correction that aired once must not be retired"
+        assert tracker["metadata"]["methodology_disclosure_episodes"] == [
+            145, 148]
+
+    def test_markers_do_not_fire_on_ordinary_show_language(self):
+        # Ep100 says "The next Monday pick will target the energy
+        # sector" — an earlier marker set matched that and would have
+        # confirmed an airing that never happened. Every marker must be
+        # language only the correction produces.
+        scripts = sorted(
+            (_ROOT / "digests/modern_investing").glob("*_tts.txt"))
+        assert len(scripts) > 100, "corpus too small to validate markers"
+        hits = [
+            s.name for s in scripts
+            if any(m in s.read_text(encoding="utf-8", errors="ignore").lower()
+                   for m in mi._DISCLOSURE_MARKERS)
+        ]
+        assert hits == ["Modern_Investing_Ep145_20260821_tts.txt"], (
+            f"markers matched unexpected scripts: {hits}")


### PR DESCRIPTION
**I reported this correction as having aired three times. It aired once.** Correcting that here.

## What the scripts say

The segment was stamped for Ep144, Ep145 and Ep146, and retired itself as complete. Checked against the shipped `_tts.txt`:

| Episode | Stamped | In the digest | **Spoken** |
|---|---|---|---|
| Ep144 | ✅ | ✅ | ❌ |
| Ep145 | ✅ | ✅ | ✅ |
| Ep146 | ✅ | ✅ | ❌ |

Ep145 line 117: *"The show used to quote a cumulative alpha figure across roughly forty five trades."* Ep144 and Ep146 contain no correction language at all — a correction-specific phrase probe returns 0 for both.

## Why

The stamp is applied at the **digest** stage. The podcast script is a **separate LLM call** made much later, and it dropped the segment two times in three. So the counter was measuring prompt injections and reporting them as airings.

That's the same shape as the record it was written to correct: **a number measuring the wrong event, reported as if it measured the right one.** I built the thing I was warning about.

## The fix

`_reconcile_disclosure_airings` checks previously-stamped episodes against their shipped script and releases any airing that never happened. It runs at the next episode's digest stage, by which point the previous script is on disk — no new hook contract needed.

On the live tracker it reduces `[144, 145, 146]` → `[145]`. Two genuine airings still owed.

A missing or unreadable script returns `None` and **never costs an airing** — absence of evidence must not silently re-arm a segment on air.

## The marker set nearly repeated the bug

Validated against all **147** committed MIT scripts: exactly one match, Ep145.

An earlier draft included `"Monday pick"`. Ep100 says *"The next Monday pick will target the energy sector"* — ordinary show language. That marker would have **confirmed an airing that never happened**, which is the failure being fixed, not a smaller version of it. `test_markers_do_not_fire_on_ordinary_show_language` pins the whole corpus so a future marker can't reintroduce it.

## ⚠️ A/B-listen (landmine #17)

This changes shipped audio. It restores the three airings **already approved** rather than proposing new ones — but if one airing is judged sufficient, set `METHODOLOGY_DISCLOSURE_EPISODES = 1` and the segment stays retired.

## Testing

- `tests/test_mit_benchmark_integrity.py` — **218 passed** (5 new).
- Live check against real committed episodes: Ep145 `True`, Ep144/146/147 `False`, reconcile yields `[145]`.
- Full suite: 28 failures — 26 baseline plus 2 in `tests/test_nerra_personal.py` that **fail identically on a clean tree** (they arrived with #1061, not this diff).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_