### PR TITLE
Update gig-work guard: CWS ran again in 2023; pin the corrected sentence

### DIFF
--- a/tests/test_uc_fact_corrections.py
+++ b/tests/test_uc_fact_corrections.py
@@ -91,12 +91,15 @@ class TestFactualCorrections:
         assert "mid-1970s" in t and "7 percent" in t
 
     def test_9_gig_work_sources(self):
-        """BLS publishes no such worker estimate (CWS last ran 2017); the
-        MIT/CEEPR revision ($3.37 -> $8.55-10) is noted; the
-        Uber-commissioned study is 2015 with a $16-30 median range."""
+        """BLS publishes no app-gig worker estimate; the ledger pass
+        found the CWS was fielded again in July 2023, so 'last ran
+        2017' was itself stale by the digest's 2026 date. The MIT/CEEPR
+        revision ($3.37 -> $8.55-10) is noted; the Uber-commissioned
+        study is 2015 with a $16-30 median range."""
         t = _digest(69)
         assert "Estimates from the Bureau of Labor Statistics" not in t
-        assert "contingent-worker survey in 2017" in t
+        assert "No official government count of gig workers exists" in t
+        assert "run in 2017 and again in 2023" in t
         assert "$3.37" in t and "revised the figure" in t
         assert "a 2014 study commissioned by Uber" not in t
         assert "a 2015 study commissioned by Uber" in t


### PR DESCRIPTION
Second and final stale-guard fix behind #1083 (which merged at the Maya Bay commit, a minute ahead of this one) — this fixes the `test` check currently red on `main`: `TestFactualCorrections::test_9_gig_work_sources`.

**What broke:** the group-N ledger verification found the BLS contingent-worker survey was fielded again in July 2023, so Ep69's "last ran 2017" framing was stale by the digest's own 2026 date. The digest now reads: the survey "run in 2017 and again in 2023, measures alternative work arrangements rather than app-based gig work". The WO-2 drift guard still pinned the retired "contingent-worker survey in 2017" phrasing.

**The fix:** the guard now pins the corrected sentence ("No official government count of gig workers exists" + "run in 2017 and again in 2023") and keeps every other assertion intact (no invented BLS estimate, the MIT/CEEPR $3.37 revision, the 2015 Uber study).

Test-only change. `tests/test_uc_fact_corrections.py`: 30 passed. This was the last data-driven failure in the CI ordering — the two guards ahead of it (disclosure markers, Maya Bay) are already fixed on `main` via #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp)_