### PR TITLE
Books: stop publishing the paid product for free

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -111,8 +111,16 @@ jobs:
       - name: Verify built artifacts are live
         # The compiler tests above pass whether or not the run built
         # anything (they did, on the zero-output run of 2026-08-22).
-        # This step asserts what the run claims: catalog files exist and
-        # every R2 object answers 200.
+        # This step asserts what the run claims: public assets answer
+        # 200, and the paid masters exist in the private bucket.
+        env:
+          # Needed since 2026-08-26: the epub and m4b are r2:// refs into
+          # the private bucket, so verifying them is a credentialed
+          # head_object, not an anonymous HEAD. Without these the check
+          # soft-passes and stops being a check.
+          R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           NOAUDIO=""
           if [ "${{ github.event.inputs.skip_audio }}" = "true" ]; then

--- a/books/catalog.json
+++ b/books/catalog.json
@@ -84,10 +84,10 @@
         "estimated_cost_usd": 2.95
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/first_principles_collected/first_principles_collected.epub",
+        "epub": "r2://nerra-books/books/first_principles_collected/first_principles_collected.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/first_principles_collected/first_principles_collected_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/first_principles_collected/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/first_principles_collected/first_principles_collected.m4b"
+        "m4b": "r2://nerra-books/books/first_principles_collected/first_principles_collected.m4b"
       },
       "audiobook": {
         "duration_seconds": 26438,
@@ -141,10 +141,10 @@
         "estimated_cost_usd": 1.05
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/first_principles_vol1/first_principles_vol1.epub",
+        "epub": "r2://nerra-books/books/first_principles_vol1/first_principles_vol1.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/first_principles_vol1/first_principles_vol1_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/first_principles_vol1/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/first_principles_vol1/first_principles_vol1.m4b"
+        "m4b": "r2://nerra-books/books/first_principles_vol1/first_principles_vol1.m4b"
       },
       "audiobook": {
         "duration_seconds": 7758,
@@ -198,10 +198,10 @@
         "estimated_cost_usd": 1.05
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/first_principles_vol2/first_principles_vol2.epub",
+        "epub": "r2://nerra-books/books/first_principles_vol2/first_principles_vol2.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/first_principles_vol2/first_principles_vol2_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/first_principles_vol2/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/first_principles_vol2/first_principles_vol2.m4b"
+        "m4b": "r2://nerra-books/books/first_principles_vol2/first_principles_vol2.m4b"
       },
       "audiobook": {
         "duration_seconds": 9885,
@@ -255,10 +255,10 @@
         "estimated_cost_usd": 1.05
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/first_principles_vol3/first_principles_vol3.epub",
+        "epub": "r2://nerra-books/books/first_principles_vol3/first_principles_vol3.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/first_principles_vol3/first_principles_vol3_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/first_principles_vol3/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/first_principles_vol3/first_principles_vol3.m4b"
+        "m4b": "r2://nerra-books/books/first_principles_vol3/first_principles_vol3.m4b"
       },
       "audiobook": {
         "duration_seconds": 9651,
@@ -365,10 +365,10 @@
         "estimated_cost_usd": 3.7
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/unintended_consequences_collected/unintended_consequences_collected.epub",
+        "epub": "r2://nerra-books/books/unintended_consequences_collected/unintended_consequences_collected.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/unintended_consequences_collected/unintended_consequences_collected_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/unintended_consequences_collected/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/unintended_consequences_collected/unintended_consequences_collected.m4b"
+        "m4b": "r2://nerra-books/books/unintended_consequences_collected/unintended_consequences_collected.m4b"
       },
       "audiobook": {
         "duration_seconds": 24069,
@@ -421,10 +421,10 @@
         "estimated_cost_usd": 1.0
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol1/unintended_consequences_vol1.epub",
+        "epub": "r2://nerra-books/books/unintended_consequences_vol1/unintended_consequences_vol1.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol1/unintended_consequences_vol1_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/unintended_consequences_vol1/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/unintended_consequences_vol1/unintended_consequences_vol1.m4b"
+        "m4b": "r2://nerra-books/books/unintended_consequences_vol1/unintended_consequences_vol1.m4b"
       },
       "audiobook": {
         "duration_seconds": 6563,
@@ -477,10 +477,10 @@
         "estimated_cost_usd": 1.0
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol2/unintended_consequences_vol2.epub",
+        "epub": "r2://nerra-books/books/unintended_consequences_vol2/unintended_consequences_vol2.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol2/unintended_consequences_vol2_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/unintended_consequences_vol2/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/unintended_consequences_vol2/unintended_consequences_vol2.m4b"
+        "m4b": "r2://nerra-books/books/unintended_consequences_vol2/unintended_consequences_vol2.m4b"
       },
       "audiobook": {
         "duration_seconds": 5995,
@@ -532,10 +532,10 @@
         "estimated_cost_usd": 0.95
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol3/unintended_consequences_vol3.epub",
+        "epub": "r2://nerra-books/books/unintended_consequences_vol3/unintended_consequences_vol3.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol3/unintended_consequences_vol3_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/unintended_consequences_vol3/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/unintended_consequences_vol3/unintended_consequences_vol3.m4b"
+        "m4b": "r2://nerra-books/books/unintended_consequences_vol3/unintended_consequences_vol3.m4b"
       },
       "audiobook": {
         "duration_seconds": 5592,
@@ -586,10 +586,10 @@
         "estimated_cost_usd": 0.9
       },
       "files": {
-        "epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol4/unintended_consequences_vol4.epub",
+        "epub": "r2://nerra-books/books/unintended_consequences_vol4/unintended_consequences_vol4.epub",
         "sample_epub": "https://audio.nerranetwork.com/books/unintended_consequences_vol4/unintended_consequences_vol4_sample.epub",
         "cover": "https://audio.nerranetwork.com/books/unintended_consequences_vol4/cover.png",
-        "m4b": "https://audio.nerranetwork.com/books/unintended_consequences_vol4/unintended_consequences_vol4.m4b"
+        "m4b": "r2://nerra-books/books/unintended_consequences_vol4/unintended_consequences_vol4.m4b"
       },
       "audiobook": {
         "duration_seconds": 6043,

--- a/docs/books.md
+++ b/docs/books.md
@@ -176,9 +176,34 @@ each at submission time.
    (192k CBR 44.1kHz mono).
 6. **Direct on nerranetwork.com** — /books.html lists volumes with buy
    buttons + the free sample EPUB (email-capture lead magnet). Direct
-   *sales* (Stripe/Gumroad checkout delivering the EPUB/M4B) are the
-   Gallery-Pro payment-rail work item — when that rail exists, books
-   plug into it; until then the page routes to the stores.
+   *sales* go through Payhip as merchant-of-record (see "Direct sales"
+   below): Payhip holds its own copy of the EPUB/M4B and delivers it to
+   the buyer, so the network never serves the paid files itself.
+
+## Where the artifacts live (two buckets, on purpose)
+
+| Artifact | Bucket | Reachable by |
+|---|---|---|
+| `cover.png`, `<id>_sample.epub` | `podcast-audio` (public, audio.nerranetwork.com) | anyone — these are the marketing assets |
+| `<id>.epub`, `<id>.m4b`, `audio/track_*.mp3` | `nerra-books` (private, no public hostname) | credentialed clients only |
+
+The catalog records public assets as https URLs and paid masters as
+`r2://nerra-books/<key>` references — a location, not a promise that
+anyone can fetch it. `scripts/verify_book_catalog.py` checks the first
+kind with an HTTP HEAD and the second with `head_object`, and fails the
+build if a paid master ever carries an https URL again.
+
+**Why the split exists.** Until 2026-08-26 everything went to the public
+bucket and every URL was committed to `books/catalog.json` in this
+*public* repo: 596 objects, 3.1 GB — nine volumes of finished EPUBs,
+audiobooks and per-chapter masters, free to anyone who opened the JSON,
+months before the first one went on sale. The lost sales were the
+smaller half of the problem: Amazon price-matches against a cheaper copy
+found anywhere else and then pays 70% of the *matched* price, so a
+single public master can zero out KDP royalties across the whole
+catalogue. Drift guards:
+`tests/test_book_compiler.py::TestBuildPipelineIntegrity::test_paid_masters_are_never_published_at_a_public_url`
+and its sibling that reads `build_book.py` itself.
 
 Pricing guidance (from the product doc's market research): $4.99–6.99
 ebook, $9.99–14.99 audiobook. The audiobook's unit economics are absurd

--- a/scripts/build_book.py
+++ b/scripts/build_book.py
@@ -67,22 +67,50 @@ logger = logging.getLogger("build_book")
 OUT_ROOT = ROOT / "outputs" / "books"
 
 
-def _r2_upload(local: Path, key: str, content_type: str) -> str:
+def _r2_upload(local: Path, key: str, content_type: str, *,
+               private: bool = False) -> str:
+    """Upload one artifact and return the reference the catalog records.
+
+    The books keyspace spans TWO buckets, and which one a file lands in
+    is a commercial decision, not a technical one:
+
+    * **public** (``podcast-audio``, https://audio.nerranetwork.com) —
+      ``cover.png`` and the sample EPUB. Marketing assets: the cover
+      feeds /books.html, the sample is the email-capture lead magnet.
+      These return ordinary https URLs.
+    * **private** (``nerra-books``, no public hostname) — the full EPUB,
+      the M4B, and the per-chapter narration masters. This is the PAID
+      product. Buyers receive it from the store they bought it at
+      (Payhip is merchant-of-record for direct sales); the network never
+      serves it. These return an ``r2://bucket/key`` reference, which
+      says where the master lives without implying anyone can fetch it.
+
+    Until 2026-08-26 every artifact went to the public bucket and its URL
+    was committed to ``books/catalog.json`` in a PUBLIC repo: 596
+    objects, 3.1 GB, the entire paid catalogue free to anyone who opened
+    the JSON. The lost sales are the smaller half. Amazon price-matches
+    against a cheaper copy found elsewhere and then pays 70% of the
+    MATCHED price, so one public master can zero out KDP royalties
+    across every volume at once — which is why docs/books.md's first
+    operating rule is never to undercut retail.
+    """
     from engine.storage import upload_to_r2
 
-    return upload_to_r2(
+    bucket = _books_private_bucket() if private else _books_bucket()
+    url = upload_to_r2(
         local, key,
-        # Same bucket + public host the podcast enclosures use, but under
-        # the books/ keyspace — never inside a show's audio prefix.
-        bucket=os.getenv("R2_BOOKS_BUCKET", "podcast-audio").strip(),
+        bucket=bucket,
         endpoint_url=os.getenv("R2_ENDPOINT_URL", "").strip(),
         access_key=os.getenv("R2_ACCESS_KEY_ID", "").strip(),
         secret_key=os.getenv("R2_SECRET_ACCESS_KEY", "").strip(),
-        public_base_url=os.getenv(
+        # A private bucket has no public host; passing one would mint a
+        # URL that 404s and read like a promise the bucket cannot keep.
+        public_base_url="" if private else os.getenv(
             "R2_BOOKS_PUBLIC_BASE_URL",
             "https://audio.nerranetwork.com").strip(),
         content_type=content_type,
     )
+    return f"r2://{bucket}/{key}" if private else url
 
 
 def _have_r2() -> bool:
@@ -116,7 +144,14 @@ def _r2_client():
 
 
 def _books_bucket() -> str:
+    """Public bucket: covers and samples only."""
     return os.getenv("R2_BOOKS_BUCKET", "podcast-audio").strip()
+
+
+def _books_private_bucket() -> str:
+    """Private bucket holding the paid masters. Created 2026-08-26 with
+    public access disabled; nothing serves out of it."""
+    return os.getenv("R2_BOOKS_PRIVATE_BUCKET", "nerra-books").strip()
 
 
 def _restore_audio_cache(volume, audio_dir: Path) -> int:
@@ -132,12 +167,14 @@ def _restore_audio_cache(volume, audio_dir: Path) -> int:
         s3 = _r2_client()
         paginator = s3.get_paginator("list_objects_v2")
         audio_dir.mkdir(parents=True, exist_ok=True)
-        for page in paginator.paginate(Bucket=_books_bucket(), Prefix=prefix):
+        for page in paginator.paginate(Bucket=_books_private_bucket(),
+                                       Prefix=prefix):
             for obj in page.get("Contents", []):
                 name = obj["Key"].rsplit("/", 1)[-1]
                 local = audio_dir / name
                 if name.startswith("track_") and not local.exists():
-                    s3.download_file(_books_bucket(), obj["Key"], str(local))
+                    s3.download_file(_books_private_bucket(),
+                                     obj["Key"], str(local))
                     restored += 1
     except Exception as exc:  # noqa: BLE001 — cache is never build-fatal
         logger.warning("audio cache restore failed (continuing cold): %s",
@@ -150,8 +187,9 @@ def _restore_audio_cache(volume, audio_dir: Path) -> int:
 def _persist_audio_cache(volume, audio_dir: Path) -> None:
     """Push narrated tracks + hash sidecars to R2. Doubles as the
     per-chapter MP3 delivery for audiobook-store submission (Spotify's
-    ingest wants chapterized MP3s — they now live at
-    books/<id>/audio/track_NNN.mp3)."""
+    ingest wants chapterized MP3s — they live at
+    books/<id>/audio/track_NNN.mp3 in the PRIVATE bucket, and are handed
+    to an aggregator by upload, never by URL)."""
     if not _have_r2() or not audio_dir.exists():
         return
     try:
@@ -159,7 +197,7 @@ def _persist_audio_cache(volume, audio_dir: Path) -> None:
             ctype = "audio/mpeg" if f.suffix == ".mp3" else "text/plain"
             _r2_upload(
                 f, f"{R2_BOOKS_PREFIX}/{volume.volume_id}/audio/{f.name}",
-                ctype)
+                ctype, private=True)
     except Exception as exc:  # noqa: BLE001
         logger.warning("audio cache persist failed (tracks stay local "
                        "only): %s", exc)
@@ -418,14 +456,15 @@ def _build_one(volume_id: str, args) -> int:
     else:
         prefix = f"{R2_BOOKS_PREFIX}/{volume.volume_id}"
         entry["files"]["epub"] = _r2_upload(
-            epub, f"{prefix}/{epub.name}", "application/epub+zip")
+            epub, f"{prefix}/{epub.name}", "application/epub+zip",
+            private=True)
         entry["files"]["sample_epub"] = _r2_upload(
             sample, f"{prefix}/{sample.name}", "application/epub+zip")
         entry["files"]["cover"] = _r2_upload(
             cover, f"{prefix}/cover.png", "image/png")
         if m4b:
             entry["files"]["m4b"] = _r2_upload(
-                m4b, f"{prefix}/{m4b.name}", "audio/mp4")
+                m4b, f"{prefix}/{m4b.name}", "audio/mp4", private=True)
         logger.info("uploaded %d artifacts to R2 under %s/",
                     len(entry["files"]), prefix)
 

--- a/scripts/verify_book_catalog.py
+++ b/scripts/verify_book_catalog.py
@@ -23,19 +23,68 @@ import requests
 ROOT = Path(__file__).resolve().parent.parent
 
 
+PAID_KINDS = ("epub", "m4b")
+
+
+def _check_private(kind: str, ref: str) -> list:
+    """Verify an ``r2://bucket/key`` master exists, with credentials.
+
+    Soft-passes when no R2 credentials are present (a fork, or a local
+    run) — an unverifiable master is not the same as a missing one, and
+    failing here would make the check useless everywhere but CI.
+    """
+    import os
+
+    bucket, _, key = ref[len("r2://"):].partition("/")
+    if not all(os.getenv(k, "").strip() for k in
+               ("R2_ENDPOINT_URL", "R2_ACCESS_KEY_ID",
+                "R2_SECRET_ACCESS_KEY")):
+        return []
+    try:
+        import boto3
+        from botocore.config import Config as BotoConfig
+
+        boto3.client(
+            "s3",
+            endpoint_url=os.environ["R2_ENDPOINT_URL"].strip(),
+            aws_access_key_id=os.environ["R2_ACCESS_KEY_ID"].strip(),
+            aws_secret_access_key=os.environ["R2_SECRET_ACCESS_KEY"].strip(),
+            config=BotoConfig(signature_version="s3v4"),
+        ).head_object(Bucket=bucket, Key=key)
+    except Exception as exc:  # noqa: BLE001
+        return [f"{kind}: private master missing ({exc}) at {ref}"]
+    return []
+
+
 def check_volume(entry: dict, *, expect_audio: bool) -> list:
     problems = []
     files = entry.get("files") or {}
     if not files.get("epub"):
         problems.append("no epub in catalog files")
         return problems
-    for kind, url in sorted(files.items()):
+    # The regression that matters more than reachability: a paid master
+    # that carries an https URL is a paid master anyone can download.
+    for kind in PAID_KINDS:
+        ref = files.get(kind)
+        if ref and not ref.startswith("r2://"):
+            problems.append(
+                f"{kind}: paid master is published at a public URL "
+                f"({ref}) — it belongs in the private bucket")
+    for kind, ref in sorted(files.items()):
+        if ref.startswith("r2://"):
+            # The paid masters (epub, m4b) live in a private bucket and
+            # MUST NOT answer to an anonymous HTTP request — that was the
+            # 2026-08-26 exposure. Reachability for these means "the
+            # object exists to a credentialed client", so check it the
+            # only way that is true: head_object.
+            problems.extend(_check_private(kind, ref))
+            continue
         try:
-            r = requests.head(url, timeout=30, allow_redirects=True)
+            r = requests.head(ref, timeout=30, allow_redirects=True)
             if r.status_code != 200:
-                problems.append(f"{kind}: HTTP {r.status_code} at {url}")
+                problems.append(f"{kind}: HTTP {r.status_code} at {ref}")
         except requests.RequestException as exc:
-            problems.append(f"{kind}: unreachable ({exc}) at {url}")
+            problems.append(f"{kind}: unreachable ({exc}) at {ref}")
     if expect_audio and not entry.get("audiobook"):
         problems.append("catalog entry has no audiobook block")
     return problems

--- a/tests/test_book_compiler.py
+++ b/tests/test_book_compiler.py
@@ -561,6 +561,49 @@ class TestBuildPipelineIntegrity:
         monkeypatch.setattr(bb, "ROOT", tmp_path)
         assert bb._unbuilt_volume_ids() == ["b_vol1"]
 
+    def test_paid_masters_are_never_published_at_a_public_url(self):
+        """The shipped catalog must not hand out the product for free.
+
+        On 2026-08-26 every volume's full EPUB, M4B and per-chapter
+        narration masters sat in the PUBLIC podcast bucket, with their
+        URLs committed to this repo's books/catalog.json — 596 objects,
+        3.1 GB, the whole paid catalogue downloadable by anyone who
+        opened the JSON. Covers and samples are meant to be public; the
+        product is not. A public master also invites Amazon's
+        price-matching, which pays 70% of the MATCHED price.
+        """
+        catalog = json.loads(
+            (_ROOT / "books" / "catalog.json").read_text(encoding="utf-8"))
+        offenders = [
+            f"{v['volume_id']}.{kind}"
+            for v in catalog.get("volumes", [])
+            for kind in ("epub", "m4b")
+            if (v.get("files") or {}).get(kind, "").startswith("http")
+        ]
+        assert not offenders, (
+            "paid masters published at public URLs: "
+            + ", ".join(offenders)
+            + " — they belong in the private bucket as r2:// refs"
+        )
+
+    def test_build_uploads_paid_masters_privately(self):
+        """The catalog guard above only catches what already shipped.
+        This one catches the build that would ship it again."""
+        src = (_ROOT / "scripts" / "build_book.py").read_text(
+            encoding="utf-8")
+        for needle in (
+            'entry["files"]["epub"] = _r2_upload(',
+            'entry["files"]["m4b"] = _r2_upload(',
+        ):
+            block = src.split(needle, 1)
+            assert len(block) == 2, f"{needle} vanished from build_book.py"
+            assert "private=True" in block[1][:220], (
+                f"{needle} must upload to the private bucket"
+            )
+        assert "ctype, private=True)" in src, (
+            "per-chapter narration masters must upload privately too"
+        )
+
     def test_workflow_verifies_live_artifacts_not_just_the_compiler(self):
         wf = (_ROOT / ".github" / "workflows" / "build-book.yml").read_text(
             encoding="utf-8")


### PR DESCRIPTION
## What was wrong

Every book artifact was uploaded to the public podcast bucket, and every URL was committed to `books/catalog.json` in this public repo. The paid catalogue was therefore published, in full, months before the first volume goes on sale.

| Measure | Value |
|---|---|
| Objects reachable anonymously | **596** |
| Total size | **3.1 GB** |
| Volumes affected | **9 of 9** |
| Contents | full EPUBs, full M4B audiobooks, every per-chapter narration master |

The lost sales are the smaller half. Amazon price-matches against a cheaper copy found anywhere else and then pays 70% of the *matched* price, so a single public master can zero out KDP royalties across the whole catalogue. That is precisely the failure `docs/books.md`'s first operating rule exists to prevent, and it was live while the rule was being written.

## The fix

Split the keyspace by what a file is **for**, not by what is convenient.

| Artifact | Bucket | Reachable by |
|---|---|---|
| `cover.png`, `<id>_sample.epub` | `podcast-audio` (public) | anyone — marketing assets |
| `<id>.epub`, `<id>.m4b`, `audio/track_*.mp3` | `nerra-books` (private) | credentialed clients only |

The catalog now records paid masters as `r2://nerra-books/<key>` — a location, not a promise anyone can fetch it. Buyers receive the file from the store they bought it at; the network never serves it.

## Migration already performed

`nerra-books` was created with public access disabled. All 596 objects were copied across and content-verified before anything was deleted: sizes identical on all 596, and the 29 ETag differences proved to be multipart artifacts, confirmed by matching edge hashes on all 29 plus full SHA-256 on the two largest (342 MB and 315 MB). Only then were the public copies removed.

Post-state probed live: paid URLs return 404, `cover.png` and `_sample.epub` still return 200, `/books.html` still renders. `scripts/verify_book_catalog.py --require-all` passes against live R2 — 9 volumes, 4 artifacts each.

## Guards

`test_paid_masters_are_never_published_at_a_public_url` reads the shipped catalog. `test_build_uploads_paid_masters_privately` reads `build_book.py` itself, so the build that would republish is caught too. `verify_book_catalog.py` fails outright on a paid master carrying an https URL. The build workflow's verify step now gets R2 credentials, without which the private half would soft-pass and the check would quietly stop being a check.

55/55 in `tests/test_book_compiler.py` pass locally.