### PR TITLE
Log why a Buttondown subscribe was rejected

### DIFF
--- a/workers/gallery/src/buttondown.ts
+++ b/workers/gallery/src/buttondown.ts
@@ -32,6 +32,20 @@ export interface SubscribeResult {
   alreadySubscribed: boolean;
   error?: string;
   status?: number;
+  /** Redacted upstream body, for the Worker log only — never returned
+   *  to the client. Without it a Buttondown 400 is unreadable: the code
+   *  alone cannot tell "duplicate" from "tag rejected" from "plan
+   *  limit", which cost an afternoon on 2026-08-26 when signup broke
+   *  and the log said only BUTTONDOWN_HTTP_400. */
+  detail?: string;
+}
+
+
+/** Strip anything email-shaped before an upstream body reaches a log. */
+export function redact(body: string): string {
+  return body
+    .replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "<email>")
+    .slice(0, 300);
 }
 
 export async function subscribe(
@@ -88,6 +102,7 @@ export async function subscribe(
     alreadySubscribed: false,
     status: resp.status,
     error: `BUTTONDOWN_HTTP_${resp.status}`,
+    detail: redact(body),
   };
 }
 

--- a/workers/gallery/src/handlers.ts
+++ b/workers/gallery/src/handlers.ts
@@ -279,7 +279,8 @@ export async function handleSubscribe(
 
   if (!result.ok) {
     // Don't leak upstream detail to the client; logged in the Worker tail.
-    console.warn("subscribe: buttondown failure", result.error, result.status);
+    console.warn("subscribe: buttondown failure", result.error,
+                 result.status, result.detail ?? "");
     return jsonResponse(request, 502, { ok: false, error: "subscribe failed" });
   }
   console.log("subscribe: ok", list, tags.join(","));


### PR DESCRIPTION
The handler's comment promised the upstream detail was "logged in the Worker tail". It wasn't - only the status code was, so a Buttondown 400 read as BUTTONDOWN_HTTP_400 and nothing else. That code cannot distinguish a duplicate from a rejected tag from a plan limit, and on 2026-08-26 it cost an afternoon: every new signup on the site was failing and the log would not say why.

It turned out to be {"code":"subscriber_blocked","detail":"This subscriber was blocked by your firewall."} - an account setting, invisible from the code. One log line would have found it in a minute.

Carry a redacted upstream body on SubscribeResult.detail and log it. Emails are stripped before it reaches a log and the body is capped at 300 chars; the client still gets the same opaque 502, so nothing leaks to visitors.