### PR TITLE
YouTube fixes effectiveness audit (full week) + lag-aware analytics windows

### DIFF
--- a/docs/reviews/video_pipeline_review_2026_08_12.md
+++ b/docs/reviews/video_pipeline_review_2026_08_12.md
@@ -207,3 +207,43 @@ through ~08-15; the 08-15+ motion-era renders are still inside the
   `long-open-cliff`. Content-side changes to the spoken open are audio
   (landmine #17) and stay operator-gated; the in-flight levers against
   it are chapters, the accelerating open, and the motion batch.
+
+## Effectiveness audit — 2026-08-24 (full week on every batch)
+
+Verdicts per lever, from lag-corrected production data (the audit also
+found and fixed the lag bug below):
+
+- **Motion package (36 slots, adaptive KB, transition split, punch-ins,
+  closing beat): WORKING.** EN Shorts views-per-day jumped ~6x by
+  cohort (08-10..14 med 1.0 → 08-15..18 med 5.4 → 08-19..23 med 6.0)
+  and Shorts AVP rose through the motion era (49.4 → 53.8% network;
+  RU motion-era Shorts retain 58-62% vs 50-52% before). EN channel
+  views +13.3% WoW, FR +74.4% WoW on the same code.
+- **Chapters: NO measurable AVP lift yet.** Long-form median AVP is
+  flat (13.0 pre → 13.4-13.6 after); the +3.1pt read on 08-17 was
+  young-video bias and regressed as views accrued. Chapters are
+  costless and still pay via search/"key moments" surfaces — keep, but
+  score the 08-26 readout honestly as "flat on AVP".
+- **Search-terms loop: FIRING.** 4 shows carry live matched queries
+  (tesla "fsd v14.1 lite", spacex "starship flight 14", M&A/MAB
+  "gemini 3.7 flash") in youtube_performance.json → title hints +
+  upload tags. EN search share 14% (flat vs 15% baseline — days in).
+- **Dub fragment titles: FIXED in the data** —
+  dub_fragment_title_share_14d = 0.04 (was 26% on FR).
+- **Open cliff: UNCHANGED** (EN hold@5% 0.51 = baseline). Remains the
+  dominant retention lever; the motion batch hasn't moved the first
+  30-45 s because that loss is decided by promise-match, which is
+  title/thumbnail/spoken-open territory (the last is landmine #17).
+- **RU cooling is real but demand-side**: RU -29.8% WoW after lag
+  correction, with steady uploads (10-13/day), IMPROVED retention, and
+  EN/FR growing on identical code — consistent with Shorts-feed
+  rotation / mean reversion off the 08-10..14 hot streak (37 vpd med),
+  not a pipeline fault. Recommendation: hold course; rising retention
+  typically precedes re-distribution. Watch the scorecard, don't thrash.
+- **Instrument bug found by this audit, fixed**: the WoW scorecard and
+  zero_view_share counted the ~48 h of unreported YouTube Analytics
+  lag as real zeros — every channel "lost" its newest 2 days of
+  uploads, RU WoW read -43% during plain lag, and EN zero-view share
+  read 0.22 (honest: 0.10). Windows are now lag-trimmed (_LAG_DAYS=2)
+  in both the scorecard and the experiment WoW metrics; guard in
+  tests/test_dashboard_growth.py::TestLagAwareAnalyticsWindows.

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1867,10 +1867,16 @@ def build_channel_scorecard(root: Path) -> Dict[str, Any]:
     hist = _load_json(root / "api" / "youtube_channel_history.json") or {}
     hist_rows = hist.get("rows", [])
 
-    # Complete upload counts (14d window ending at the analytics anchor)
-    # from the indexes; analytics rows for the same window from stats.
-    win_lo = (anchor_d - _dt.timedelta(days=14)).isoformat()
-    win_hi = anchor_d.isoformat()
+    # Complete upload counts from the indexes; analytics rows for the
+    # same window from stats. LAG-AWARE (Aug 24 2026): YouTube Analytics
+    # day-data finalizes ~48 h behind, so the window ENDS 2 days before
+    # the anchor — uploads from the unreported tail used to count as
+    # zero-view (every channel "lost" its newest 2 days of uploads) and
+    # the RU WoW read -43% during a plain reporting lag, over-alarming
+    # the scorecard the moment anyone looked.
+    _LAG_DAYS = 2
+    win_lo = (anchor_d - _dt.timedelta(days=14 + _LAG_DAYS)).isoformat()
+    win_hi = (anchor_d - _dt.timedelta(days=_LAG_DAYS)).isoformat()
     uploads: Dict[str, int] = {}
     for v in _iter_video_index_rows(root):
         pub = str(v.get("published") or "")[:10]
@@ -1894,6 +1900,8 @@ def build_channel_scorecard(root: Path) -> Dict[str, Any]:
     channels_out: Dict[str, Any] = {}
     for ch, c in (stats.get("channels") or {}).items():
         ds = [d for d in (c.get("day_series") or []) if isinstance(d, dict)]
+        # Trailing 2 rows are the unreported/partial tail — see _LAG_DAYS.
+        ds = ds[:-2] if len(ds) > 2 else ds
         last7 = ds[-7:]
         prior7 = ds[-14:-7]
         v7 = sum(int(d.get("views") or 0) for d in last7)
@@ -1935,10 +1943,12 @@ def build_channel_scorecard(root: Path) -> Dict[str, Any]:
         "configured": True,
         "as_of": stats.get("generated"),
         "window_note": (
-            "WoW = last 7 analytics days vs the 7 before, anchored to the "
-            "analytics fetch. zero_view_share compares INDEX uploads (the "
-            "complete record) with analytics rows — the API omits zero-"
-            "activity videos, so this is the FR-launch early warning."),
+            "WoW = last 7 COMPLETE analytics days vs the 7 before (the "
+            "trailing 2 days are excluded as unreported lag), anchored to "
+            "the analytics fetch. zero_view_share compares INDEX uploads "
+            "with analytics rows over the same lag-trimmed window — the "
+            "API omits zero-activity videos, so this is the FR-launch "
+            "early warning."),
         "channels": channels_out,
         "subscriber_series": {ch: s[-30:] for ch, s in subs_series.items()},
     }
@@ -1975,6 +1985,10 @@ def _experiment_live_metrics(root: Path) -> Dict[str, Any]:
     # Channel views WoW from the day series.
     for ch in ("en", "ru"):
         ds = ((stats.get("channels") or {}).get(ch) or {}).get("day_series") or []
+        # Lag-aware: the trailing 2 analytics days are unreported/partial
+        # (same rule as the channel scorecard) — without the trim this
+        # metric reported RU -43% WoW during a plain reporting lag.
+        ds = ds[:-2] if len(ds) > 2 else ds
         v7 = sum(int(d.get("views") or 0) for d in ds[-7:])
         vp7 = sum(int(d.get("views") or 0) for d in ds[-14:-7])
         out[f"channel_views_wow_{ch}"] = (

--- a/tests/test_dashboard_growth.py
+++ b/tests/test_dashboard_growth.py
@@ -131,3 +131,18 @@ class TestHtmlWiring:
                        "Staggered Shorts", "Specials queue",
                        "Analytics freshness"):
             assert marker in html, f"missing card: {marker}"
+
+
+class TestLagAwareAnalyticsWindows:
+    """Aug 24 2026: YouTube Analytics day-data finalizes ~48h behind.
+    Without trimming the unreported tail, every channel 'lost' its
+    newest 2 days of uploads to zero-view counting and the RU WoW read
+    -43% during a plain reporting lag."""
+
+    def test_scorecard_trims_the_lag_tail(self):
+        src = (ROOT / "scripts" / "generate_dashboard.py").read_text(
+            encoding="utf-8")
+        assert "_LAG_DAYS = 2" in src
+        # Both the scorecard and the experiment WoW metric trim.
+        assert src.count("ds = ds[:-2] if len(ds) > 2 else ds") == 2
+        assert "excluded as unreported lag" in src


### PR DESCRIPTION
Detailed review of how the YouTube fixes are working after a full week in production, plus one instrument fix the audit itself surfaced. Verdicts appended to `docs/reviews/video_pipeline_review_2026_08_12.md`.

## How the fixes are working

- **Motion package (36-slot cadence, adaptive Ken Burns, transition split, punch-ins, closing beat): working.** EN Shorts views-per-day rose ~6× by publish cohort (median 1.0 → 5.4 → 6.0), network Shorts AVP 49.4% → 53.8% through the motion era, and RU motion-era Shorts retain 58–62% (from 50–52%). Channel views: **EN +13.3% WoW, FR +74.4% WoW** on the same code — FR is breaking out.
- **Chapters: flat on AVP** (13.0 → 13.4–13.6; the +3.1pt read on 08-17 was young-video bias and regressed as views accrued). They're costless and still pay via search/"Key moments" surfaces — keep, and score the 08-26 readout honestly as flat-on-AVP.
- **Search-terms loop: firing.** Four shows carry live matched queries (tesla "fsd v14.1 lite", spacex "starship flight 14", M&A/MAB "gemini 3.7 flash") into title hints + upload tags. EN search share 14% vs the 15% baseline — too early to read.
- **Dub fragment titles: fixed in the data** — fragment share down to 0.04 (was 26% on FR).
- **Open cliff: unchanged at 0.51** — still the dominant retention lever. The loss in the first 30–45 s is promise-match territory (title/thumbnail/spoken open; the last is landmine #17 and stays operator-gated).
- **RU −29.8% WoW is demand-side cooling, not a pipeline fault**: uploads steady at 10–13/day, retention *improved*, and EN/FR grow on identical code — consistent with Shorts-feed rotation / mean reversion off the 08-10..14 hot streak (37 vpd median). Recommendation: hold course; rising retention typically precedes re-distribution.

## Instrument fix (found by this audit)

The WoW scorecard, `zero_view_share_14d`, and the `channel_views_wow_*` experiment metrics counted YouTube Analytics' ~48 h unreported tail as real zeros — every channel "lost" its newest 2 days of uploads (EN zero-view share read 0.22; honest value 0.10) and **RU WoW read −43% during plain reporting lag**, which is exactly the false alarm that sent this audit chasing a phantom outage. All three now trim the trailing 2 analytics days (`_LAG_DAYS = 2`), the card's window note says so, and `tests/test_dashboard_growth.py::TestLagAwareAnalyticsWindows` pins the trim.

Dashboard-only change; no render/audio/upload behavior touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsFQZkigeUpWYwoWRdbhTA)_