### PR TITLE
Fix disclosure-marker guard: derive expected airings from tracker stamps

### DIFF
--- a/tests/test_mit_benchmark_integrity.py
+++ b/tests/test_mit_benchmark_integrity.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import datetime
 import itertools
 import json
+import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -2839,7 +2840,17 @@ class TestDisclosureCountsAirings(TestMethodologyDisclosure):
         # Ep100 says "The next Monday pick will target the energy
         # sector" — an earlier marker set matched that and would have
         # confirmed an airing that never happened. Every marker must be
-        # language only the correction produces.
+        # language only the correction produces — so markers may match
+        # ONLY episodes the tracker has stamped as disclosure airings.
+        # (The correction airs up to METHODOLOGY_DISCLOSURE_EPISODES
+        # times; a pinned one-episode list here broke the day the
+        # second legitimate airing shipped.)
+        tracker = json.loads(
+            (_ROOT / "digests/modern_investing/investment_tracker.json")
+            .read_text(encoding="utf-8"))
+        stamped = set(
+            tracker["metadata"]["methodology_disclosure_episodes"])
+        assert 145 in stamped, "the known Ep145 airing must stay stamped"
         scripts = sorted(
             (_ROOT / "digests/modern_investing").glob("*_tts.txt"))
         assert len(scripts) > 100, "corpus too small to validate markers"
@@ -2848,8 +2859,12 @@ class TestDisclosureCountsAirings(TestMethodologyDisclosure):
             if any(m in s.read_text(encoding="utf-8", errors="ignore").lower()
                    for m in mi._DISCLOSURE_MARKERS)
         ]
-        assert hits == ["Modern_Investing_Ep145_20260821_tts.txt"], (
-            f"markers matched unexpected scripts: {hits}")
+        hit_eps = {int(re.search(r"_Ep(\d+)_", h).group(1)) for h in hits}
+        assert 145 in hit_eps, "the Ep145 airing must match the markers"
+        unstamped = sorted(hit_eps - stamped)
+        assert not unstamped, (
+            f"markers matched episodes never stamped as disclosure "
+            f"airings (ordinary show language?): {unstamped} in {hits}")
 
 
 class TestPodcastPromptCarriesTheCorrection:

--- a/tests/test_uc_fact_corrections.py
+++ b/tests/test_uc_fact_corrections.py
@@ -68,9 +68,16 @@ class TestFactualCorrections:
         assert "two to six percent" in t
 
     def test_6_maya_bay_cap(self):
+        """WO-2 replaced the wrong 'daily cap of 375' with '380 per
+        hour'; the ledger pass then found no source for ANY specific
+        per-hour figure, so the digest now states the verified facts
+        (June 2018 closure, early-2022 reopening, hourly caps, boats
+        moored offshore) without an unverifiable number."""
         t = _digest(79)
         assert "daily cap of 375" not in t
-        assert "380 per hour" in t and "January 2022" in t
+        assert "380 per hour" not in t
+        assert "closed Maya Bay in June 2018" in t
+        assert "reopening it in early 2022 with strict hourly visitor caps" in t
 
     def test_7_maginot_depth(self):
         t = _digest(9)


### PR DESCRIPTION
Follow-up to #1082 (this commit missed the merge by a minute) — and it fixes the `test` check that is currently red on `main`.

**What broke:** `TestDisclosureCountsAirings::test_markers_do_not_fire_on_ordinary_show_language` pinned its expected marker matches to the literal list `[Ep145]`. That was correct the day it was written and broke the day the self-retiring methodology correction legitimately aired its second time — today's Ep149 (2026-08-25), stamped `[145, 149]` in `investment_tracker.json` by the pipeline. The correction airs up to `METHODOLOGY_DISCLOSURE_EPISODES` (3) times, so a hard-coded one-episode list breaks on every legitimate airing, including the third one still to come.

**The fix:** the test now reads the stamped airing list from the committed tracker and asserts the markers match **only stamped episodes** — which is its real purpose (no marker may fire on ordinary show language, the Ep100 "Monday pick" lesson) — while still requiring the known Ep145 airing to both stay stamped and keep matching, so the guard cannot silently go vacuous.

Test-only change; no pipeline behavior touched. `tests/test_mit_benchmark_integrity.py`: 221 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp)_