### PR TITLE
MIT: let the correction outrank its segment's time budget

### DIFF
--- a/shows/prompts/modern_investing_podcast.txt
+++ b/shows/prompts/modern_investing_podcast.txt
@@ -29,7 +29,9 @@ STRUCTURAL REQUIREMENTS (these determine episode length):
 - Trade Review: 6-8 sentences (skip for Episode 1)
 - Tools & Techniques: 4-6 sentences each for 2-3 items
 - Quick Hits: 2-3 sentences each for 3-4 items
-- Portfolio Performance: 3-4 sentences
+- Portfolio Performance: 3-4 sentences — EXCEPT on an episode whose
+  briefing carries a methodology correction, where this segment runs
+  as long as that correction needs (see segment 10)
 - Total: 55-75+ sentences, producing a 12-14 minute episode
 
 EXAMPLE OF IDEAL STORY COVERAGE (use this depth and style):
@@ -176,6 +178,20 @@ Patrick: Quick reminder — everything we discuss here is for education and ente
 
 10. [Portfolio Performance — 30-45 seconds]
 - This is the ONLY segment that reports running portfolio stats (win rate, YTD %, alpha vs NASDAQ)
+- **If the briefing's Portfolio Performance section contains a methodology
+  correction — a passage explaining why the track record restarted, what
+  earlier figure it replaced, or how a listener should audit a track
+  record — speak it IN FULL, as its own beat, BEFORE the numbers.** Let
+  the segment run well past its usual length to fit it. It is not
+  optional colour and it is not a candidate for compression: it exists
+  because a figure the show used to quote stopped appearing, and a
+  listener who heard the old number is owed the explanation. Do not
+  summarise it into a sentence, do not fold it into the stats read, and
+  do not drop it because the segment has a short time budget — the
+  budget yields to the correction, not the other way round. Carry the
+  briefing's own reasoning and ordering; do not invent new claims about
+  the record. On an episode whose briefing has no such passage, this
+  segment is the numbers only, at its normal length.
 - Running total of all simulated trades
 - Win rate and average return per trade
 - DO NOT repeat any specific trade narrative or P&L from Trade Review — just the cumulative numbers

--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -2850,3 +2850,55 @@ class TestDisclosureCountsAirings(TestMethodologyDisclosure):
         ]
         assert hits == ["Modern_Investing_Ep145_20260821_tts.txt"], (
             f"markers matched unexpected scripts: {hits}")
+
+
+class TestPodcastPromptCarriesTheCorrection:
+    """The digest-side fix alone was not enough.
+
+    Ep148 proved the reconcile works — the tracker went [144,145,146] ->
+    [145] and re-offered the airing — and then the podcast stage dropped
+    the segment for the THIRD time in four attempts. Cause: the
+    correction lands inside the digest's Portfolio Performance section,
+    and the podcast prompt budgets that segment at "3-4 sentences /
+    30-45 seconds". A ~250-word passage cannot survive a 3-sentence
+    budget, so the model was compressing it away while following
+    instructions correctly.
+
+    Counting airings honestly stops the segment retiring on a miscount;
+    it does not make the segment air. The budget has to yield.
+    """
+
+    @staticmethod
+    def _prompt():
+        return (_ROOT / "shows/prompts/modern_investing_podcast.txt").read_text(
+            encoding="utf-8")
+
+    def test_correction_is_exempt_from_the_segment_budget(self):
+        text = self._prompt()
+        assert "methodology" in text.lower(), (
+            "the podcast prompt does not mention the correction at all — "
+            "it will be compressed away like any other overlong passage")
+        # The length spec and the segment body must BOTH carry the
+        # exemption: the model reads the spec when planning lengths and
+        # the segment body when writing, and one without the other is
+        # how it got dropped.
+        assert "3-4 sentences — EXCEPT" in text
+        lower = text.lower()
+        assert "speak it in full" in lower
+        assert "not a candidate for compression" in lower
+
+    def test_prompt_supplies_no_quotable_correction_sentence(self):
+        # De-seed by shape, never with a quotable example (CLAUDE.md).
+        # The correction's wording comes from the digest; the prompt must
+        # describe the SHAPE only, or the model will parrot the example
+        # on episodes that carry no correction at all.
+        text = self._prompt()
+        for seeded in ("forty-five", "forty five", "+9.28", "9.28"):
+            assert seeded not in text.lower(), (
+                f"prompt seeds a quotable figure: {seeded!r}")
+
+    def test_no_correction_means_normal_length(self):
+        # The exemption must be conditional. An unconditional "run long"
+        # would stretch Portfolio Performance on every episode forever.
+        lower = self._prompt().lower()
+        assert "no such passage" in lower and "normal length" in lower


### PR DESCRIPTION
Ep148 was the first live test of #1068. It proved the reconcile works **and** exposed the rest of the problem.

## What Ep148 showed

| | Result |
|---|---|
| Tracker reconciled | `[144, 145, 146]` → `[145]` ✅ |
| Airing re-offered and stamped | `[145, 148]` ✅ |
| Correction in the **digest** | ✅ |
| Correction in the **spoken script** | ❌ |

Third drop in four attempts.

## Cause

The correction lands inside the digest's `### Portfolio Performance` section. The podcast prompt budgets that segment at **"3-4 sentences / 30-45 seconds"** and tells the model it is *"just the cumulative numbers"*.

A ~250-word passage cannot survive a 3-sentence budget. **The model wasn't misbehaving — it was following the instruction it had, and the one it needed didn't exist.**

Ep145 surviving now looks like the outlier it was, not the norm.

## Why #1068 alone was never going to be enough

Counting airings honestly stops the segment retiring on a miscount. It does not make the segment air. Without this change the loop churns forever: offered → dropped → released → offered again. Honest measurement of a broken delivery is still a broken delivery — it just stops lying about it.

## The fix

The exemption is stated in **both** places the model reads:

- the **length spec** it plans from (`3-4 sentences — EXCEPT…`)
- the **segment body** it writes from (`speak it IN FULL, as its own beat, BEFORE the numbers`… `the budget yields to the correction, not the other way round`)

One without the other is how the passage got dropped in the first place.

**De-seeded by shape** per CLAUDE.md: the prompt describes what a methodology correction *is* and never supplies a sentence of one. The wording comes from the digest, so a quotable example here would be parroted on episodes carrying no correction at all. `test_prompt_supplies_no_quotable_correction_sentence` pins that.

**Conditional**, so it can't quietly stretch Portfolio Performance forever: an episode whose briefing has no such passage keeps the normal short segment.

## ⚠️ A/B-listen (landmine #17)

Prompt change. **Ep149 is the test** — the digest should carry the correction and this time the script should too. Two airings are still owed; if one is judged enough, `METHODOLOGY_DISCLOSURE_EPISODES = 1`.

## Testing

- `tests/test_mit_benchmark_integrity.py` — **221 passed** (3 new).
- `tests/test_prompt_fidelity.py` + `test_prompt_quality_pass.py` — 55 passed.
- Full suite: 28 failures, **identical to the current baseline** (26 long-standing + 2 in `tests/test_nerra_personal.py` from #1061).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKLT8qmj3wDVb1TzRLXaFB)_