### PR TITLE
Fix: sample-EPUB build KeyError on the combined edition's parts

### DIFF
--- a/engine/book_compiler.py
+++ b/engine/book_compiler.py
@@ -280,7 +280,15 @@ def resolve_parts(volume: BookVolume,
     by_ep = {c.episode_num: c for c in chapters}
     layout: List[Tuple[str, List[BookChapter]]] = []
     for part in volume.parts:
-        layout.append((part["title"], [by_ep[e] for e in part["episodes"]]))
+        # Tolerate a chapter SUBSET: the free-sample EPUB builds from
+        # chapters[:1], so a part may reference episodes not present.
+        # (The full partition is validated at load_volume; the KeyError
+        # here killed the first collected-edition CI build.)
+        chs = [by_ep[e] for e in part["episodes"] if e in by_ep]
+        if chs:
+            layout.append((part["title"], chs))
+    if not layout:
+        return None
     flat = [c.number for _, chs in layout for c in chs]
     if flat != sorted(flat):
         raise ValueError(

--- a/tests/test_book_release_pass.py
+++ b/tests/test_book_release_pass.py
@@ -347,6 +347,20 @@ class TestWO6CombinedVolume:
         with pytest.raises(ValueError):
             load_volume(bad)
 
+    def test_sample_epub_builds_from_chapter_subset(self, built, tmp_path):
+        """build_book's free-sample EPUB passes chapters[:1]; parts that
+        reference absent episodes must collapse, not KeyError — the exact
+        failure that killed the first collected-edition CI build."""
+        import zipfile
+        from engine.book_compiler import build_epub
+        vol, chapters, _ = built
+        out = tmp_path / "sample.epub"
+        build_epub(vol, chapters[:1], out)  # raised KeyError before the fix
+        names = zipfile.ZipFile(out).namelist()
+        assert "OEBPS/chap_001.xhtml" in names
+        assert "OEBPS/part_01.xhtml" in names
+        assert "OEBPS/part_02.xhtml" not in names
+
     def test_every_collected_chapter_has_a_verified_ledger(self):
         """WO-4: all 30 shipping chapters carry a committed, non-empty
         claims sidecar, and each passes the offline gate (anchoring +


### PR DESCRIPTION
The first WO-10 build of `unintended_consequences_collected` (run 32775444927) failed at the **free-sample** step: the full 30-chapter EPUB, all 31 art images, and the gallery uploads had already completed cleanly, then `build_book.py` built the sample from `chapters[:1]` and `resolve_parts` raised `KeyError: 2` — it indexed every part episode unconditionally, and a one-chapter subset can't satisfy a 30-episode partition.

**Fix:** parts collapse to the chapters actually present at render time (empty parts dropped, all-absent → no parts layout), while the full-partition validation stays where it belongs, in `load_volume`. Regression guard reproduces the exact `chapters[:1]` failure shape; full-volume behavior pinned unchanged (5 part pages).

Also noted from the failed run's log: one of 31 Grok Imagine images was rejected by content moderation — the soft-fail contract worked (that chapter ships without art, loudly), and art cost matched the $1.55 estimate. The narration step never ran, so the failed run burned art money only; on re-dispatch the art cache is cold again (runner-local), so the collected build will re-bill ~$1.55 of art.

**After merge:** I re-dispatch the collected build and continue the WO-10 sequence (UC vols 1–4, FP vols 1–3, one at a time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp)_