### PR TITLE
WO-1: widen citation-shape detection and re-measure exposure

### DIFF
--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -356,7 +356,7 @@ jobs:
             tests/test_four_show_quality_pass.py \
             tests/test_russian_shows_quality_pass.py \
             tests/test_tts_dialogue.py tests/test_dp_pod_show.py \
-            tests/test_source_integrity.py \
+            tests/test_source_integrity.py tests/test_citation_shapes.py \
             -q --tb=short
 
       - name: Validate config before run

--- a/docs/citation_exposure_2026_08_22.md
+++ b/docs/citation_exposure_2026_08_22.md
@@ -1,5 +1,14 @@
 # Citation-shape exposure across the published corpus
 
+> **A count is a floor, not a measurement. These patterns detect known
+> fabrication templates; novel shapes are not detected.** Tested against 14
+> fabrications independently verified by hand fact-check, the template set
+> this report was measured with caught **4 of 14 (28%)** — the counts below
+> measure *one template*, not exposure. Superseded by
+> [`citation_exposure_2026_08_23.md`](citation_exposure_2026_08_23.md)
+> (widened pattern set); this file is retained because the delta between the
+> two is the useful artifact.
+
 Measured 2026-08-22 by `scripts/measure_citation_exposure.py` — deterministic regex counts of citation-shaped constructions (`engine.claims.CITATION_SHAPE_PATTERNS`, the fabrication signature) over every committed digest `.md`. A count is EXPOSURE, not a verdict: each match is a sentence asserting provenance that no ledger backs, which may be true, stale, or invented — unverifiable either way.
 
 This ranking is the triage order for the backfill (soften-in-place / re-source / regenerate — operator decision per show).

--- a/docs/citation_exposure_2026_08_23.md
+++ b/docs/citation_exposure_2026_08_23.md
@@ -1,0 +1,122 @@
+# Citation-shape exposure across the published corpus
+
+> **A count is a floor, not a measurement. These patterns detect known fabrication templates; novel shapes are not detected.** The Aug 22 report's original template set caught 4 of 14 hand-verified fabrications — a low per-show number here is not evidence of health.
+
+Measured 2026-08-24 by `scripts/measure_citation_exposure.py` — deterministic regex counts of citation-shaped constructions (`engine.claims.CITATION_SHAPE_PATTERNS`, the fabrication signature) over every committed digest `.md`. A count is EXPOSURE, not a verdict: each match is a sentence asserting provenance that no ledger backs, which may be true, stale, or invented — unverifiable either way.
+
+This ranking is the triage order for the backfill (soften-in-place / re-source / regenerate — operator decision per show).
+
+| Show | Episodes | With shapes | Shapes | Per episode |
+|---|---:|---:|---:|---:|
+| unintended_consequences | 98 | 54 | 83 | 0.85 |
+| planetterrian | 137 | 56 | 73 | 0.53 |
+| dp_pod | 25 | 7 | 7 | 0.28 |
+| omni_view | 150 | 19 | 25 | 0.17 |
+| models_agents_beginners | 137 | 8 | 10 | 0.07 |
+| first_principles | 79 | 5 | 5 | 0.06 |
+| tesla_shorts_time | 188 | 11 | 11 | 0.06 |
+| fascinating_frontiers | 139 | 7 | 7 | 0.05 |
+| spacex | 78 | 4 | 4 | 0.05 |
+| modern_investing | 148 | 6 | 6 | 0.04 |
+| env_intel | 62 | 2 | 2 | 0.03 |
+| models_agents | 151 | 5 | 5 | 0.03 |
+| finansy_prosto | 73 | 0 | 0 | 0.00 |
+| nerra_daily | 3 | 0 | 0 | 0.00 |
+| offshore_north | 1 | 0 | 0 | 0.00 |
+| privet_russian | 66 | 0 | 0 | 0.00 |
+
+## Highest-exposure episodes (top 20)
+
+- **digests/unintended_consequences/Unintended_Consequences_Ep071_20260727.md** — 7 (`Estimates from`, `In 1952, the Lorillard Tobacco Company introduced`, `Internal documents`, `Internal memos`, `The Federal Trade Commission briefly required tar-and-nicotine disclosures in 1957`, `memo from British American Tobacco observed that “`)
+- **digests/models_agents_beginners/MAB_Ep079_20260621.md** — 3 (`Researchers noted`, `according to The D`)
+- **digests/omni_view/Omni_View_Ep103_20260705.md** — 3 (`analysts noted`, `researchers noted`)
+- **digests/planetterrian/Planetterrian_Daily_Ep078_20260603.md** — 3 (`Researchers documented`, `monitoring across managed forests showed`, `researchers documented`)
+- **digests/planetterrian/Planetterrian_Daily_Ep109_20260703.md** — 3 (`Researchers documented`, `Sampling of cats and their fleas in the region detected`, `scientists found`)
+- **digests/unintended_consequences/Unintended_Consequences_Ep032_20260617.md** — 3 (`Estimates compiled by`, `In 1962 the World Health Organization issued`, `compiled by the A`)
+- **digests/unintended_consequences/Unintended_Consequences_Ep069_20260725.md** — 3 (`A 2018 study`, `Estimates from`, `a 2014 study`)
+- **digests/unintended_consequences/Unintended_Consequences_Ep072_20260728.md** — 3 (`a 1975 paper`, `engineer Nils Bohlin, who filed the patent in 1959 after studying crash data that showed`, `researchers documented`)
+- **digests/unintended_consequences/Unintended_Consequences_Ep094_20260819.md** — 3 (`A 2008 paper`, `A 2012 study`, `chemist Arlene Blum and the biochemist Bruce Ames showed`)
+- **digests/omni_view/Omni_View_Ep035_20260421.md** — 2 (`according to the c`, `according to the r`)
+- **digests/omni_view/Omni_View_Ep054_20260518.md** — 2 (`Analysts noted`, `analysts noted`)
+- **digests/omni_view/Omni_View_Ep132_20260803.md** — 2 (`according to a r`, `survey of UK factories showed`)
+- **digests/omni_view/Omni_View_Ep144_20260815.md** — 2 (`according to a s`, `according to the U`)
+- **digests/planetterrian/Planetterrian_Daily_Ep027_20260307.md** — 2 (`Researchers found`, `studies showed`)
+- **digests/planetterrian/Planetterrian_Daily_Ep032_20260320.md** — 2 (`Researchers found`, `researchers found`)
+- **digests/planetterrian/Planetterrian_Daily_Ep038_20260331.md** — 2 (`Researchers found`)
+- **digests/planetterrian/Planetterrian_Daily_Ep051_20260427.md** — 2 (`Data compiled by the B`, `compiled by the B`)
+- **digests/planetterrian/Planetterrian_Daily_Ep085_20260610.md** — 2 (`researchers documented`, `studies found`)
+- **digests/planetterrian/Planetterrian_Daily_Ep093_20260618.md** — 2 (`survey of Australian native bees found`, `testing across multiple ape species revealed`)
+- **digests/planetterrian/Planetterrian_Daily_Ep112_20260706.md** — 2 (`Researchers documented`, `measurements in large population datasets and found`)
+
+## Pattern breakdown (network-wide)
+
+- `(?i)\b(?:researchers|scientists|analysts|officials) (?:found|noted|estimated|documented)\b` — 80
+- `(?i)\baccording to (?:a|an|the) [a-z]` — 46
+- `(?i)\b(?:sampling|testing|monitoring|surveys?|measurements?|audits?)\s+(?:in|across|of|at)\s+[^.]{0,70}?\b(?:detected|found|showed|revealed|recorded|documented)\b` — 20
+- `(?i)\bestimates (?:from|compiled by)\b` — 18
+- `(?i)\ba \d{4} (?:study|paper|report|memo|survey|analysis|bulletin|note)\b` — 13
+- `(?i)\bstudies (?:later )?(?:showed|estimated|found)\b` — 10
+- `(?i)\binternal (?:documents|memos|reports)\b` — 9
+- `\b(?:[Ii]n|[Bb]y)\s+\d{4},?\s+the\s+[A-Z][\w'&.\- ]{3,50}?\s+(?i:issued|published|released|adopted|recommended|established|introduced|required|banned|mandated|approved|suspended)\b` — 9
+- `(?i)\bmost accounts\b` — 7
+- `\b[Tt]he\s+[A-Z][\w'&.\- ]{3,50}?\s+(?i:briefly\s+|formally\s+|first\s+|quietly\s+)?(?i:issued|published|adopted|recommended|established|introduced|required|banned|mandated|approved|suspended|authorized)\b[^.]{0,60}?\bin\s+\d{4}\b` — 5
+- `\b(?i:physician|pharmacologist|chemist|biologist|economist|engineer|scientist|professor|researcher|historian|epidemiologist|statistician)\s+(?:Sir\s+|Dr\.?\s+)?[A-Z][a-z]+\s+[A-Z][a-z]+\b[^.]{0,80}?\b(?i:noted|found|warned|observed|argued|reported|showed|concluded|estimated)\b` — 5
+- `\b(?i:tracked|compiled|catalogued|documented|maintained|preserved)\s+by\s+the\s+[A-Z]` — 4
+- `(?i)\bcontemporary\s+(?:accounts?|records?|reports?|sources?|documentation)\s+(?:describe|record|show|indicate|note|suggest|confirm)\b` — 3
+- `(?i)\baccording to\s+(?:surveys?|data|figures|records|analyses?|estimates?|reports?|research)\s+(?:by|from|conducted by)\b` — 2
+- `\b(?i:records|documents|archives|papers|files|data|figures|statistics)\s+(?i:(?:are|were|is|now)\s+)?(?i:preserved|held|housed|maintained|tracked|compiled|collected|published)\s+(?i:by|at|in)\s+(?:the\s+)?[A-Z]` — 2
+- `(?i)\b(?:accounts?|records?|reports?|sources?)\s+from\s+the\s+(?:period|time|era|day)\b` — 2
+- `(?i)\ba\s+\d{4}\s+[\w\- ]{0,35}?(?:journal|magazine|newspaper|publication|periodical|trade press|newsletter)\b` — 2
+- `(?i)\b(?:memo|memorandum|report|study|letter|document|paper|bulletin)\b[^.]{0,90}?\b(?:observed|noted|stated|concluded|said|wrote|argued)\s+that\s+[\"'‘“]` — 1
+
+
+## Delta vs the 2026-08-22 report (the useful artifact)
+
+The template set was widened after hand fact-check showed the original 8
+patterns caught **4 of 14 (28%)** independently verified fabrications. The
+widened set (18 patterns) catches **14 of 14**, pinned by
+`tests/test_citation_shapes.py`.
+
+| Measure | 2026-08-22 (8 patterns) | 2026-08-23 (18 patterns) |
+|---|---:|---:|
+| Digests scanned | 1,523 | 1,535 |
+| Citation shapes | 182 | 238 |
+| Episodes with shapes | 152 | 184 |
+| unintended_consequences per-ep | 0.56 | **0.85** (+52%) |
+| planetterrian per-ep | 0.42 | **0.53** (+26%) |
+
+New-pattern hits: **55**. The biggest movers are exactly the shows whose
+formats invite invented provenance — UC's history essays (dated
+institutional actions, archival records, quoted documents) and
+Planetterrian's study summaries (attributed empirical findings).
+
+## Precision of the widened patterns (hand-classified, 2026-08-23)
+
+Per WO-1: 40 of the 55 new-pattern hits were sampled at random
+(seed 20260823) and hand-classified. **TP** = the sentence genuinely
+asserts a provenance-bearing fact (attributed study/survey/data, dated
+institutional action, named expert, archival record, quoted document) —
+i.e., the flag is actionable: the sentence needs a ledger entry or the
+general form. TP does **not** mean the claim is false — on the news shows
+many flagged sentences summarize real, source-linked studies.
+
+- **Post case-fix precision: 40/40 TP (100%) on the sample.** The 15
+  unsampled hits were also eyeballed: all provenance-bearing, no
+  mechanical misfires.
+- **The case-sensitivity fix is what got it there.** The first measurement
+  pass compiled every pattern `IGNORECASE`, which nullified the `[A-Z]`
+  named-entity anchors; the same 40-hit sample then contained at least 7
+  clear misfires (~82% precision) — "data collected by the rover's
+  instruments", "the record cadence established in 2025", "the first
+  versions of the algorithmic News Feed introduced in 2011", an
+  Anthropic reported-speech fragment. Case handling now lives inside each
+  pattern and a comment in `engine/claims.py` pins why.
+- **Noisiest surviving class:** dated corporate/institutional actions
+  ("In 1952, the Lorillard Tobacco Company introduced the Kent
+  cigarette…"). Counted TP because invented institutional history is a
+  verified fabrication category (the FTC-1957 claim; "the 1947 Rent
+  Control Law" which never existed), but these are the flags most likely
+  to be true-and-easily-sourced during backfill.
+
+Both figures clear WO-1's ~60% floor with a wide margin; no tightening
+beyond the case fix was needed.

--- a/engine/claims.py
+++ b/engine/claims.py
@@ -64,18 +64,87 @@ logger = logging.getLogger(__name__)
 # scripts/measure_citation_exposure.py).
 
 CITATION_SHAPE_PATTERNS: List[str] = [
-    r"\ba \d{4} (?:study|paper|report|memo|survey|analysis|bulletin|note)\b",
-    r"\b(?:researchers|scientists|analysts|officials) "
+    # ---- Original template set (Aug 22) — the dated-artifact shape.
+    # These carry no capitalization anchors, so they compile
+    # case-insensitively via the (?i) prefix. ----
+    r"(?i)\ba \d{4} (?:study|paper|report|memo|survey|analysis|bulletin|note)\b",
+    r"(?i)\b(?:researchers|scientists|analysts|officials) "
     r"(?:found|noted|estimated|documented)\b",
-    r"\binternal (?:documents|memos|reports)\b",
-    r"\baccording to (?:a|an|the) [a-z]",
-    r"\bestimates (?:from|compiled by)\b",
-    r"\bstudies (?:later )?(?:showed|estimated|found)\b",
-    r"\btrade data show\b",
-    r"\bmost accounts\b",
+    r"(?i)\binternal (?:documents|memos|reports)\b",
+    r"(?i)\baccording to (?:a|an|the) [a-z]",
+    r"(?i)\bestimates (?:from|compiled by)\b",
+    r"(?i)\bstudies (?:later )?(?:showed|estimated|found)\b",
+    r"(?i)\btrade data show\b",
+    r"(?i)\bmost accounts\b",
+    # ---- WO-1 widening (Aug 23) — the original set caught 4 of 14
+    # hand-verified fabrications. Each pattern below maps to a verified
+    # miss category; the fixture in tests/test_citation_shapes.py pins
+    # all 14 catches and the general-form guards. The distinction that
+    # binds: unnamed PEOPLE ("contemporary observers warned") are the
+    # sanctioned general form; non-existent DOCUMENTS, records,
+    # institutions and datasets are the fabrication signature.
+    #
+    # The [A-Z] classes below are LOAD-BEARING named-entity anchors and
+    # must stay case-sensitive — the first measurement pass compiled
+    # everything IGNORECASE and precision collapsed ("data collected by
+    # the rover's instruments", "the record cadence established in
+    # 2025" both flagged). Sentence-initial words use [Xx] classes;
+    # keyword alternations use scoped (?i:...) groups instead. ----
+    # dated institutional action: "In 1962 the WHO issued guidance"
+    r"\b(?:[Ii]n|[Bb]y)\s+\d{4},?\s+the\s+[A-Z][\w'&.\- ]{3,50}?\s+"
+    r"(?i:issued|published|released|adopted|recommended|established|"
+    r"introduced|required|banned|mandated|approved|suspended)\b",
+    # invented regulatory history: "The FTC briefly required X in 1957"
+    r"\b[Tt]he\s+[A-Z][\w'&.\- ]{3,50}?\s+(?i:briefly\s+|formally\s+|"
+    r"first\s+|quietly\s+)?(?i:issued|published|adopted|recommended|"
+    r"established|introduced|required|banned|mandated|approved|"
+    r"suspended|authorized)\b[^.]{0,60}?\bin\s+\d{4}\b",
+    # archival / data custody: "records are preserved by the X Museum"
+    r"\b(?i:records|documents|archives|papers|files|data|figures|"
+    r"statistics)\s+(?i:(?:are|were|is|now)\s+)?(?i:preserved|held|"
+    r"housed|maintained|tracked|compiled|collected|published)\s+"
+    r"(?i:by|at|in)\s+(?:the\s+)?[A-Z]",
+    # institutional data custody: "waste now tracked by the Ellen
+    # MacArthur Foundation" — the custodied noun varies too much to
+    # enumerate, so anchor on the custody verb + named institution.
+    r"\b(?i:tracked|compiled|catalogued|documented|"
+    r"maintained|preserved)\s+by\s+the\s+[A-Z]",
+    # named-expert attribution: "pharmacologist Sir Robert Robinson had
+    # noted" — a titled, named person lending authority to a claim.
+    r"\b(?i:physician|pharmacologist|chemist|biologist|economist|"
+    r"engineer|scientist|professor|researcher|historian|epidemiologist|"
+    r"statistician)\s+(?:Sir\s+|Dr\.?\s+)?[A-Z][a-z]+\s+[A-Z][a-z]+"
+    r"\b[^.]{0,80}?\b(?i:noted|found|warned|observed|argued|reported|"
+    r"showed|concluded|estimated)\b",
+    # quoted document: "a 1974 internal memo ... observed that '..."
+    r"(?i)\b(?:memo|memorandum|report|study|letter|document|paper|bulletin)"
+    r"\b[^.]{0,90}?\b(?:observed|noted|stated|concluded|said|wrote|"
+    r"argued)\s+that\s+[\"'‘“]",
+    # attributed survey / data: "according to surveys by X"
+    r"(?i)\baccording to\s+(?:surveys?|data|figures|records|analyses?|"
+    r"estimates?|reports?|research)\s+(?:by|from|conducted by)\b",
+    # invented empirical finding: "sampling in several cities detected"
+    r"(?i)\b(?:sampling|testing|monitoring|surveys?|measurements?|audits?)"
+    r"\s+(?:in|across|of|at)\s+[^.]{0,70}?\b(?:detected|found|showed|"
+    r"revealed|recorded|documented)\b",
+    # dated periodical: "a 1954 British textile journal noted"
+    r"(?i)\ba\s+\d{4}\s+[\w\- ]{0,35}?(?:journal|magazine|newspaper|"
+    r"publication|periodical|trade press|newsletter)\b",
+    # invented archival record: "accounts from the period describe".
+    # Deliberately excludes bare "contemporary observers warned" —
+    # unnamed people are the sanctioned general form; non-existent
+    # documents are not.
+    r"(?i)\b(?:accounts?|records?|reports?|sources?)\s+from\s+the\s+"
+    r"(?:period|time|era|day)\b",
+    r"(?i)\bcontemporary\s+(?:accounts?|records?|reports?|sources?|"
+    r"documentation)\s+(?:describe|record|show|indicate|note|suggest|"
+    r"confirm)\b",
 ]
 
-_CITATION_SHAPE_RES = [re.compile(p, re.IGNORECASE) for p in CITATION_SHAPE_PATTERNS]
+# Case handling lives INSIDE each pattern ((?i) prefix or scoped (?i:...)
+# groups) — a global IGNORECASE here would nullify the [A-Z] named-entity
+# anchors that keep the widened set precise.
+_CITATION_SHAPE_RES = [re.compile(p) for p in CITATION_SHAPE_PATTERNS]
 
 # Fenced ledger block the generation stage appends after the prose.
 _CLAIMS_FENCE_RE = re.compile(

--- a/scripts/measure_citation_exposure.py
+++ b/scripts/measure_citation_exposure.py
@@ -119,6 +119,12 @@ def render_report(result: dict, top: int) -> str:
     out = [
         "# Citation-shape exposure across the published corpus",
         "",
+        "> **A count is a floor, not a measurement. These patterns detect "
+        "known fabrication templates; novel shapes are not detected.** "
+        "The Aug 22 report's original template set caught 4 of 14 "
+        "hand-verified fabrications — a low per-show number here is not "
+        "evidence of health.",
+        "",
         f"Measured {date.today().isoformat()} by "
         "`scripts/measure_citation_exposure.py` — deterministic regex counts "
         "of citation-shaped constructions "

--- a/tests/test_citation_shapes.py
+++ b/tests/test_citation_shapes.py
@@ -1,0 +1,152 @@
+"""WO-1 regression fixture: the citation-shape lint vocabulary.
+
+The original ``CITATION_SHAPE_PATTERNS`` set caught 4 of 14 fabrications
+independently verified by hand fact-check — it measured ONE template, not
+exposure. This fixture pins the widened vocabulary against all 14 verified
+fabrications (must catch) and the sanctioned general-form escape hatch
+(must NOT catch). The distinction that must survive any future tuning:
+attributing to unnamed *people* ("contemporary observers warned") is the
+sanctioned general form; attributing to non-existent *documents, records,
+institutions, or datasets* is the fabrication signature.
+
+A count from these patterns is a FLOOR, not a measurement — they detect
+known fabrication templates; novel shapes are not detected.
+"""
+
+import pytest
+
+from engine.claims import find_citation_shapes
+
+# ---------------------------------------------------------------------------
+# 14 verified fabrications — every one shipped in a published book volume
+# and failed hand fact-check. All MUST be caught.
+# ---------------------------------------------------------------------------
+
+MUST_CATCH = [
+    # -- Caught by the original template set (do not regress) --
+    pytest.param(
+        "Estimates compiled by the American Medical Association suggest "
+        "roughly 50,000 lobotomies performed in the United States.",
+        id="uc-v2c12-estimates-compiled",
+    ),
+    pytest.param(
+        "A 1995 survey of U.S. physicians found that more than 80 percent "
+        "recommended estrogen to asymptomatic patients.",
+        id="uc-v2c15-dated-survey",
+    ),
+    pytest.param(
+        "Estimates from the World Health Organization and national "
+        "registries suggest that asbestos-related diseases still claim "
+        "roughly 40,000 lives worldwide each year.",
+        id="uc-v4c7-estimates-from",
+    ),
+    pytest.param(
+        "Estimates from the Bureau of Labor Statistics suggest that "
+        "roughly 1.5 million workers performed driving or delivery tasks "
+        "through apps as of 2023.",
+        id="uc-v4c9-estimates-from-bls",
+    ),
+    # -- The gap: missed by the original set --
+    pytest.param(
+        "In 1962 the World Health Organization issued guidance "
+        "discouraging psychosurgery except under strict research protocols.",
+        id="uc-v2c12-dated-institutional-action",
+    ),
+    pytest.param(
+        "surviving dial-painter records are preserved by the National "
+        "Museum of Nuclear Science & History.",
+        id="uc-v2c13-archival-custody",
+    ),
+    pytest.param(
+        "A small number of researchers, including British pharmacologist "
+        "Sir Robert Robinson, had noted in the early 1940s that high-dose "
+        "estrogens could alter genital-tract development.",
+        id="uc-v2c19-named-expert",
+    ),
+    pytest.param(
+        "the 92 million tonnes of annual textile waste now tracked by the "
+        "Ellen MacArthur Foundation and national environmental agencies.",
+        id="uc-v4c3-institutional-data-custody",
+    ),
+    pytest.param(
+        "A 1974 internal memo from British American Tobacco observed that "
+        "'the smoker is obtaining a higher delivery than the figures "
+        "suggest.'",
+        id="uc-v4c11-quoted-document",
+    ),
+    pytest.param(
+        "The Federal Trade Commission briefly required tar-and-nicotine "
+        "disclosures in 1957, then suspended the rule after industry "
+        "complaints.",
+        id="uc-v4c11-invented-regulatory-history",
+    ),
+    pytest.param(
+        "Maya Bay's coral cover declined by roughly 80 percent in the "
+        "decade after the film, according to surveys by Thailand's "
+        "Department of National Parks.",
+        id="uc-v4c19-attributed-survey",
+    ),
+    pytest.param(
+        "Wastewater sampling in several cities during 2020-2022 detected "
+        "elevated alcohol residues near schools and offices.",
+        id="uc-v2c16-invented-empirical-finding",
+    ),
+    pytest.param(
+        "A 1954 British textile journal noted that one pound of polyester "
+        "could yield garments for several families.",
+        id="uc-v2c20-dated-periodical",
+    ),
+    pytest.param(
+        "Accounts from the period describe a bounty that officials "
+        "believed would reduce the snake population.",
+        id="uc-v1c1-invented-archival-record",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# General-form prose — the sanctioned escape hatch the prompt constraint
+# steers toward. Flagging any of these punishes exactly the behaviour the
+# gate asks for. All must pass clean.
+# ---------------------------------------------------------------------------
+
+MUST_NOT_CATCH = [
+    pytest.param(
+        "Contemporary observers warned that the bounty might backfire.",
+        id="general-observers-warned",
+    ),
+    pytest.param(
+        "The policy was widely criticised at the time.",
+        id="general-criticised",
+    ),
+    pytest.param(
+        "By the late 1960s the practice had largely stopped.",
+        id="general-dated-trend",
+    ),
+    pytest.param(
+        "Filters became standard across the industry within a decade.",
+        id="general-industry-trend",
+    ),
+]
+
+
+class TestWidenedCitationShapes:
+    @pytest.mark.parametrize("sentence", MUST_CATCH)
+    def test_verified_fabrication_is_caught(self, sentence):
+        findings = find_citation_shapes(sentence)
+        assert findings, f"verified fabrication not flagged: {sentence!r}"
+
+    @pytest.mark.parametrize("sentence", MUST_NOT_CATCH)
+    def test_general_form_is_not_caught(self, sentence):
+        findings = find_citation_shapes(sentence)
+        assert not findings, (
+            f"general form falsely flagged by "
+            f"{[f['pattern'] for f in findings]}: {sentence!r}"
+        )
+
+    def test_observers_vs_documents_distinction(self):
+        """Attributing to unnamed PEOPLE is sanctioned; attributing to
+        non-existent DOCUMENTS is not. Both use 'contemporary'."""
+        assert not find_citation_shapes(
+            "Contemporary observers warned that the lake would change.")
+        assert find_citation_shapes(
+            "Contemporary accounts describe a bounty paid per snake.")


### PR DESCRIPTION
Executes **WO-1** from the 2026-08-22 work-order handover. Measurement only — nothing auto-rewritten, the verification gate untouched (fuzzy threshold unchanged).

## Why

The Aug 22 exposure report (182 shapes / 152 episodes) read as a measurement of exposure and was actually a measurement of *one template*: against the work order's 14 hand-verified fabrications, `CITATION_SHAPE_PATTERNS` caught **4 of 14 (28%)**.

## What shipped

**1 · Regression fixture** — `tests/test_citation_shapes.py`: all 14 verified fabrications as must-catch cases (the 4 already-caught pinned against regression, the 10 misses as the gap), the 4 general-form guards as must-not-catch (the sanctioned escape hatch is never punished), and the observers-vs-documents distinction pinned explicitly — attributing to unnamed *people* is sanctioned; attributing to non-existent *documents* is the fabrication signature.

**2 · Ten new patterns** in `engine/claims.py`, one per verified miss category: dated institutional action, invented regulatory history ("The FTC briefly required X in 1957"), archival/data custody, institutional data custody, named-expert attribution, quoted document, attributed survey, invented empirical finding, dated periodical, invented archival record. **All 14 caught, all guards clean** (73 tests green including the existing source-integrity suite).

**3 · A precision bug found and fixed during tuning** — `find_citation_shapes` compiled every pattern `IGNORECASE`, which nullified the `[A-Z]` named-entity anchors the new patterns depend on. The first 40-hit sample contained ≥7 clear misfires (~82% precision): "data collected by the rover's instruments", "the record cadence established in 2025", "the first versions of the algorithmic News Feed introduced in 2011". Case handling now lives *inside* each pattern (`(?i)` prefix on the anchor-free legacy set, scoped `(?i:…)` groups + case-sensitive `[A-Z]` anchors on the new set), with a comment pinning why a global flag must never return.

**4 · Precision reported explicitly** (WO-1 task 4): 40 of 55 new-pattern hits sampled at random (seed 20260823), hand-classified. **Post-fix: 40/40 TP**; the 15 unsampled hits also eyeballed clean. TP = the sentence genuinely asserts a provenance-bearing fact (actionable flag), *not* that the claim is false — news-show hits often summarize real, source-linked studies. Noisiest surviving class (dated corporate/institutional actions) is called out in the report. Both figures clear the ~60% floor; no tightening beyond the case fix was needed.

**5 · Re-measurement** — `docs/citation_exposure_2026_08_23.md`:

| Measure | Aug 22 (8 patterns) | Aug 23 (18 patterns) |
|---|---:|---:|
| Citation shapes | 182 | **238** |
| Episodes with shapes | 152 | **184** |
| UC per-episode | 0.56 | **0.85** |
| Planetterrian per-episode | 0.42 | **0.53** |

The Aug 22 report is retained with a superseded note (the delta is the useful artifact), and **both reports now lead with the required framing: "A count is a floor, not a measurement. These patterns detect known fabrication templates; novel shapes are not detected."**

**6 · Smoke coverage** — `tests/test_citation_shapes.py` added to the run-show smoke step.

## Expected live effect (not a change to the gate's mechanics)

The lint vocabulary IS the gate's vocabulary, so the enforced narrative shows (UC/FPD) now face the stricter set — a citation-shaped sentence in a new fabrication category needs a verified claim or the general form. That is the widening working as designed; shadow-mode shows just get more honest metrics.

## Verification

- 73/73 on `test_citation_shapes.py` + `test_source_integrity.py`; 254/254 across config/generator/book-compiler/dp_pod/schedule suites
- `soften_citations.py` dry-run over the corpus: 0 auto-rewrites (WO-1 is measurement only), 238 flags for manual review — consistent with the report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp)_