### PR TITLE
Nerra Personal: deliver the Stripe links to every page build

### DIFF
--- a/.github/workflows/nightly-maintenance.yml
+++ b/.github/workflows/nightly-maintenance.yml
@@ -236,6 +236,14 @@ jobs:
           GOOGLE_ADS_ID: ${{ secrets.GOOGLE_ADS_ID }}
           GOOGLE_ADS_SIGNUP_LABEL: ${{ secrets.GOOGLE_ADS_SIGNUP_LABEL }}
           PLAUSIBLE_DOMAIN: ${{ secrets.PLAUSIBLE_DOMAIN }}
+          # Nerra Personal + donations: the four live Stripe Payment
+          # Links (public URLs — they render into join/support pages).
+          # Repo variables override these committed defaults so the
+          # operator can rotate links without a commit.
+          STRIPE_LINK_PERSONAL: ${{ vars.STRIPE_LINK_PERSONAL || 'https://buy.stripe.com/8x26oI4Ho7Lc6Qa1VB0Ba00' }}
+          STRIPE_LINK_PERSONAL_LOCAL: ${{ vars.STRIPE_LINK_PERSONAL_LOCAL || 'https://buy.stripe.com/dRm6oI7TAfdEgqK9o30Ba01' }}
+          STRIPE_LINK_DONATE_MONTHLY: ${{ vars.STRIPE_LINK_DONATE_MONTHLY || 'https://buy.stripe.com/7sYcN61vc6H8b6q1VB0Ba02' }}
+          STRIPE_LINK_DONATE_ONCE: ${{ vars.STRIPE_LINK_DONATE_ONCE || 'https://donate.stripe.com/dRm8wQ8XEd5weiC0Rx0Ba03' }}
         run: |
           python generate_html.py --show modern_investing
           python generate_html.py --show tesla

--- a/.github/workflows/run-show.yml
+++ b/.github/workflows/run-show.yml
@@ -636,6 +636,14 @@ jobs:
           GOOGLE_ADS_ID: ${{ secrets.GOOGLE_ADS_ID }}
           GOOGLE_ADS_SIGNUP_LABEL: ${{ secrets.GOOGLE_ADS_SIGNUP_LABEL }}
           PLAUSIBLE_DOMAIN: ${{ secrets.PLAUSIBLE_DOMAIN }}
+          # Nerra Personal + donations: the four live Stripe Payment
+          # Links (public URLs — they render into join/support pages).
+          # Repo variables override these committed defaults so the
+          # operator can rotate links without a commit.
+          STRIPE_LINK_PERSONAL: ${{ vars.STRIPE_LINK_PERSONAL || 'https://buy.stripe.com/8x26oI4Ho7Lc6Qa1VB0Ba00' }}
+          STRIPE_LINK_PERSONAL_LOCAL: ${{ vars.STRIPE_LINK_PERSONAL_LOCAL || 'https://buy.stripe.com/dRm6oI7TAfdEgqK9o30Ba01' }}
+          STRIPE_LINK_DONATE_MONTHLY: ${{ vars.STRIPE_LINK_DONATE_MONTHLY || 'https://buy.stripe.com/7sYcN61vc6H8b6q1VB0Ba02' }}
+          STRIPE_LINK_DONATE_ONCE: ${{ vars.STRIPE_LINK_DONATE_ONCE || 'https://donate.stripe.com/dRm8wQ8XEd5weiC0Rx0Ba03' }}
         run: |
           # Regenerate show page (static episodes) + blog posts for this show
           python generate_html.py --show ${{ matrix.show }} --blogs
@@ -857,6 +865,14 @@ jobs:
           GOOGLE_ADS_ID: ${{ secrets.GOOGLE_ADS_ID }}
           GOOGLE_ADS_SIGNUP_LABEL: ${{ secrets.GOOGLE_ADS_SIGNUP_LABEL }}
           PLAUSIBLE_DOMAIN: ${{ secrets.PLAUSIBLE_DOMAIN }}
+          # Nerra Personal + donations: the four live Stripe Payment
+          # Links (public URLs — they render into join/support pages).
+          # Repo variables override these committed defaults so the
+          # operator can rotate links without a commit.
+          STRIPE_LINK_PERSONAL: ${{ vars.STRIPE_LINK_PERSONAL || 'https://buy.stripe.com/8x26oI4Ho7Lc6Qa1VB0Ba00' }}
+          STRIPE_LINK_PERSONAL_LOCAL: ${{ vars.STRIPE_LINK_PERSONAL_LOCAL || 'https://buy.stripe.com/dRm6oI7TAfdEgqK9o30Ba01' }}
+          STRIPE_LINK_DONATE_MONTHLY: ${{ vars.STRIPE_LINK_DONATE_MONTHLY || 'https://buy.stripe.com/7sYcN61vc6H8b6q1VB0Ba02' }}
+          STRIPE_LINK_DONATE_ONCE: ${{ vars.STRIPE_LINK_DONATE_ONCE || 'https://donate.stripe.com/dRm8wQ8XEd5weiC0Rx0Ba03' }}
           # R2 read creds for the gallery-manifest rebuild (clean no-op
           # when unset — the builder writes an empty manifest).
           R2_GALLERY_BUCKET: ${{ secrets.R2_GALLERY_BUCKET }}


### PR DESCRIPTION
Closes the last code-side gap in the Nerra Personal launch chain.

**What was wrong:** the four live Payment Links exist in Stripe (verified via the connected account: correct `tier`/`kind` metadata, /account.html redirects, webhook endpoint enabled with both events) and `generate_html` reads `STRIPE_LINK_*` — but **no workflow ever passed those variables**, so `join.html` and `support.html` rendered "Launching soon" on every rebuild, and checklist step 7 could never take effect.

**The fix:** the three site-regen env blocks (nightly maintenance + run-show finalize + per-show regen) now carry the four links as committed defaults with repo-variable override (`${{ vars.STRIPE_LINK_* || '<live link>' }}`) — rotating a link needs no commit, and the links are public by design (they render into the public pages).

**Verified by template render**: join carries both membership links, support carries both donation links, no launching-soon state. YAML validated; scheduling/schedule suites green.

After merge, the next nightly (or a manual nightly dispatch) publishes the live pages with full marketing env intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01A898v2jsxZ82urWy94jxVp)_