### PR TITLE
Nerra Personal: wire the live bindings, close the donation feed loophole

### DIFF
--- a/docs/nerra_personal.md
+++ b/docs/nerra_personal.md
@@ -43,7 +43,16 @@ Worker's 90-day JWT cookie + Buttondown record). Nothing was forked:
 Pricing (operator sets the amounts in Stripe; the pages read the links
 from env): **Personal $4.99/mo**, **Personal + Local $8.99/mo**. Tier is
 carried on the Payment Link's `metadata.tier`
-(`personal` / `personal_local`); amount ≥ $7.99 is the fallback mapping.
+(`personal` / `personal_local`), which Stripe copies onto every Checkout
+Session the link creates.
+
+That marker is **required**, not a hint. The webhook endpoint receives
+every completed checkout in the Stripe account — including the
+`/support.html` donations, which live in the same account. An earlier
+`amount_total >= $7.99` fallback would have handed a paid feed to anyone
+who donated $10 once, so it was removed on 2026-08-23: a session without
+a known `tier` is ignored and logged, never activated. Donation links
+carry `metadata.kind = "donation"` so the log line says which.
 
 The builder's cost discipline: each show's episode is downloaded and
 promo-trimmed ONCE per day into a shared cache (the same

--- a/workers/gallery/src/personal.ts
+++ b/workers/gallery/src/personal.ts
@@ -264,21 +264,32 @@ export async function handleStripeWebhook(
 
   if (event.type === "checkout.session.completed") {
     const session = event.data?.object ?? {};
+    // Tier comes from the Payment Link's metadata, which Stripe copies
+    // onto every Checkout Session the link creates (operator sets
+    // {"tier": "personal"|"personal_local"} on each membership link).
+    //
+    // The marker is REQUIRED, not a hint. This endpoint receives EVERY
+    // completed checkout in the account, and since 2026-08-23 that
+    // includes the /support.html donation links. The earlier
+    // `amount_total >= 799` fallback was written when memberships were
+    // the only thing that could complete a checkout here; with donations
+    // live it would hand a paid feed to anyone who gave $10 once. An
+    // untagged session is not a membership purchase, so it is ignored.
+    const tier = session.metadata?.tier;
+    if (tier !== "personal" && tier !== "personal_local") {
+      console.log(
+        "stripe: ignoring non-membership checkout",
+        session.metadata?.kind || "untagged",
+      );
+      return jsonResponse(request, 200, { ok: true });
+    }
     const email = String(
       session.customer_details?.email || session.customer_email || "",
     ).toLowerCase();
     if (!email) {
-      console.warn("stripe: completed session with no email");
+      console.warn("stripe: membership checkout with no email");
       return jsonResponse(request, 200, { ok: true });
     }
-    // Tier comes from the Payment Link's metadata (operator sets
-    // {"tier": "personal"|"personal_local"} on each link); amount is the
-    // fallback so an unmetadata'd link still activates the right tier.
-    const tier =
-      session.metadata?.tier === "personal_local" ||
-      (session.amount_total ?? 0) >= 799
-        ? "personal_local"
-        : "personal";
     const existing = (await loadMember(env, email)) || {
       shows: [], first_name: "", city: "", tier: "none", status: "none",
       updated_at: "",

--- a/workers/gallery/test/personal.test.ts
+++ b/workers/gallery/test/personal.test.ts
@@ -141,6 +141,7 @@ describe("stripe webhook lifecycle", () => {
       type: "checkout.session.completed",
       data: { object: {
         customer_email: "fan@example.com",
+        metadata: { tier: "personal" },
         subscription: "sub_9",
         amount_total: 499,
       } },
@@ -153,6 +154,40 @@ describe("stripe webhook lifecycle", () => {
     expect(kv.store.has(`feedtok:${rec.feed_token}`)).toBe(false);
     const after = JSON.parse(kv.store.get("member:fan@example.com")!);
     expect(after.status).toBe("cancelled");
+  });
+
+  it("ignores a donation checkout instead of minting a feed", async () => {
+    // /support.html donations hit the SAME endpoint as memberships. A $10
+    // gift used to clear the old amount>=799 fallback and hand the donor a
+    // paid feed. The tier marker is what separates the two.
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    const res = await post(env, {
+      type: "checkout.session.completed",
+      data: { object: {
+        customer_details: { email: "donor@example.com" },
+        metadata: { kind: "donation", interval: "once" },
+        amount_total: 1000,
+      } },
+    });
+    expect(res.status).toBe(200);
+    expect(kv.store.has("member:donor@example.com")).toBe(false);
+    expect([...kv.store.keys()].some((k) => k.startsWith("feedtok:")))
+      .toBe(false);
+  });
+
+  it("ignores an untagged checkout however large the amount", async () => {
+    const env = envWith();
+    const kv = env.RATE_LIMIT_KV as unknown as FakeKV;
+    const res = await post(env, {
+      type: "checkout.session.completed",
+      data: { object: {
+        customer_details: { email: "stranger@example.com" },
+        amount_total: 99999,
+      } },
+    });
+    expect(res.status).toBe(200);
+    expect(kv.store.has("member:stranger@example.com")).toBe(false);
   });
 
   it("rejects a bad signature outright", async () => {

--- a/workers/gallery/wrangler.toml
+++ b/workers/gallery/wrangler.toml
@@ -26,39 +26,33 @@ routes = [
 binding = "GALLERY_BUCKET"
 bucket_name = "nerra-gallery"
 
-# KV namespace for rate limiting on subscribe/login, and for the
-# per-email revocation list. COMMENTED OUT because no namespace has ever
-# been provisioned — so this is not a regression, it is the config
-# finally matching production. Both consumers fail open when the binding
-# is absent (see checkRateLimit / isEmailRevoked in src/handlers.ts), so
-# the Worker runs correctly without it; it simply has no rate limiting.
+# KV namespace for rate limiting on subscribe/login, for the per-email
+# revocation list, and (Aug 2026) for the Nerra Personal member records
+# (`member:<email>`) and feed tokens (`feedtok:<token>`). Provisioned
+# 2026-08-23 as `gallery_rate_limits`; the id below is that namespace.
 #
-# DO NOT uncomment these lines with a blank `id`. Wrangler validates the
-# whole config before running ANY command, so a blank id doesn't just
-# fail `deploy` — it also blocks `wrangler kv namespace list`, which is
-# how you'd look the id up. That loop cost the operator five failed
-# deploys on 2026-07-30.
+# Both rate-limit consumers fail open when the binding is absent (see
+# checkRateLimit / isEmailRevoked in src/handlers.ts), but the Personal
+# endpoints do NOT — they answer 503 "not configured" without it.
 #
-# To enable rate limiting, from a directory WITHOUT this wrangler.toml
-# (so the same validation doesn't block you):
+# NEVER leave `id` blank here. Wrangler validates the whole config before
+# running ANY command, so a blank id doesn't just fail `deploy` — it also
+# blocks `wrangler kv namespace list`, which is how you'd look the id up.
+# That loop cost the operator five failed deploys on 2026-07-30. To look
+# up ids, run from a directory WITHOUT this wrangler.toml:
 #     cd <repo root>
-#     workers/gallery/node_modules/.bin/wrangler kv namespace create gallery_rate_limits
-# then paste the returned id below and uncomment all four lines.
-# [[kv_namespaces]]
-# binding = "RATE_LIMIT_KV"
-# id = ""
-# preview_id = ""  # Optional preview namespace
+#     workers/gallery/node_modules/.bin/wrangler kv namespace list
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "6bef8549fdb541009f43ce92ee3fbdbd"
 
-# Nerra Personal (Aug 2026): the private personalized-feed audio bucket.
-# COMMENTED OUT for the same reason as the KV block above — uncommenting
-# before the bucket exists blocks every wrangler command. To enable:
-#     wrangler r2 bucket create nerra-personal
-# then uncomment. The /api/feed, /api/account and Stripe endpoints answer
-# 503 "not configured" until this + the KV namespace + the secrets exist;
-# nothing else in the Worker changes behaviour.
-# [[r2_buckets]]
-# binding = "PERSONAL_BUCKET"
-# bucket_name = "nerra-personal"
+# Nerra Personal (Aug 2026): the private personalized-feed audio bucket,
+# created 2026-08-23. Keys live under `personal/<token>/` and are served
+# ONLY through the Worker's token-checked /api/feed endpoint — the bucket
+# stays private, so cancelling a subscription revokes the feed at once.
+[[r2_buckets]]
+binding = "PERSONAL_BUCKET"
+bucket_name = "nerra-personal"
 
 # Secrets are set out-of-band via:
 #   wrangler secret put JWT_SECRET


### PR DESCRIPTION
Operator checklist steps 1-7 of docs/nerra_personal.md, executed 2026-08-23, plus one fix the checklist did not anticipate.

## What is live already

Cloudflare: KV namespace gallery_rate_limits (6bef8549fdb541009f43ce92ee3fbdbd) and R2 bucket nerra-personal created; secrets PERSONAL_ADMIN_TOKEN and STRIPE_WEBHOOK_SECRET set; Worker deployed as version 73d195e6.

Stripe (Lil Learning, live mode): four products with tax codes, four prices, four Payment Links, and webhook endpoint we_1U7jIr on checkout.session.completed + customer.subscription.deleted. All four link URLs are set as Actions variables, so the next generate_html run flips join/support out of their launching-soon states.

## The fix

The webhook resolved tier as metadata.tier === "personal_local" || amount_total >= 799. That was correct while memberships were the only thing that could complete a checkout at this endpoint. Donations live in the same Stripe account and therefore hit the same endpoint, so a single $10 gift would have cleared 799 and been handed an active personal_local record, a feed token, and a private daily feed, free and permanent.

The tier marker is now required. Stripe copies a Payment Link's metadata onto every Checkout Session it creates, so it is reliable; anything without a known tier is logged and ignored. Both donation links carry metadata.kind="donation".

## Verification

68 worker tests pass, including two new drift guards. Against the live api.nerranetwork.com: /api/health 200, /api/account 401 without a cookie, /api/feed/<bogus> 404, /api/admin/personal-specs 401 without a bearer and {"ok":true,"specs":[]} with one. The batch builder was run end to end against that endpoint and correctly no-opped on zero subscribers.

## Not in this PR

MEMBER_BOOK_CODE was deliberately left unset: no volume has a buy link yet, so account.html shows its honest "member codes appear here as new volumes launch" line rather than a code that redeems nowhere. Step 8, the private batch host, is still outstanding.