### PR TITLE
Fix Nvidia + SPCX pronunciation network-wide; stop SpaceX mega-story retells and headline-chapter spam

### DIFF
--- a/assets/pronunciation.py
+++ b/assets/pronunciation.py
@@ -439,8 +439,14 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # SoFi, NOIRLab, Afeela, DSPy, HarmfulQA, TheoremQA, VideoQA, MedQuAD,
     # Cassini, Oberth, Karpathy, Milei, Zelensky(+yy/yj), Altman, Amodei.
     #
-    # ``NVIDIA`` stays (its garble revert lands on the different token "Nvidia";
-    # moving it would change the audio). ``Lifespan.io`` stays (strip_urls
+    # ``NVIDIA`` -> "En-vidia" REMOVED 2026-08-27: it was a dead round-trip
+    # after all — engine.utils.fix_phonetic_garbles reverts "en-vidia" ->
+    # "Nvidia" (case-insensitively) before the script is saved, so TTS never
+    # received the guide and the voice shipped "navidia" / "in video" on air
+    # (MIT Ep083/110/132, M&A Ep091, OV Ep117 Whisper transcripts). The guide
+    # now lives in shows/pronunciation_map.yaml (audio-only, applied at
+    # synthesis AFTER the garble repair, case-insensitive so it covers
+    # NVIDIA / Nvidia / nvidia). ``Lifespan.io`` stays (strip_urls
     # rewrites the .io domain before this map runs, so it needs the script-save
     # layer).
     #
@@ -452,7 +458,6 @@ WORD_PRONUNCIATIONS: Dict[str, str] = {
     # changes shipped audio → A/B-listened. If one regresses, re-add it to
     # shows/pronunciation_map.yaml (audio-only), not here.
     "Lifespan.io": "Life-span dot i o",
-    "NVIDIA": "En-vidia",
 
     # --- Scientific names ---
     # ``Cassini`` / ``Oberth`` MOVED to shows/pronunciation_map.yaml on

--- a/digests/spacex/chapters_ep077.json
+++ b/digests/spacex/chapters_ep077.json
@@ -4,26 +4,6 @@
     {
       "startTime": 12.7,
       "title": "Introduction",
-      "endTime": 75.0
-    },
-    {
-      "startTime": 75.0,
-      "title": "SpaceX is hiring for natural gas trading to support energy…",
-      "endTime": 112.9
-    },
-    {
-      "startTime": 112.9,
-      "title": "Cape Canaveral studying impact of future Starship launches",
-      "endTime": 183.1
-    },
-    {
-      "startTime": 183.1,
-      "title": "NASA contracted SpaceX for $843 million to develop the…",
-      "endTime": 225.1
-    },
-    {
-      "startTime": 225.1,
-      "title": "Nvidia joins Starcloud’s $250 million orbital data center…",
       "endTime": 299.3
     },
     {

--- a/engine/chapters.py
+++ b/engine/chapters.py
@@ -256,6 +256,7 @@ def parse_chapters(
     auto_segment_target_seconds: float = 90.0,
     estimated_words_per_minute: float = 165.0,
     story_headlines: Optional[List[str]] = None,
+    known_sections_only: bool = False,
 ) -> List[Chapter]:
     """Parse a podcast script to identify section boundaries.
 
@@ -420,7 +421,20 @@ def parse_chapters(
         and (chapters[0].word_end - chapters[0].word_start)
         >= int(total_words * 0.50)
     )
-    if (len(chapters) < min_chapters or head_spans_most) and total_words > 0:
+    # Aug 27 2026 (spacex Ep077): shows whose prompts speak a full, fixed
+    # section set opt out of auto-segmentation entirely — every inserted
+    # chapter would carry a digest headline / first-sentence title outside
+    # the known section set, which ships as listener-facing spam in the
+    # chapter UI ("SpaceX is hiring for natural gas trading to support
+    # energy…" between Introduction and Counterpoint). For those shows the
+    # matched markers ARE the navigation.
+    if known_sections_only and (len(chapters) < min_chapters or head_spans_most):
+        logger.info(
+            "known_sections_only: skipping auto-segmentation for %s "
+            "(%d marker chapters stand as-is)",
+            show_name or "show", len(chapters),
+        )
+    elif (len(chapters) < min_chapters or head_spans_most) and total_words > 0:
         words_per_segment = max(
             int(estimated_words_per_minute * (auto_segment_target_seconds / 60.0)),
             120,

--- a/engine/config.py
+++ b/engine/config.py
@@ -506,6 +506,12 @@ class SectionMarker:
 class ChaptersConfig:
     enabled: bool = True
     section_markers: List[SectionMarker] = field(default_factory=list)
+    # Aug 27 2026 (spacex Ep077): when true, chapters come ONLY from the
+    # show's section_markers — the auto-segment fallback (which titles
+    # inserted chapters with digest headlines / first sentences) is
+    # disabled. For shows whose prompts speak a full, fixed section set,
+    # headline-titled insertions are listener-facing spam, not navigation.
+    known_sections_only: bool = False
 
 
 @dataclass
@@ -1148,7 +1154,12 @@ def _build_chapters(raw: dict) -> ChaptersConfig:
         return ChaptersConfig()
     markers = _build_section_markers(raw.get("section_markers"))
     enabled = raw.get("enabled", True)
-    return ChaptersConfig(enabled=enabled, section_markers=markers)
+    known_sections_only = bool(raw.get("known_sections_only", False))
+    return ChaptersConfig(
+        enabled=enabled,
+        section_markers=markers,
+        known_sections_only=known_sections_only,
+    )
 
 
 def _build_nested(cls, raw: dict):

--- a/run_show.py
+++ b/run_show.py
@@ -2955,6 +2955,8 @@ def run(args: argparse.Namespace) -> None:
                 config.chapters.section_markers,
                 show_name=config.name,
                 story_headlines=_chapter_headlines,
+                known_sections_only=getattr(
+                    config.chapters, "known_sections_only", False),
             ) if config.chapters.enabled and config.chapters.section_markers else []
 
             # Final defense-in-depth: strip any speaker prefixes that survived

--- a/shows/hooks/spacex.py
+++ b/shows/hooks/spacex.py
@@ -121,15 +121,19 @@ def pronunciation_overrides() -> dict:
         "extra_words": {"tf": "tons-force"},
         # SPCX is already letter-spelled at TTS-call time by
         # shows/pronunciation_map.yaml, but that leaves the saved _tts.txt
-        # carrying the raw ticker while the voice receives "S P C X" — the
-        # 2026-07-31 Ep051 ticker investigation had to reconstruct what the
-        # voice was actually sent because the on-disk script didn't show it.
-        # Expanding at script-save time too makes the committed TTS text
+        # carrying the raw ticker while the voice receives the spelling —
+        # the 2026-07-31 Ep051 ticker investigation had to reconstruct what
+        # the voice was actually sent because the on-disk script didn't show
+        # it. Expanding at script-save time too makes the committed TTS text
         # match the audio input byte-for-byte (the TTS-call map then finds
         # nothing left to replace — the voice receives the identical string,
         # so this is bookkeeping, not an audio change). The chapter patterns
-        # in shows/spacex.yaml already tolerate both forms.
-        "extra_acronyms": {"SPCX": "S P C X"},
+        # in shows/spacex.yaml tolerate the raw ticker and both spellings.
+        # Aug 27 2026: spelling changed "S P C X" -> "Ess Pee See Ex" —
+        # Grok's text_normalization read the "S P" bigram as the S&P index
+        # (Ep051 aired "S&P CX"); letter-name words can't be merged. MUST
+        # stay identical to the SPCX value in shows/pronunciation_map.yaml.
+        "extra_acronyms": {"SPCX": "Ess Pee See Ex"},
     }
 
 
@@ -308,8 +312,8 @@ def _price_sentence(price: float, change_str: str, source: str) -> str:
         except (TypeError, ValueError):
             change_part = ""
     if source == "yfinance_history":
-        return f"S P C X closed at {spoken}{change_part}. "
-    return f"S P C X is trading at {spoken}{change_part}. "
+        return f"Ess Pee See Ex closed at {spoken}{change_part}. "
+    return f"Ess Pee See Ex is trading at {spoken}{change_part}. "
 
 
 # Closing variants, rotated by calendar date (the TST anti-fossilization

--- a/shows/prompts/spacex_digest.txt
+++ b/shows/prompts/spacex_digest.txt
@@ -3,6 +3,10 @@ This block guides you (the writer). Never copy instructions, length targets, or 
 
 ABSOLUTE RULE — ZERO STORY OVERLAP: each story appears in exactly ONE section. Before writing each section, re-read what you covered above and skip anything already used. Fewer unique items beat duplicated ones.
 
+ONE STORY = ONE ITEM: when several fetched articles cover the SAME event, synthesize them into a SINGLE Top News item carrying the best facts from all of them — never write one item per outlet. A run of items that each re-state the same event with a different attribution ("X reports… Y states… Z indicates…") is duplication, not coverage.
+
+MEGA-STORY DAYS: when a single development dominates the fetch (one site/deal/capex figure driving most items), put FULL depth in exactly one primary section (Top News OR Engineering Deep Dive OR AI & Compute — whichever owns the mechanism). Every other section may use at most one short pointer clause to that story and MUST NOT restate the same dollar figure, pad/site count, year target, or job count. No second full retelling.
+
 REQUIRED SECTIONS, in this order (never omit any except Market Watch per its rule):
 1. HOOK line  2. ### Top News (8–10 items)  3. ### Community Buzz (4–5 fresh items, zero overlap with Top News)  4. ## The Counterpoint  5. ### AI & Compute (the SpaceX↔xAI/Grok/X thread — see rule)  6. ### Engineering Deep Dive (the flagship section — first-principles engineering analysis, mandatory even on quiet days)  7. ### Market Watch (a SHORT, secondary note — see rule)  8. one-sentence sign-off
 [END PRODUCTION NOTES]

--- a/shows/prompts/spacex_podcast.txt
+++ b/shows/prompts/spacex_podcast.txt
@@ -45,6 +45,8 @@ RULES:
 - Mention sources naturally in conversation ("according to NASASpaceflight") — never read URLs, timestamps, or section headers aloud
 - No emoji, markdown, or pet names for the audience
 - Never repeat a fact you already stated — each sentence must add NEW information (Episode 1 restated the earnings-report point four times; that is padding, not coverage)
+- MEGA-STORY DAYS: if one development dominates the digest, give it full spoken depth in a single stretch (usually Top News or the Engineering Deep Dive). Do not re-open the same dollar figure, pad/site count, or year target again inside AI & Compute, the Counterpoint, or the teaser — one clause of forward pointer max. Chapters still use their required anchor phrases; the ban is on re-telling the same facts, not on anchors.
+- Never narrate a roll call of outlet attributions for one story ("X reports… Y states… Z notes…" sentence after sentence). Synthesize what is known into one account; attribute at most once where a claim genuinely needs it.
 - Never use the same transition phrase twice in one episode ("That same..." ran three times in Episode 1 — rotate your connectives)
 
 EXAMPLE OF IDEAL STORY COVERAGE (this depth and style for every story — 5 fact-bearing sentences, 0 commentary, 1 transition):

--- a/shows/pronunciation_map.yaml
+++ b/shows/pronunciation_map.yaml
@@ -33,7 +33,16 @@ corrections:
   AAPL: "A A P L"
   # SPCX added June 13 2026 (SpaceX IPO'd June 12; SpaceX Daily carries a
   # daily Market Watch on the ticker — same letter-spelling class as TSLA).
-  SPCX: "S P C X"
+  # CHANGED Aug 27 2026 (operator-reported, transcript-evidenced): the
+  # spaced letter form "S P C X" collides with Grok's server-side
+  # text_normalization, which reads the leading "S P" bigram as the S&P
+  # index — Ep051's Whisper transcript shipped "S&P CX closed at $112.20"
+  # verbatim. Letter-NAME words are immune to that merge (same class as
+  # DSPy -> "D S Pie"): still a literal letter spelling, not a phonetic
+  # respelling of a word. Kept in sync with shows/hooks/spacex.py
+  # (script-save expansion + spoken market lines) and the Market Watch
+  # chapter pattern in shows/spacex.yaml.
+  SPCX: "Ess Pee See Ex"
 
   # ---------------- Canadian registered accounts ----------------
   # Spelled-out is universally how listeners refer to these vehicles
@@ -150,6 +159,17 @@ corrections:
   "IG Metall": "I G Metall"
   "IF Metall": "I F Metall"
   # Companies / brands / missions
+  # Nvidia added Aug 27 2026 (operator-reported, transcript-evidenced):
+  # the plain written form ships garbled on the production voice — Whisper
+  # heard "navidia" (MIT Ep083/110/132, M&A Ep091, OV Ep117) and even
+  # "in video Vera Rubin chips". The old script-save guide
+  # (assets/pronunciation.py NVIDIA -> "En-vidia") was a dead round-trip:
+  # engine.utils.fix_phonetic_garbles reverts "en-vidia" -> "Nvidia"
+  # before the script is saved, so TTS never received the guide. This
+  # audio-only layer runs at synthesis, AFTER the garble repair, so the
+  # guide finally reaches the voice. Case-insensitive match covers
+  # NVIDIA / Nvidia / nvidia.
+  Nvidia: "En-vidia"
   Mistral: "Mee-stral"
   AstraZeneca: "Astra-Zeneca"
   Alnylam: "Al-nye-lam"

--- a/shows/spacex.yaml
+++ b/shows/spacex.yaml
@@ -311,13 +311,21 @@ episode:
 
 chapters:
   enabled: true
+  # Aug 27 2026 (Ep077): the auto-segment fallback spliced four truncated
+  # digest-headline chapters between Introduction and Counterpoint. This
+  # show's prompt speaks a full fixed section set — chapters must come only
+  # from the markers below (drift guard: tests/test_spacex_show.py).
+  known_sections_only: true
   # June 2026 lessons baked in at launch: positional `where` anchors
   # (the Tesla chapter-bug class) and a Closing pattern that covers
   # EVERY closing-pool variant in engine/intros.py (guarded by
   # tests/test_spacex_show.py).
   # NOTE: chapters parse the POST-pronunciation script (Ep001 lesson):
-  # assets/pronunciation.py maps "SpaceX" -> "Space X" and "SPCX" ->
-  # "S P C X" for TTS, so every pattern must tolerate both forms.
+  # assets/pronunciation.py maps "SpaceX" -> "Space X" and the spacex hook
+  # maps "SPCX" -> "Ess Pee See Ex" for TTS (was "S P C X" until Aug 27
+  # 2026 — Grok normalization read "S P" as the S&P index), so every
+  # pattern must tolerate the raw ticker and BOTH spellings (older
+  # committed scripts keep the spaced-letter form).
   section_markers:
     - pattern: "Space ?X Daily|welcome to Space ?X"
       title: "Introduction"
@@ -341,7 +349,7 @@ chapters:
     # episodes shipped with no Market Watch chapter. Closing stays listed
     # FIRST with where:end so sign-off-only price lines remain Closing
     # (Ep3 / Ep62-64 class).
-    - pattern: "on the market side|market watch|quick (market note|note on the market|look at the (tape|market))|S ?P ?C ?X (closed|closing|is at|at \\$|at [a-z]+ hundred|is trading|trading at|trades at|opened)"
+    - pattern: "on the market side|market watch|quick (market note|note on the market|look at the (tape|market))|(S ?P ?C ?X|Ess Pee See Ex) (closed|closing|is at|at \\$|at [a-z]+ hundred|is trading|trading at|trades at|opened)"
       title: "Market Watch"
     - pattern: "one thing worth watching|worth keeping an eye on|the counterpoint"
       title: "The Counterpoint"

--- a/tests/test_pronunciation_grok_alignment.py
+++ b/tests/test_pronunciation_grok_alignment.py
@@ -23,11 +23,12 @@ from engine.tts import prepare_text_for_tts as tts_prepare
 from engine.utils import _PHONETIC_GARBLES, fix_phonetic_garbles
 
 
-# ``NVIDIA`` -> "En-vidia" is reverted by the garble layer to "Nvidia" (a
-# DIFFERENT token than the "NVIDIA" key), so removing it could let an all-caps
-# "NVIDIA" reach Grok and letter-split. Kept until the A/B-listen batch settles
-# it; every other garble-reverted respelling has been dropped.
-_TOLERATED_ROUND_TRIPS = {"NVIDIA"}
+# 2026-08-27: the last tolerated round-trip (``NVIDIA`` -> "En-vidia") was
+# resolved the same way as every other one — moved to the audio-only YAML
+# layer. The round trip was not protective after all: fix_phonetic_garbles
+# matches case-insensitively, so the revert fired on "En-vidia" and TTS
+# received plain "Nvidia", which shipped as "navidia" / "in video" on air.
+_TOLERATED_ROUND_TRIPS: set = set()
 
 
 def test_no_new_garble_redundant_respellings():
@@ -48,7 +49,7 @@ def test_no_new_garble_redundant_respellings():
 def test_removed_garble_redundant_entries_stay_removed():
     for word in (
         "Teslarati", "Anthropic", "Enceladus", "Qwen",
-        "Llama", "Starmer", "Tianwen", "Hassabis",
+        "Llama", "Starmer", "Tianwen", "Hassabis", "NVIDIA",
     ):
         assert word not in WORD_PRONUNCIATIONS, (
             f"{word} respelling was removed as a dead round-trip — re-adding it "
@@ -73,6 +74,10 @@ def test_garble_layer_still_protects_against_llm_garbles():
 #   2. the synthesis layer (engine.tts, shows/pronunciation_map.yaml) still
 #      emits the respelling -> audio is unchanged.
 _MOVED = {
+    # 2026-08-27: Nvidia joined the moved set — the script-save NVIDIA entry
+    # was reverted by the garble layer before TTS, so the voice never got the
+    # guide ("navidia" shipped on MIT/M&A/OV). Audio-only layer now owns it.
+    "Nvidia": "En-vidia",
     "Milei": "Mee-lay",
     "Mistral": "Mee-stral",
     "Cassini": "Kah-see-nee",

--- a/tests/test_spacex_show.py
+++ b/tests/test_spacex_show.py
@@ -352,13 +352,14 @@ class TestStockClosing:
         from shows.hooks.spacex import _pick_closing
         import datetime
         closing = _pick_closing(0.0, "", "", date=datetime.date(2026, 6, 13))
+        assert "Ess Pee See Ex" not in closing
         assert "S P C X" not in closing
         assert "unavailable" not in closing.lower()
 
     def test_price_sentence_phrasing_by_source(self):
         from shows.hooks.spacex import _price_sentence
         closed = _price_sentence(161.0, "+19.2%", "yfinance_history")
-        assert closed.startswith("S P C X closed at")
+        assert closed.startswith("Ess Pee See Ex closed at")
         assert "percent" in closed
         live = _price_sentence(161.0, "+19.2%", "yfinance_fast_info")
         assert "is trading at" in live and "closed" not in live
@@ -380,10 +381,45 @@ class TestStockClosing:
         assert "down market day" in _tone_from_change(150.0, "-3.1%")
 
     def test_spcx_ticker_letter_spelled_for_tts(self):
+        # Aug 27 2026: letter-NAME words, not spaced letters — Grok's
+        # text_normalization read the "S P" bigram as the S&P index and
+        # Ep051 aired "S&P CX closed at $112.20". The map value, the hook's
+        # script-save expansion, and the spoken market lines must all agree
+        # or the saved _tts.txt stops matching the audio input.
+        from shows.hooks.spacex import pronunciation_overrides
         pron = yaml.safe_load(
             (_ROOT / "shows/pronunciation_map.yaml").read_text(encoding="utf-8")
         )
-        assert pron["corrections"].get("SPCX") == "S P C X"
+        assert pron["corrections"].get("SPCX") == "Ess Pee See Ex"
+        assert pronunciation_overrides()["extra_acronyms"]["SPCX"] == "Ess Pee See Ex"
+
+    def test_spcx_spelling_cannot_trigger_sp_index_merge(self):
+        # The regression signature: a spelling whose spoken form starts with
+        # the bare "S P" bigram gets merged to "S&P" by Grok's server-side
+        # normalizer. Whatever the spelling becomes, it must never reopen that.
+        pron = yaml.safe_load(
+            (_ROOT / "shows/pronunciation_map.yaml").read_text(encoding="utf-8")
+        )
+        spoken = pron["corrections"]["SPCX"]
+        assert not re.match(r"^S\s+P\b", spoken), (
+            f"SPCX spelling {spoken!r} leads with the 'S P' bigram — Grok "
+            "text_normalization reads that as the S&P index (Ep051 aired "
+            "'S&P CX')"
+        )
+
+    def test_new_spcx_spelling_matches_market_watch_pattern(self):
+        # Chapter patterns parse the saved script, which now carries the
+        # letter-name spelling — Market Watch must fire on it (and the old
+        # spaced form stays tolerated for the committed archive).
+        markers = _spacex_markers()
+        mw = next(m for m in markers if m["title"] == "Market Watch")
+        for line in (
+            "And a quick market note: Ess Pee See Ex is trading at two "
+            "hundred one dollars.",
+            "Ess Pee See Ex closed at one hundred sixty dollars.",
+            "A quick look at the tape shows S P C X at one hundred forty dollars.",
+        ):
+            assert re.search(mw["pattern"], line, re.IGNORECASE), line
 
     def test_tf_thrust_unit_expanded_for_tts(self):
         """Ep2 lesson: "thrust now exceeds 280 tf" was spoken as "280 T F"
@@ -850,3 +886,70 @@ class TestEngineeringAnchorRotation:
             "the price-once rule is gone — the same number aired twice "
             "~30s apart for weeks (escalated since 2026-06-13)"
         )
+
+
+class TestKnownSectionsOnlyChapters:
+    """Aug 27 2026 (Ep077): the auto-segment fallback spliced four truncated
+    digest-headline chapters ("SpaceX is hiring for natural gas trading to
+    support energy…") between Introduction and Counterpoint. SpaceX speaks a
+    full fixed section set — chapters must come only from the YAML markers."""
+
+    KNOWN_TITLES = {
+        "Introduction", "The Counterpoint", "AI & Compute",
+        "The Engineering Angle", "Market Watch", "Tomorrow Teaser", "Closing",
+    }
+
+    def test_yaml_pins_known_sections_only(self):
+        cfg = load_config(_ROOT / "shows/spacex.yaml")
+        assert cfg.chapters.known_sections_only is True
+
+    def test_marker_titles_are_the_known_set(self):
+        assert {m["title"] for m in _spacex_markers()} == self.KNOWN_TITLES
+
+    def test_no_committed_chapters_json_outside_known_set(self):
+        # Scoped to Ep077+ — thirteen older files (Ep021-Ep060) carry
+        # auto-segment headline chapters from days when the mid-body
+        # markers never fired; those ARE that episode's only navigation,
+        # so they stay as frozen archive (the review's "cleaned or
+        # accepted as frozen archive" split). Ep077 was cleaned; from
+        # known_sections_only onward no new file can regress.
+        import json
+        offenders = {}
+        for path in sorted((_ROOT / "digests/spacex").glob("chapters_ep*.json")):
+            ep = int(re.search(r"ep(\d+)", path.name).group(1))
+            if ep < 77:
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            bad = [c["title"] for c in data.get("chapters", [])
+                   if c.get("title") not in self.KNOWN_TITLES]
+            if bad:
+                offenders[path.name] = bad
+        assert not offenders, (
+            "committed spacex chapter files carry non-section titles "
+            f"(Ep077 class): {offenders}"
+        )
+
+    def test_parse_chapters_does_not_invent_titles(self):
+        # A long head span used to trigger auto-segmentation with digest
+        # headlines as titles; with known_sections_only the marker chapters
+        # stand as-is.
+        body = " ".join(
+            f"filler sentence number {i} about natural gas trading and pads."
+            for i in range(120)
+        )
+        script = (
+            "Welcome to SpaceX Daily, episode seventy-seven.\n\n"
+            + body + "\n\n"
+            + "One thing worth watching is the permitting question.\n\n"
+            + "That's a wrap on today's SpaceX developments. See you tomorrow."
+        )
+        headlines = [
+            "SpaceX is hiring for natural gas trading to support energy needs",
+            "Cape Canaveral studying impact of future Starship launches",
+        ]
+        chapters = parse_chapters(
+            script, _spacex_markers(), show_name="SpaceX Daily",
+            story_headlines=headlines, known_sections_only=True,
+        )
+        titles = {c.title for c in chapters}
+        assert titles <= self.KNOWN_TITLES, titles


### PR DESCRIPTION
Operator-reported audio bugs, all verified against shipped Whisper transcripts before fixing.

## Pronunciation

**SPCX spoken as "S&P-CX"** — the TTS letter spelling `S P C X` collides with Grok's server-side `text_normalization`, which reads the leading "S P" bigram as the S&P index. Hard evidence on air: Ep051's transcript says *"S&P CX closed at $112.20"* and Ep081's says *"SNP-CX is trading at $137.95"*. The spoken form is now the letter-name words **"Ess Pee See Ex"** (same class as the existing `DSPy → "D S Pie"` guide — still a literal letter spelling, not a phonetic respelling) in all three places that must agree: `shows/pronunciation_map.yaml`, the spacex hook's script-save expansion + spoken market lines, and the Market Watch chapter pattern (old spaced form stays tolerated for the committed archive). A new drift guard rejects any future SPCX spelling that leads with the "S P" bigram.

**Nvidia spoken as "navidia" / "in video"** — the script-save guide `NVIDIA → "En-vidia"` was a dead round-trip: `fix_phonetic_garbles` reverts `en-vidia → Nvidia` case-insensitively *before* the script is saved, so TTS never received the guide. Shipped evidence: "navidia" on MIT Ep083/110/132, M&A Ep091, OV Ep117, and *"first production **in video** Vera Rubin chips"*. The guide now lives in `shows/pronunciation_map.yaml` (audio-only, applied at synthesis **after** the garble repair; case-insensitive match covers NVIDIA/Nvidia/nvidia), and the dead script-save entry is removed — transcripts stay clean, audio finally gets the guide. The NVDA ticker itself shows no mishearing in any transcript (Whisper writes it cleanly), so its letter spelling is unchanged; the "NVDA — Nvidia" pick lines sounded broken because the name half garbled.

## SpaceX quality (implements the merged Aug-26 review's P0/P1)

**Ep081 told the Louisiana $100B story four times** — cold open, Engineering, a ten-item Top News roll call ("Aviation Week reports… Engadget states… EGAMERS reports… Business news 97.5 FM indicates…"), and AI &amp; Compute again. The generator's own warnings fired ("$100 billion appears 6 times", blocks 3/5 duplication) but nothing in the prompt forbade the shape. Added:
- digest: **MEGA-STORY DAYS** rule (full depth in exactly one primary section; other sections get one pointer clause, never a restated figure) + **ONE STORY = ONE ITEM** (synthesize multi-outlet coverage into a single item — never one item per outlet)
- podcast: mirror rule + a ban on narrating outlet-attribution roll calls

**Ep077 shipped four truncated-headline chapters** ("SpaceX is hiring for natural gas trading to support energy…") — the auto-segment fallback spliced digest headlines into a show that speaks a full fixed section set. New `chapters.known_sections_only` config flag (on for spacex; default false so Tesla-style shows keep headline navigation) disables auto-segmentation; Ep077's committed chapters JSON is cleaned (headline spans folded into Introduction). Drift guards: no committed spacex chapters file from Ep077 on may carry a non-section title (Ep021–Ep060 stay as frozen archive — those headline chapters are that era's only navigation), and `parse_chapters` invents no titles under the flag.

## ⚠️ A/B-listen required (landmine #17)

The two prompt edits and both pronunciation changes alter shipped audio on the next episodes. Spot-listen the next spacex episode (ticker line + story structure) and any MIT/M&A episode that mentions Nvidia.

## Tests

`test_spacex_show` (78), `test_chapters`, `test_config`, `test_pronunciation*` (4 suites), `test_tts_grok`, `test_prompt_fidelity` — 523 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199jonshZcnncec9ibNmych

---
_Generated by [Claude Code](https://claude.ai/code/session_0199jonshZcnncec9ibNmych)_