### PR TITLE
Pipeline reliability: gate repair, topic cooldown, Nerra Daily before 6am PT

### DIFF
--- a/.github/workflows/nerra-daily.yml
+++ b/.github/workflows/nerra-daily.yml
@@ -12,7 +12,7 @@ name: Nerra Daily Edition
 # scripts/build_daily_edition.py exits 0 quietly until every show
 # expected that weekday has published — so the edition assembles minutes
 # after the LAST show of the morning lands. The scheduled sweeps are
-# late-day idempotent fallbacks: past 14:00 UTC the gate stops waiting
+# late-day idempotent fallbacks: past 12:00 UTC the gate stops waiting
 # for stragglers (a show that skipped its day would otherwise block the
 # edition forever) and builds with whatever published. Re-runs are free:
 # the committed summaries entry for the edition date is the idempotency
@@ -24,7 +24,11 @@ on:
     types: [completed]
   schedule:
     # Idempotent sweeps after the morning slate (GitHub cron is often
-    # hours late — fine, the gate handles it).
+    # hours late — fine, the gate handles it). The 12:23 sweep backs the
+    # force hour (12:00 UTC since the Aug 2026 land-by-6am-Pacific pass);
+    # the exact-time driver is the Cloudflare Worker's 12:07 UTC dispatch
+    # (workers/scheduler EDITION_DISPATCH).
+    - cron: '23 12 * * *'
     - cron: '23 14 * * *'
     - cron: '23 17 * * *'
   workflow_dispatch:

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -547,6 +547,32 @@ jobs:
           # can break a run.
           NERRA_SINGLE_PASS_RENDER: ${{ vars.NERRA_SINGLE_PASS_RENDER }}
 
+      - name: Commit topic-queue cooldown state (gate-block skips)
+        # A source_integrity_failed skip publishes nothing and the normal
+        # commit step is skipped — so the ONLY durable record that a topic
+        # blocked the gate is the queue annotation run_show wrote
+        # (gate_blocks / gate_blocked_last, engine/topic_queue.py).
+        # Without this commit the loop-breaker has amnesia and the same
+        # topic is re-picked every day (UC 2026-08-24/25: two lost days on
+        # one 403-heavy topic). Narrow by design: commits ONLY the
+        # shows/topic_queues/ path, best-effort, never fails the job.
+        if: always() && steps.pipeline.outputs.skipped == 'true'
+        run: |
+          if git diff --quiet -- shows/topic_queues/; then
+            echo "No topic-queue cooldown state to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add shows/topic_queues/
+          git commit -m "Topic-queue gate-block state: ${{ matrix.show }} $(date -u +%F)"
+          for i in 1 2 3 4; do
+            git pull --rebase origin main && git push origin main && exit 0
+            sleep $((2 ** i))
+          done
+          echo "::warning::Could not push topic-queue cooldown state (non-fatal; a rerun re-records it)"
+          exit 0
+
       - name: Validate output
         if: steps.pipeline.outputs.skipped != 'true'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,29 @@ remove leakage; the ledger carries provenance. Audit tools:
 (ex-`check_sources.py`) grades FEED health only — it has no view on
 truth. Drift guards: `tests/test_source_integrity.py`.
 
+**Aug 25 2026 — unreachable ≠ fabricated, plus two loop-breakers.** UC
+lost two days because its next topic's authoritative sources
+(officialgazette.gov.ph) 403 GitHub runners: the gate read "cannot
+fetch" as "fabricated", the queue-preserving skip re-picked the same
+topic daily, and nothing persisted the failure. Now: (1) verification
+labels 403/429/5xx/transport failures `unreachable` — **still a gate
+FAILURE** (the enforce contract is untouched), but distinct from the
+fabrication signature (404 / quote-not-found); (2) an enforce-mode
+block first gets ONE `attempt_claim_repair` pass (the model re-sources
+only the failed claims with fetchable alternatives — claim text and
+anchor are pinned, the repaired ledger re-runs the FULL mechanical
+gate, so repair can never launder an unverifiable claim); (3) a topic
+the gate blocks twice is **deferred by the picker**
+(`gate_blocks`/`gate_blocked_last` on the queue entry, committed by
+run-show.yml's skip-path step — the annotation is the only thing that
+survives a skip; threshold in
+`engine.topic_queue.GATE_BLOCK_DEFER_THRESHOLD`). Deferred topics stay
+in the queue for the operator and are surfaced by
+`queue_health()["gate_deferred"]`. Guards:
+`TestUnreachableClassification`, `TestClaimRepair`
+(`tests/test_source_integrity.py`), `TestGateBlockCooldown`
+(`tests/test_unintended_consequences.py`).
+
 ## Project Overview
 
 Automated daily podcast generation system running 17 shows via a unified
@@ -564,7 +587,9 @@ today's work, not just explain yesterday's):
   `scripts/build_daily_edition.py` + `engine/daily_edition.py`, workflow
   `.github/workflows/nerra-daily.yml` (workflow_run after each Run Podcast
   Show + ready gate: builds minutes after the last expected show lands;
-  ≥14:00 UTC sweeps build with whatever published; committed summaries
+  ≥12:00 UTC sweeps build with whatever published (12:00 force hour +
+  the scheduler Worker's 12:07 dispatch land straggler days ~5:40am PT
+  — Aug 2026 pass); committed summaries
   entry per date = idempotency key). **Each segment's baked-in outro tail
   (network sibling plug → surface plug → AI disclosure) is trimmed via
   the committed Whisper word timestamps** (`find_promo_cut` — fuzzy on

--- a/docs/nerra_daily.md
+++ b/docs/nerra_daily.md
@@ -100,10 +100,19 @@ develops Mira's editorial voice beyond announcing.
 - `workflow_run` after every "Run Podcast Show" completion + the
   `--when-ready` gate in `scripts/build_daily_edition.py`: the edition
   assembles minutes after the LAST show expected that weekday lands.
-- Scheduled sweeps (14:23 / 17:23 UTC) are idempotent fallbacks; past
-  14:00 UTC the gate stops waiting for stragglers (a show that
-  legitimately skipped would otherwise block the edition forever) and
-  builds with whatever published, refusing below 4 segments.
+- Scheduled sweeps (12:23 / 14:23 / 17:23 UTC) are idempotent
+  fallbacks; past **12:00 UTC** (was 14:00 — Aug 2026
+  land-by-6am-Pacific pass) the gate stops waiting for stragglers (a
+  show that legitimately skipped would otherwise block the edition
+  forever) and builds with whatever published, refusing below 4
+  segments. The punctual force driver is the Cloudflare scheduler
+  Worker's 12:07 UTC dispatch (`EDITION_DISPATCH` in
+  `workers/scheduler` — GitHub sweeps run hours late), so a straggler
+  day lands ~12:40 UTC = 5:40am PDT / 4:40am PST; a complete day still
+  assembles minutes after the last show (~10:30-11:00 UTC). A show
+  publishing between 12:00 and its old 14:00 window now misses the
+  edition — `metrics_ep*.json` `missing_expected` counts those, so the
+  hour can be revisited on data.
 - Idempotency key: the committed summaries entry for the edition date.
   Re-runs after a failed commit rebuild cleanly (the MP3 re-uploads to
   the same R2 key).

--- a/docs/reviews/ledger/unintended_consequences.yaml
+++ b/docs/reviews/ledger/unintended_consequences.yaml
@@ -77,4 +77,54 @@ reviews:
         evidence: null
     agent_cost_usd: null
 
+  - date: 2026-08-25
+    pr: null
+    doc: null
+    reviewer: claude-code (operator-directed outage forensics + pipeline fix)
+    summary: >-
+      UC published nothing 8/24-8/25: the source-integrity gate blocked
+      the Philippine land-reform topic both days (officialgazette.gov.ph
+      403s automated readers - six of eight claims on 8/24; statute pages
+      defeat the quote match), and the gate's queue-preserving skip
+      re-picked the same topic daily with no persisted state. The 16:56
+      audit retries died on an unrelated stale test guard (8/25) or
+      grok-4.6 APIConnectionError (8/24, first_principles).
+    shipped:
+      - >-
+        Gate labels 403/429/5xx/transport failures `unreachable` (still a
+        FAILURE - the enforce contract is untouched) distinct from the
+        fabrication signature (engine/claims.py).
+      - >-
+        One-shot claim repair before an enforce-mode block: the model
+        re-sources ONLY failed claims with fetchable alternatives (claim
+        text + anchor pinned), then the FULL mechanical gate re-runs.
+      - >-
+        Gate-block cooldown: record_gate_block() annotates the queue
+        entry (committed by run-show.yml's skip-path step); the picker
+        defers a topic at 2 blocks, loudly. queue_health gains
+        gate_deferred.
+      - >-
+        Philippine land-reform topic annotated gate_blocks: 2 so UC runs
+        its next topic (Brazil ethanol) immediately after merge.
+    deferred:
+      - >-
+        Re-clear the Philippine topic once the repair pass has a track
+        record (delete gate_blocks/gate_blocked_last to retry it).
+      - >-
+        grok-4.6 staged-trial signals for the 2026-09-01 readout: FPD
+        APIConnectionError retry death (8/24), UC digest truncation retry
+        + repetition warnings ("rice and corn" x5, "### segment" x6).
+    predictions:
+      - metric: "UC consecutive missed days from a single gate-blocked topic"
+        baseline: "2 (2026-08-24/25, same topic re-picked daily)"
+        expected: "max 2 by construction - the cooldown defers on the 2nd block; 0 missed days from this class over the next 30 days"
+        verdict: pending
+        evidence: null
+      - metric: "enforce-mode gate blocks recovered by claim repair (metrics: source_integrity_repair_succeeded)"
+        baseline: "0 (no repair path existed)"
+        expected: ">=1 recovery in the first 30 days of narrative episodes, with zero unverified claims shipped (gate contract intact)"
+        verdict: pending
+        evidence: null
+    agent_cost_usd: null
+
 do_not_retry: []

--- a/engine/claims.py
+++ b/engine/claims.py
@@ -437,6 +437,24 @@ def default_fetch(url: str) -> Tuple[int, str]:
     return resp.status_code, ""
 
 
+#: HTTP statuses that mean "this source could not be READ from our
+#: infrastructure", not "this source does not support the claim". A 403
+#: from a bot-blocking government site (officialgazette.gov.ph 403'd six
+#: of eight claims on UC Ep99, 2026-08-24, and took the show down for two
+#: days) says nothing about the citation's truth — unlike a 404 (the
+#: source does not exist: the fabrication signature) or a 200 whose body
+#: lacks the quote. Unreachable claims still FAIL the gate — the contract
+#: stays "nothing unverified ships" — but they are labelled so the repair
+#: pass can ask for a *fetchable* alternative source instead of treating
+#: the model as a fabricator.
+_UNREACHABLE_STATUSES = frozenset({401, 403, 407, 408, 425, 429,
+                                   500, 502, 503, 504, 522, 524})
+
+
+def _is_unreachable(status: Optional[int]) -> bool:
+    return status is None or status in _UNREACHABLE_STATUSES
+
+
 def verify_claim_sources(
     claims: List[dict],
     fetch: Optional[Callable[[str], Tuple[int, str]]] = None,
@@ -444,8 +462,11 @@ def verify_claim_sources(
     """Run the §2.2 source checks; return one result dict per claim.
 
     Each result: ``{"id", "url", "resolved", "quote_found", "passed",
-    "reason"}``. URLs are fetched once each (deduped) with one retry on
-    transport error. No model calls — HTTP + string matching only.
+    "unreachable", "reason"}``. URLs are fetched once each (deduped) with
+    one retry on transport error. No model calls — HTTP + string matching
+    only. ``unreachable`` marks fetch-blocked sources (403/429/5xx/
+    transport) — still a failure, but distinct from the fabrication
+    signature, and repairable with an alternative source.
     """
     if fetch is None:
         fetch = default_fetch
@@ -493,6 +514,7 @@ def verify_claim_sources(
             "resolved": resolved,
             "quote_found": quote_found,
             "passed": resolved and quote_found,
+            "unreachable": not resolved and _is_unreachable(status),
             "reason": reason,
         })
     return results
@@ -563,11 +585,14 @@ class GateResult:
     verified_claims: List[dict] = field(default_factory=list)
 
     def summary(self) -> str:
+        unreachable = sum(
+            1 for v in self.failed_verifications if v.get("unreachable"))
         return (
             f"ledger={'yes' if self.ledger_present else 'MISSING'} "
             f"claims={self.claims_total} anchored={self.claims_anchored} "
             f"verified={self.claims_verified} "
             f"failed_verifications={len(self.failed_verifications)} "
+            f"(unreachable_sources={unreachable}) "
             f"uncovered_citation_shapes={len(self.uncovered_shapes)}"
         )
 
@@ -647,6 +672,130 @@ def run_source_integrity_gate(
         or result.shape_errors
     )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Claim repair — one bounded chance to re-source failed claims
+# ---------------------------------------------------------------------------
+# Discovered 2026-08-25 (UC Ep99, two lost days): the gate blocked because
+# the topic's authoritative sources 403 GitHub's runner IPs and long
+# statute pages defeat the fuzzy quote match — the FACTS were never
+# disproven, the citations could not be READ. Repair asks the model, once,
+# to re-source ONLY the failed claims (same claim text, a different
+# fetchable source + verbatim quote), then re-verifies MECHANICALLY. The
+# gate's contract is untouched: nothing ships unless every claim traces to
+# a fetched, quote-matched source — repair just stops a bot-blocked
+# government site from reading as fabrication.
+
+REPAIR_MAX_CLAIMS = 10
+
+
+def build_repair_prompt(episode_text: str, failed: List[dict],
+                        claims: List[dict]) -> str:
+    """Prompt for the one-shot repair call. *failed* are verification
+    results; *claims* the original ledger entries (for claim text)."""
+    by_id = {str(c.get("id", "")): c for c in claims}
+    lines = []
+    for v in failed[:REPAIR_MAX_CLAIMS]:
+        cid = str(v.get("id", ""))
+        claim = by_id.get(cid, {})
+        why = ("the source could not be fetched from our verification "
+               "infrastructure (it may block automated readers)"
+               if v.get("unreachable")
+               else f"verification failed: {v.get('reason', 'unknown')}")
+        lines.append(
+            f"- id: {cid}\n"
+            f"  claim: {claim.get('claim', '')}\n"
+            f"  episode_span: {claim.get('episode_span', '')}\n"
+            f"  original_source: {v.get('url', '')}\n"
+            f"  problem: {why}"
+        )
+    return (
+        "Some claims in an episode's source ledger failed automated "
+        "verification. For EACH claim below, provide a replacement ledger "
+        "entry with a DIFFERENT source_url that (a) directly supports the "
+        "claim, (b) is publicly fetchable without login or bot-blocking "
+        "(prefer major encyclopedias, news organizations, .edu pages, "
+        "archived copies), and (c) a supporting_quote of 5-25 words copied "
+        "VERBATIM from that source's text. Keep the claim and episode_span "
+        "EXACTLY as given — only the sourcing changes. If you cannot find "
+        "a genuine source for a claim, omit it (an omitted claim blocks "
+        "publication — never invent a source).\n\n"
+        "Failed claims:\n" + "\n".join(lines) + "\n\n"
+        "Episode text (for context):\n---\n" + episode_text[:6000] + "\n---\n\n"
+        "Reply with ONLY a JSON array of objects with keys: id, claim, "
+        "episode_span, source_url, supporting_quote."
+    )
+
+
+def parse_repair_response(text: str) -> List[dict]:
+    """Extract the repair call's JSON array; [] on any shape problem."""
+    if not text:
+        return []
+    m = re.search(r"\[.*\]", text, re.DOTALL)
+    if not m:
+        return []
+    try:
+        data = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return []
+    return [e for e in data if isinstance(e, dict)]
+
+
+def attempt_claim_repair(
+    episode_text: str,
+    gate: GateResult,
+    claims: List[dict],
+    generate: Callable[[str], str],
+    fetch: Optional[Callable[[str], Tuple[int, str]]] = None,
+) -> Tuple[GateResult, List[dict]]:
+    """One bounded repair pass. Returns ``(new_gate_result, new_claims)``.
+
+    *generate* is the injected LLM call (prompt -> text). The repaired
+    ledger replaces failed entries with the model's re-sourced versions
+    (id-matched; a claim the model omitted stays failed), then the FULL
+    gate re-runs — anchoring, mechanical verification, and the lint all
+    apply to the repaired ledger exactly as to the original. Any error
+    returns the original result unchanged (repair can only help, never
+    mask)."""
+    if gate.passed or not gate.failed_verifications:
+        return gate, claims
+    try:
+        prompt = build_repair_prompt(
+            episode_text, gate.failed_verifications, claims)
+        replacements = parse_repair_response(generate(prompt))
+    except Exception as exc:  # noqa: BLE001 — repair is best-effort
+        logger.warning("claim repair call failed: %s", exc)
+        return gate, claims
+    if not replacements:
+        logger.info("claim repair produced no usable replacements")
+        return gate, claims
+
+    failed_ids = {str(v.get("id", "")) for v in gate.failed_verifications}
+    by_id = {str(r.get("id", "")): r for r in replacements
+             if str(r.get("id", "")) in failed_ids}
+    if not by_id:
+        return gate, claims
+    repaired: List[dict] = []
+    for claim in claims:
+        cid = str(claim.get("id", ""))
+        if cid in by_id:
+            replacement = dict(by_id[cid])
+            # The claim text and anchor are NOT the model's to rewrite in
+            # a repair — only the sourcing. Keep the originals.
+            replacement["claim"] = claim.get("claim", "")
+            replacement["episode_span"] = claim.get("episode_span", "")
+            replacement["id"] = cid
+            repaired.append(replacement)
+        else:
+            repaired.append(claim)
+    new_gate = run_source_integrity_gate(episode_text, repaired, fetch=fetch)
+    logger.info(
+        "claim repair: %d replacement(s) tried — gate now %s (%s)",
+        len(by_id), "PASSED" if new_gate.passed else "still failing",
+        new_gate.summary(),
+    )
+    return new_gate, repaired
 
 
 # ---------------------------------------------------------------------------

--- a/engine/topic_queue.py
+++ b/engine/topic_queue.py
@@ -33,6 +33,15 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+#: A topic whose episode the source-integrity gate has blocked this many
+#: times is DEFERRED by the picker (it stays in the queue, annotated, for
+#: the operator to prune or re-clear). Without this, the gate's
+#: queue-preserving skip turns one pathological topic into an indefinite
+#: outage: UC re-picked "the-philippine-land-reform-and" on 2026-08-24 AND
+#: -25 — its authoritative sources 403 GitHub runners, so the block was
+#: deterministic and the show simply stopped publishing.
+GATE_BLOCK_DEFER_THRESHOLD = 2
+
 
 def _load_queue(queue_path: Path) -> Dict[str, Any]:
     """Load a queue YAML. Empty dict on missing file (callers handle)."""
@@ -59,10 +68,24 @@ def pick_next_topic(queue_path: Path) -> Optional[Dict[str, Any]]:
     """
     data = _load_queue(queue_path)
     queue = data.get("queue", [])
+    deferred = 0
     for entry in queue:
         if not isinstance(entry, dict):
             continue
         if entry.get("produced") is True:
+            continue
+        if int(entry.get("gate_blocks") or 0) >= GATE_BLOCK_DEFER_THRESHOLD:
+            # Loop-breaker: the source-integrity gate has blocked this
+            # topic repeatedly — defer it so one bad topic can never take
+            # the show down indefinitely. Loud, never silent.
+            deferred += 1
+            logger.warning(
+                "Topic %r deferred: source-integrity gate blocked it %s "
+                "time(s) (last %s) — operator should re-source or prune it "
+                "in %s",
+                entry.get("id"), entry.get("gate_blocks"),
+                entry.get("gate_blocked_last", "?"), queue_path.name,
+            )
             continue
         # Defensive — make sure required fields are present.
         for required in ("id", "title", "brief"):
@@ -75,9 +98,10 @@ def pick_next_topic(queue_path: Path) -> Optional[Dict[str, Any]]:
         else:
             return dict(entry)  # shallow copy
     logger.warning(
-        "Topic queue %s: every topic has been produced. "
+        "Topic queue %s: every topic has been produced%s. "
         "Append new topics to keep the show running.",
         queue_path,
+        f" or gate-deferred ({deferred})" if deferred else "",
     )
     return None
 
@@ -200,6 +224,58 @@ def mark_topic_produced(
     return True
 
 
+def record_gate_block(queue_path: Path, topic_id: str,
+                      date_str: str) -> bool:
+    """Record that the source-integrity gate blocked *topic_id* today.
+
+    Increments the entry's ``gate_blocks`` counter and stamps
+    ``gate_blocked_last`` — the committed state the picker's defer
+    threshold reads (the skip path publishes nothing, so this annotation
+    is the ONLY thing that survives to the next day's fresh checkout;
+    run-show.yml commits it on gate-block skips). Idempotent per day: a
+    rerun on the same date does not double-count.
+
+    Returns True if the file changed."""
+    if not queue_path.exists():
+        logger.error("record_gate_block: queue file missing: %s", queue_path)
+        return False
+    with queue_path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    queue = data.get("queue", [])
+    blocks = 0
+    updated = False
+    for entry in queue:
+        if isinstance(entry, dict) and entry.get("id") == topic_id:
+            if str(entry.get("gate_blocked_last") or "") == date_str:
+                logger.info(
+                    "record_gate_block: %r already recorded for %s",
+                    topic_id, date_str)
+                return False
+            blocks = int(entry.get("gate_blocks") or 0) + 1
+            entry["gate_blocks"] = blocks
+            entry["gate_blocked_last"] = date_str
+            updated = True
+            break
+    if not updated:
+        logger.warning(
+            "record_gate_block: topic_id %r not found in %s",
+            topic_id, queue_path)
+        return False
+    with queue_path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(
+            data, fh,
+            allow_unicode=True,
+            sort_keys=False,
+            default_flow_style=False,
+            width=10000,
+        )
+    logger.warning(
+        "record_gate_block: %r now at %d gate block(s) (defer threshold %d)",
+        topic_id, blocks, GATE_BLOCK_DEFER_THRESHOLD,
+    )
+    return True
+
+
 def queue_health(queue_path: Path) -> Dict[str, int]:
     """Return ``{"total", "produced", "remaining"}`` for monitoring.
 
@@ -210,4 +286,17 @@ def queue_health(queue_path: Path) -> Dict[str, int]:
     queue = data.get("queue", [])
     total = len(queue)
     produced = sum(1 for e in queue if isinstance(e, dict) and e.get("produced") is True)
-    return {"total": total, "produced": produced, "remaining": total - produced}
+    gate_deferred = sum(
+        1 for e in queue
+        if isinstance(e, dict) and e.get("produced") is not True
+        and int(e.get("gate_blocks") or 0) >= GATE_BLOCK_DEFER_THRESHOLD
+    )
+    return {
+        "total": total,
+        "produced": produced,
+        "remaining": total - produced,
+        # Deferred topics still count in ``remaining`` (they are runway an
+        # operator can re-clear) but are surfaced separately so a queue
+        # full of gate-deferred topics doesn't read as healthy.
+        "gate_deferred": gate_deferred,
+    }

--- a/run_show.py
+++ b/run_show.py
@@ -2198,6 +2198,51 @@ def run(args: argparse.Namespace) -> None:
                     len(_si_gate.uncovered_shapes))
                 metrics.record("source_integrity_passed", _si_gate.passed)
                 metrics.record("source_integrity_enforced", _si_enforce)
+
+                # One bounded repair pass before an enforce-mode block
+                # (Aug 25 2026: UC lost two days because its topic's
+                # authoritative sources 403 GitHub runners — the gate read
+                # "cannot fetch" as "fabricated"). The model gets ONE
+                # chance to re-source the failed claims with fetchable
+                # alternatives; the repaired ledger then re-runs the FULL
+                # mechanical gate. Still failing => block, exactly as
+                # before — the enforce contract is untouched.
+                if (not _si_gate.passed and _si_enforce
+                        and _si_gate.failed_verifications):
+                    metrics.record("source_integrity_repair_attempted", True)
+                    logger.warning(
+                        "Source-integrity gate failing (%s) — attempting a "
+                        "one-shot claim repair before blocking",
+                        _si_gate.summary())
+
+                    def _repair_llm(prompt: str) -> str:
+                        from digests.xai_grok import grok_generate_text
+                        from engine.tracking import record_llm_usage
+                        text, _meta = grok_generate_text(
+                            prompt=prompt,
+                            model=getattr(config.llm, "model", "grok-4.3"),
+                            temperature=0.2, max_tokens=2000,
+                            timeout_seconds=300,
+                        )
+                        _usage = (_meta or {}).get("usage")
+                        record_llm_usage(
+                            tracker, "claim_repair",
+                            int(getattr(_usage, "prompt_tokens", 0) or 0),
+                            int(getattr(_usage, "completion_tokens", 0) or 0),
+                            model=str((_meta or {}).get("model")
+                                      or getattr(config.llm, "model", "")),
+                        )
+                        return text
+
+                    _si_gate, _si_claims = _si_mod.attempt_claim_repair(
+                        x_thread, _si_gate, _si_claims or [], _repair_llm)
+                    metrics.record(
+                        "source_integrity_repair_succeeded", _si_gate.passed)
+                    if _si_gate.passed:
+                        logger.info(
+                            "Claim repair recovered the episode: %s",
+                            _si_gate.summary())
+
                 if not _si_gate.passed:
                     logger.error(
                         "Source-integrity gate FAILED: %s", _si_gate.summary())
@@ -2212,6 +2257,27 @@ def run(args: argparse.Namespace) -> None:
                     for _e in _si_gate.shape_errors:
                         logger.error("  malformed ledger entry: %s", _e)
                     if _si_enforce:
+                        # Loop-breaker state: annotate the topic-queue
+                        # entry so tomorrow's picker can defer a topic the
+                        # gate keeps blocking (the skip preserves the
+                        # queue slot BY DESIGN, which made one 403-heavy
+                        # topic an indefinite outage — UC 2026-08-24/25).
+                        # run-show.yml commits the annotation on skip.
+                        if narrative_topic.get("id"):
+                            try:
+                                from engine.topic_queue import (
+                                    record_gate_block,
+                                )
+                                record_gate_block(
+                                    queue_path,
+                                    narrative_topic["id"],
+                                    today.isoformat(),
+                                )
+                            except Exception as _rb_exc:  # noqa: BLE001
+                                logger.warning(
+                                    "could not record gate block on topic "
+                                    "%r: %s",
+                                    narrative_topic.get("id"), _rb_exc)
                         save_usage(tracker, digests_dir)
                         _skip_episode(
                             "source_integrity_failed",

--- a/scripts/build_daily_edition.py
+++ b/scripts/build_daily_edition.py
@@ -69,8 +69,15 @@ logger = logging.getLogger("nerra_daily")
 
 #: After this UTC hour the gate stops waiting for missing shows and builds
 #: with whatever published (a show that legitimately skipped its day would
-#: otherwise hold the edition hostage forever).
-FORCE_BUILD_UTC_HOUR = 14
+#: otherwise hold the edition hostage forever). 12:00 UTC (was 14:00,
+#: Aug 2026 "land by 6am Pacific" pass): with the ~30 min build, a
+#: force-built edition lands ~12:40 UTC = 5:40am PDT / 4:40am PST — the
+#: old 14:00 hour put straggler days at ~8am PT. The trade (a show
+#: publishing 12:00-14:00 UTC now misses the edition) is measured by
+#: metrics_ep*.json ``missing_expected``; revisit the hour on that data.
+#: Punctual force trigger: workers/scheduler dispatches nerra-daily.yml
+#: at 12:07 UTC; the 12:23 GitHub sweep is the delayed fallback.
+FORCE_BUILD_UTC_HOUR = 12
 
 LINKS_MODEL = os.environ.get("NERRA_DAILY_LINKS_MODEL", "grok-4.3")
 

--- a/shows/topic_queues/unintended_consequences.yaml
+++ b/shows/topic_queues/unintended_consequences.yaml
@@ -692,6 +692,14 @@ queue:
   produced: false
   episode_number: null
   produced_date: null
+  # Gate-deferred 2026-08-25 (backfilled from the run logs): the source-
+  # integrity gate blocked this topic's episode on 8/24 AND 8/25 —
+  # officialgazette.gov.ph 403s automated readers and the statute pages
+  # defeat the quote match. The picker now defers it (gate_blocks >= 2).
+  # To retry: delete gate_blocks/gate_blocked_last (the claim-repair pass
+  # shipped alongside this annotation improves its odds).
+  gate_blocks: 2
+  gate_blocked_last: '2026-08-25'
 - id: brazil-s-ethanol-mandate-and
   title: Brazil's Ethanol Mandate and the Soybean Frontier
   brief: In the 1970s Brazil subsidized sugarcane ethanol to reduce oil imports and support domestic agriculture. Rising ethanol demand pushed sugarcane into prime pasture, displacing cattle ranchers northward into the Amazon where they cleared forest for new grazing. Deforestation rates accelerated in the 2000s even as ethanol production met its energy goals. The mechanism was an indirect land-use cascade rather than direct feedstock expansion.

--- a/tests/test_scheduling_punctuality.py
+++ b/tests/test_scheduling_punctuality.py
@@ -153,3 +153,36 @@ def test_audit_rss_limits_match_cron_cadence():
                 f"{show}: daily cadence but audit limit is {limit}h "
                 "(>120h) — a real outage would go unnoticed for days"
             )
+
+
+def test_edition_dispatch_slot():
+    """Nerra Daily's force-build must have an exact-time driver (Aug 2026
+    land-by-6am-Pacific pass): the Worker dispatches nerra-daily.yml at
+    12:07 UTC — a minute the existing cron trigger already covers — and
+    the edition's force hour sits just before it. Deliberately NOT a
+    SLOTS row (those parse as shows above)."""
+    m = re.search(
+        r"EDITION_DISPATCH = \{ hour: (\d+), minute: (\d+), "
+        r'workflow: "([\w.-]+)" \}', _TS)
+    assert m, "EDITION_DISPATCH missing from workers/scheduler"
+    hour, minute, workflow = int(m.group(1)), int(m.group(2)), m.group(3)
+    assert workflow == "nerra-daily.yml"
+    # The wrangler cron ("1,7,16,31,37,46 6-12 * * *") must cover the slot.
+    toml = (_ROOT / "workers" / "scheduler" / "wrangler.toml").read_text(
+        encoding="utf-8")
+    cron = re.search(r'crons = \["([^"]+)"\]', toml).group(1)
+    minutes, hours = cron.split()[0], cron.split()[1]
+    assert str(minute) in minutes.split(",")
+    lo, hi = hours.split("-")
+    assert int(lo) <= hour <= int(hi)
+    # The force hour precedes the dispatch, so the dispatched run builds.
+    build_src = (_ROOT / "scripts" / "build_daily_edition.py").read_text(
+        encoding="utf-8")
+    force = int(re.search(r"FORCE_BUILD_UTC_HOUR = (\d+)", build_src).group(1))
+    assert force <= hour
+    # 6am Pacific is 13:00 UTC in summer; force + ~30 min build must beat it.
+    assert force <= 12, "force hour past 12 UTC cannot land by 6am PDT"
+    # The GitHub sweep fallback for the force hour exists.
+    edition_wf = (_ROOT / ".github" / "workflows" / "nerra-daily.yml"
+                  ).read_text(encoding="utf-8")
+    assert f"- cron: '23 {force} * * *'" in edition_wf

--- a/tests/test_source_integrity.py
+++ b/tests/test_source_integrity.py
@@ -406,3 +406,133 @@ class TestDiagnosedFabricationsSoftened:
     def test_fabricated_citation_gone(self, filename, phrase):
         path = ROOT / "digests" / "unintended_consequences" / filename
         assert phrase not in path.read_text(encoding="utf-8")
+
+
+class TestUnreachableClassification:
+    """403/429/5xx/transport failures are 'source could not be READ', not
+    the fabrication signature (officialgazette.gov.ph 403'd six of eight
+    UC Ep99 claims, 2026-08-24, and took the show down for two days).
+    Still a gate FAILURE — the contract stays 'nothing unverified ships' —
+    but labelled so repair can ask for a fetchable alternative."""
+
+    def test_403_marks_unreachable_and_still_blocks(self):
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM],
+            fetch=_fetch_with("", status=403))
+        assert not gate.passed
+        assert gate.failed_verifications[0]["unreachable"] is True
+        assert "unreachable_sources=1" in gate.summary()
+
+    def test_404_is_not_unreachable(self):
+        # A source that says it does not exist IS the fabrication signal.
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=_fetch_dead)
+        assert not gate.passed
+        assert gate.failed_verifications[0]["unreachable"] is False
+
+    def test_transport_error_marks_unreachable(self):
+        def _boom(url):
+            raise OSError("connection refused")
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=_boom)
+        assert not gate.passed
+        assert gate.failed_verifications[0]["unreachable"] is True
+
+    def test_quote_mismatch_is_not_unreachable(self):
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM],
+            fetch=_fetch_with("entirely different text about markets"))
+        assert not gate.passed
+        assert gate.failed_verifications[0]["unreachable"] is False
+
+
+class TestClaimRepair:
+    """One bounded chance to re-source failed claims — the repaired ledger
+    re-runs the FULL mechanical gate, so repair can never launder an
+    unverifiable claim into publication."""
+
+    def _repaired_entry(self, url="https://example.edu/alt-source"):
+        return {
+            "id": "c1",
+            "claim": "IGNORED — repair may not rewrite the claim",
+            "episode_span": "IGNORED",
+            "source_url": url,
+            "source_title": "Alternative source",
+            "supporting_quote": GOOD_CLAIM["supporting_quote"],
+            "confidence": "high",
+        }
+
+    def _routed_fetch(self, good_url):
+        def _fetch(url):
+            if url == good_url:
+                return 200, f"<html>{GOOD_CLAIM['supporting_quote']}</html>"
+            return 403, ""
+        return _fetch
+
+    def test_repair_recovers_unreachable_claim(self):
+        from engine.claims import attempt_claim_repair
+
+        fetch = self._routed_fetch("https://example.edu/alt-source")
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=fetch)
+        assert not gate.passed
+
+        def generate(prompt):
+            assert "could not be fetched" in prompt
+            return json.dumps([self._repaired_entry()])
+
+        new_gate, new_claims = attempt_claim_repair(
+            EPISODE_WITH_CLAIM, gate, [GOOD_CLAIM], generate, fetch=fetch)
+        assert new_gate.passed
+        assert new_gate.claims_verified == 1
+        # Claim text + anchor are the ORIGINAL's — repair only re-sources.
+        assert new_claims[0]["claim"] == GOOD_CLAIM["claim"]
+        assert new_claims[0]["episode_span"] == GOOD_CLAIM["episode_span"]
+        assert new_claims[0]["source_url"] == "https://example.edu/alt-source"
+
+    def test_repair_with_bad_replacement_still_blocks(self):
+        from engine.claims import attempt_claim_repair
+
+        fetch = self._routed_fetch("https://example.edu/never-returned")
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=fetch)
+
+        def generate(prompt):
+            return json.dumps(
+                [self._repaired_entry(url="https://example.edu/still-403")])
+
+        new_gate, _ = attempt_claim_repair(
+            EPISODE_WITH_CLAIM, gate, [GOOD_CLAIM], generate, fetch=fetch)
+        assert not new_gate.passed
+
+    def test_repair_llm_garbage_returns_original(self):
+        from engine.claims import attempt_claim_repair
+
+        fetch = self._routed_fetch("https://example.edu/x")
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=fetch)
+        new_gate, new_claims = attempt_claim_repair(
+            EPISODE_WITH_CLAIM, gate, [GOOD_CLAIM],
+            lambda p: "no json here", fetch=fetch)
+        assert new_gate is gate and new_claims == [GOOD_CLAIM]
+
+    def test_repair_noop_on_passing_gate(self):
+        from engine.claims import attempt_claim_repair
+
+        fetch = _fetch_with(GOOD_CLAIM["supporting_quote"])
+        gate = run_source_integrity_gate(
+            EPISODE_WITH_CLAIM, [GOOD_CLAIM], fetch=fetch)
+        assert gate.passed
+
+        def generate(prompt):
+            raise AssertionError("repair must not call the LLM when passing")
+
+        new_gate, _ = attempt_claim_repair(
+            EPISODE_WITH_CLAIM, gate, [GOOD_CLAIM], generate, fetch=fetch)
+        assert new_gate.passed
+
+    def test_run_show_wires_repair_before_block(self):
+        # The enforce path must attempt repair before _skip_episode.
+        assert "attempt_claim_repair" in RUN_SHOW_SRC
+        assert RUN_SHOW_SRC.index("attempt_claim_repair") < RUN_SHOW_SRC.index(
+            '"source_integrity_failed"')

--- a/tests/test_unintended_consequences.py
+++ b/tests/test_unintended_consequences.py
@@ -357,3 +357,91 @@ def test_cron_entry_exists_for_unintended_consequences():
         "CRON_MAP entry for Unintended Consequences missing — show "
         "would fire but never run"
     )
+
+
+class TestGateBlockCooldown:
+    """Loop-breaker (Aug 25 2026): the source-integrity gate's skip
+    preserves the queue slot by design, which turned one 403-heavy topic
+    into an indefinite outage (UC re-picked the Philippine land-reform
+    topic on 8/24 AND 8/25 and published nothing either day). A topic the
+    gate has blocked GATE_BLOCK_DEFER_THRESHOLD times is deferred by the
+    picker — loudly, staying in the queue for the operator."""
+
+    def _queue(self, tmp_path: Path, first_extra=None):
+        queue_file = tmp_path / "q.yaml"
+        first = {"id": "hot", "title": "Hot topic", "brief": "sources 403",
+                 "category": "classic", "produced": False,
+                 "episode_number": None, "produced_date": None}
+        first.update(first_extra or {})
+        queue_file.write_text(yaml.safe_dump({
+            "queue": [
+                first,
+                {"id": "next", "title": "Next", "brief": "fine sources",
+                 "category": "tech", "produced": False,
+                 "episode_number": None, "produced_date": None},
+            ],
+        }))
+        return queue_file
+
+    def test_below_threshold_still_picked(self, tmp_path: Path):
+        from engine.topic_queue import pick_next_topic
+        queue_file = self._queue(tmp_path, {"gate_blocks": 1})
+        assert pick_next_topic(queue_file)["id"] == "hot"
+
+    def test_at_threshold_deferred(self, tmp_path: Path):
+        from engine.topic_queue import (
+            GATE_BLOCK_DEFER_THRESHOLD, pick_next_topic,
+        )
+        queue_file = self._queue(
+            tmp_path, {"gate_blocks": GATE_BLOCK_DEFER_THRESHOLD,
+                       "gate_blocked_last": "2026-08-25"})
+        assert pick_next_topic(queue_file)["id"] == "next"
+
+    def test_all_deferred_returns_none(self, tmp_path: Path):
+        from engine.topic_queue import pick_next_topic
+        queue_file = tmp_path / "q.yaml"
+        queue_file.write_text(yaml.safe_dump({
+            "queue": [
+                {"id": "hot", "title": "Hot", "brief": "blocked",
+                 "category": "classic", "produced": False, "gate_blocks": 2,
+                 "episode_number": None, "produced_date": None},
+            ],
+        }))
+        assert pick_next_topic(queue_file) is None
+
+    def test_record_gate_block_increments_and_is_idempotent_per_day(
+            self, tmp_path: Path):
+        from engine.topic_queue import pick_next_topic, record_gate_block
+        queue_file = self._queue(tmp_path)
+        assert record_gate_block(queue_file, "hot", "2026-08-24") is True
+        # Same-day rerun must not double-count.
+        assert record_gate_block(queue_file, "hot", "2026-08-24") is False
+        assert pick_next_topic(queue_file)["id"] == "hot"  # 1 < threshold
+        assert record_gate_block(queue_file, "hot", "2026-08-25") is True
+        data = yaml.safe_load(queue_file.read_text())
+        entry = data["queue"][0]
+        assert entry["gate_blocks"] == 2
+        assert entry["gate_blocked_last"] == "2026-08-25"
+        # Threshold reached -> deferred; the next topic runs.
+        assert pick_next_topic(queue_file)["id"] == "next"
+
+    def test_queue_health_surfaces_deferred(self, tmp_path: Path):
+        from engine.topic_queue import queue_health
+        queue_file = self._queue(tmp_path, {"gate_blocks": 2})
+        health = queue_health(queue_file)
+        assert health["remaining"] == 2
+        assert health["gate_deferred"] == 1
+
+    def test_run_show_records_block_before_skip(self):
+        src = (Path(__file__).resolve().parent.parent / "run_show.py").read_text(
+            encoding="utf-8")
+        assert "record_gate_block" in src
+        assert src.index("record_gate_block") < src.index(
+            '"source_integrity_failed"')
+
+    def test_workflow_commits_cooldown_state_on_skip(self):
+        wf = (Path(__file__).resolve().parent.parent / ".github" / "workflows"
+              / "run-show.yml").read_text(encoding="utf-8")
+        assert "Commit topic-queue cooldown state" in wf
+        assert "steps.pipeline.outputs.skipped == 'true'" in wf
+        assert "git add shows/topic_queues/" in wf

--- a/workers/scheduler/src/index.ts
+++ b/workers/scheduler/src/index.ts
@@ -14,6 +14,17 @@ interface Env {
 const REPO = "Planetterrian/nerranetwork";
 const WORKFLOW = "run-show.yml";
 
+// Nerra Daily edition force-dispatch (Aug 2026, "land by 6am Pacific"):
+// the edition's when-ready gate stops waiting for stragglers at
+// FORCE_BUILD_UTC_HOUR (12:00 UTC, scripts/build_daily_edition.py), but
+// its GitHub sweep crons are as late as any other — on 2026-08-24/25 the
+// 14:23 sweep ran 15:07/15:13 and the edition landed ~8am PT. This slot
+// fires nerra-daily.yml at 12:07 UTC sharp (a minute the wrangler cron
+// already covers), so a straggler day still assembles by ~12:40 UTC =
+// 5:40am PDT / 4:40am PST. Deliberately an OBJECT, not a SLOTS row —
+// tests/test_scheduling_punctuality.py parses SLOTS rows as shows.
+const EDITION_DISPATCH = { hour: 12, minute: 7, workflow: "nerra-daily.yml" };
+
 // [utcHour, utcMinute, show, dayFilter]
 const SLOTS: Array<[number, number, string, string | null]> = [
   [6, 7,  "privet_russian",          "monday"],
@@ -53,9 +64,14 @@ function dayFilterPasses(filter: string | null, now: Date): boolean {
   }
 }
 
-async function dispatch(env: Env, show: string): Promise<void> {
+async function dispatchWorkflow(
+  env: Env,
+  workflow: string,
+  inputs: Record<string, string>,
+  label: string,
+): Promise<void> {
   const res = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/dispatches`,
+    `https://api.github.com/repos/${REPO}/actions/workflows/${workflow}/dispatches`,
     {
       method: "POST",
       headers: {
@@ -64,19 +80,32 @@ async function dispatch(env: Env, show: string): Promise<void> {
         "User-Agent": "nerra-scheduler",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ ref: "main", inputs: { show } }),
+      body: JSON.stringify({ ref: "main", inputs }),
     },
   );
   if (res.status !== 204) {
     const body = await res.text();
-    throw new Error(`workflow_dispatch for ${show} failed: ${res.status} ${body}`);
+    throw new Error(`workflow_dispatch for ${label} failed: ${res.status} ${body}`);
   }
-  console.log(`Dispatched ${show}`);
+  console.log(`Dispatched ${label}`);
+}
+
+async function dispatch(env: Env, show: string): Promise<void> {
+  await dispatchWorkflow(env, WORKFLOW, { show }, show);
 }
 
 export default {
   async scheduled(controller: ScheduledController, env: Env): Promise<void> {
     const now = new Date(controller.scheduledTime);
+    if (
+      now.getUTCHours() === EDITION_DISPATCH.hour &&
+      now.getUTCMinutes() === EDITION_DISPATCH.minute
+    ) {
+      // The edition workflow's own gate decides whether there is anything
+      // to build (already-published days no-op on the fast gate).
+      await dispatchWorkflow(env, EDITION_DISPATCH.workflow, {}, "nerra-daily");
+      return;
+    }
     const slot = SLOTS.find(
       ([h, m]) => h === now.getUTCHours() && m === now.getUTCMinutes(),
     );


### PR DESCRIPTION
## TLDR

Implements the fixes from the UC outage forensics plus the land-Nerra-Daily-by-6am-Pacific structure. Root causes being fixed: UC published nothing on 8/24–8/25 because the source-integrity gate blocked its next topic both days (`officialgazette.gov.ph` 403s automated readers — the gate read "cannot fetch" as "fabricated"), the queue-preserving skip re-picked the same topic daily with no persisted state, and Nerra Daily's force-built editions were landing ~8am PT.

## What shipped

**1. Gate: unreachable ≠ fabricated** (`engine/claims.py`). Verification labels 403/429/5xx/transport failures `unreachable` — **still a gate failure** (the enforce contract from the provenance pass is untouched: nothing unverified ships), but distinct from the fabrication signature (404 / quote-not-found). The split appears in `summary()` and metrics.

**2. One-shot claim repair before an enforce-mode block** (`engine/claims.py::attempt_claim_repair`, wired in `run_show.py`). The model gets one bounded chance to re-source *only* the failed claims with fetchable alternatives — claim text and `episode_span` are pinned (repair may not rewrite the claim, only the sourcing) — then the **full mechanical gate re-runs** on the repaired ledger: anchoring, HTTP fetch, fuzzy quote match, and the lint. Repair can never launder an unverifiable claim; a still-failing gate blocks exactly as before. Metrics: `source_integrity_repair_attempted/succeeded`; the repair call's tokens are tracked as `claim_repair`.

**3. Gate-block cooldown loop-breaker** (`engine/topic_queue.py` + `run_show.py` + `run-show.yml`). On a `source_integrity_failed` skip, `record_gate_block()` annotates the queue entry (`gate_blocks`/`gate_blocked_last`, idempotent per day), and a new narrow workflow step commits **only `shows/topic_queues/`** on gate-block skips — the annotation is the only state that survives a skip. `pick_next_topic` defers a topic at 2 blocks (loudly; the entry stays in the queue for you to prune or re-clear), and `queue_health()` surfaces `gate_deferred` so a queue full of deferred topics can't read as healthy runway.

**4. UC unblocked now.** The Philippine land-reform topic is annotated `gate_blocks: 2` (backfilled from the run logs) with a comment explaining how to re-clear it — on merge, UC's next run picks **"Brazil's Ethanol Mandate and the Soybean Frontier"** (verified locally). To retry the Philippine topic later, delete the two annotation keys; the repair pass improves its odds.

**5. Nerra Daily lands before 6am Pacific.** `FORCE_BUILD_UTC_HOUR` 14 → 12 (`scripts/build_daily_edition.py`), a 12:23 UTC sweep cron in `nerra-daily.yml`, and an exact-time `EDITION_DISPATCH` slot in `workers/scheduler` (12:07 UTC — a minute the existing wrangler cron already covers, so **no wrangler.toml change**) dispatching `nerra-daily.yml`. Straggler days now land ~12:40 UTC = **5:40am PDT / 4:40am PST**; complete days already land ~4am PT via the workflow_run trigger. The trade — a show publishing 12:00–14:00 UTC now misses the edition — is counted by `metrics_ep*.json` `missing_expected`, so the hour can be revisited on data. The dispatch is deliberately an object literal, not a `SLOTS` row (the punctuality test parses `SLOTS` rows as shows).

Docs: CLAUDE.md (provenance + NDaily sections), `docs/nerra_daily.md`; ledger entry with scoreable predictions in `docs/reviews/ledger/unintended_consequences.yaml`.

## ⚠️ A/B-listen required (landmine #17)

**None.** No prompt files, TTS settings, or audio-affecting code changed. The claim-repair prompt is pipeline-internal (its output is a JSON ledger, never spoken); the gate/queue/scheduling changes are pipeline-side only.

## Operator items

- **Deploy the scheduler Worker** if it isn't live — the 12:07 edition dispatch and the show slots both ride it (`workers/scheduler` README: `wrangler secret put GITHUB_DISPATCH_TOKEN` + `wrangler deploy`). Yesterday's timing pattern (all shows ~1h late, offshore_north 7h late) indicates the Worker is not currently firing; without it, the 12:23/14:23 GitHub sweeps still work but run late.
- The grok-4.6 staged trial's Sept 1 readout should weigh: FPD's `APIConnectionError` retry death (8/24) and UC's digest truncation-retry + repetition warnings ("rice and corn" ×5) on 4.6.

## Test results

- `test_source_integrity.py` — **63 passed** (+9 new: `TestUnreachableClassification`, `TestClaimRepair`)
- `test_unintended_consequences.py` — **26 passed** (+7 new: `TestGateBlockCooldown`)
- `test_scheduling_punctuality.py` — **8 passed** (+1 new: `test_edition_dispatch_slot`; SLOTS↔CRON_MAP sync intact)
- Full affected + smoke batch (`test_daily_edition`, `test_review_agent`, `test_queue_restock`, `test_skip_markers`, `test_citation_shapes`, `test_pipeline_safety`, `test_prompt_fidelity`, `test_generator`, `test_episode_validity`, `test_config`, `test_schedule`) — **485 passed, 2 skipped**

## Predictions (ledger-tracked)

- UC misses at most 2 consecutive days from any single gate-blocked topic *by construction*; 0 missed days from this class over the next 30 days.
- ≥1 enforce-mode block recovered by claim repair in the first 30 days of narrative episodes, with zero unverified claims shipped.
- Nerra Daily landing time: every edition ≤ 13:00 UTC (6am PDT) once the Worker is deployed; force-built days ~12:40 UTC.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYQGYUppYc1N8h9g5xHx11)_