### PR TITLE
Withdraw FPD + UC from the grok-4.6 trial: back to grok-4.3 (playbook latency gate)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1697,7 +1697,14 @@ day** (operator-directed; experiment `staged-grok-46-trial`, readout
 2026-09-01): grok-4.6 on dp_pod's SCRIPT stage only, first_principles +
 unintended_consequences whole-show (narrative — no news fetch), and the
 synth + reviewer stages; `NERRA_LLM_TIMEOUT_SECONDS` raised to 600 in
-run-show.yml to cover 4.6 latency. Every daily NEWS show's digest/fetch
+run-show.yml to cover 4.6 latency. **2026-08-27: the FPD + UC whole-show
+arms were WITHDRAWN (operator-directed, playbook latency gate)** — on
+the GitHub-cron outage day FPD's 4.6 digest calls stalled ~260 s and
+server-disconnected on both of its runs and UC died on both of its
+runs, so both shows are back on the grok-4.3 network default; the
+narrative-length question is unanswered, not answered negative, and a
+re-pin needs a fresh staged trial. dp_pod's script arm and the synth +
+reviewer stages continue. Every daily NEWS show's digest/fetch
 stays grok-4.3 — scope pinned by
 `tests/test_llm_usage_pass.py::TestStagedGrok46Trial`. Reviewer
 FACTUAL_ERRORS comparisons from 2026-08-18 on must be cross-show under

--- a/docs/experiments.yaml
+++ b/docs/experiments.yaml
@@ -375,11 +375,26 @@ experiments:
       Any retry follows docs/model_upgrade_playbook.md: one show first,
       digest-latency gate before network-wide.
   - id: staged-grok-46-trial
-    title: "grok-4.6 staged trial — dp_pod script, FPD+UC whole-show, synth, reviewer"
+    title: "grok-4.6 staged trial — dp_pod script, synth, reviewer (FPD+UC arms withdrawn 2026-08-27)"
     area: quality
     shipped: 2026-08-18
     readout: 2026-09-01
     status: reading
+    interim: >
+      2026-08-27 (operator-directed): the first_principles and
+      unintended_consequences WHOLE-SHOW arms are withdrawn — on the
+      GitHub-cron outage day, FPD's grok-4.6 digest calls stalled ~260s
+      and the server disconnected without a response (three tenacity
+      attempts, on both of its runs) and UC died on both of its runs;
+      both shows missed their slots twice in one day, the same
+      operational signature that forced the Aug-18 same-day network
+      revert. Both shows are back on the grok-4.3 network default (the
+      playbook's latency gate: an arm that costs episodes is over,
+      whatever its editorial promise). The 4.3-vs-4.6 narrative-length
+      question for FPD/UC is UNANSWERED, not answered negative — a
+      retry needs xAI-side latency to be demonstrably fixed first. The
+      dp_pod script-stage arm and the synth + reviewer stages continue
+      to the 2026-09-01 readout unchanged.
     baseline: >
       All stages on grok-4.3 after the same-day revert of the network-wide
       4.6 upgrade. dp_pod on 4.3: zero exclamation points in 27/30

--- a/shows/first_principles.yaml
+++ b/shows/first_principles.yaml
@@ -26,17 +26,18 @@ multilingual:
   - fr
 llm:
   provider: xai
-  # 2026-08-18 STAGED grok-4.6 trial (operator-directed; experiment
-  # staged-grok-46-trial, per docs/model_upgrade_playbook.md). Narrative
-  # show: no news fetch — the brief IS model-knowledge prose, so a
-  # stronger model is the first sanctioned lever against the accepted
-  # grok-4.3 narrative-length plateau (podcast-side retries stay banned).
-  # Measured 4.6 latency on this show's digest: ~205s (fits the raised
-  # NERRA_LLM_TIMEOUT_SECONDS=600 with wide margin). Watch: reviewer
-  # FACTUAL_ERRORS vs the other shows on the same reviewer, stage
-  # durations in metrics_ep*.json, Slow-LLM-completion warnings.
-  # Revert = delete this line. A/B-listen the first episode (#17).
-  model: grok-4.6
+  # 2026-08-27 WITHDRAWN from the staged grok-4.6 trial (operator-
+  # directed, per the model-upgrade playbook's latency gate): on outage
+  # day the 4.6 digest calls stalled ~260s each and the server
+  # disconnected without a response — three tenacity attempts, twice in
+  # a row, and the show missed its slot both times (runs 33080123951 /
+  # 33084796001). Same operational signature as the Aug-18 network-wide
+  # revert. The deleted `model: grok-4.6` pin means this show inherits
+  # the grok-4.3 network default again; the accepted 4.3 narrative-
+  # length plateau applies, attacked only via the sanctioned digest-side
+  # lever below (min_digest_words + digest_expand_below_target). Do not
+  # re-pin 4.6 here without a fresh staged trial per
+  # docs/model_upgrade_playbook.md.
   system_prompt_file: shows/prompts/first_principles_system.txt
   digest_prompt_file: shows/prompts/first_principles_episode.txt
   podcast_prompt_file: shows/prompts/first_principles_podcast.txt
@@ -61,11 +62,12 @@ llm:
   # (digest_expand_below_target). ~$39/yr of retry calls recovered.
   podcast_expand_below_target: false
   # Digest-stage expansion retry (June 2026 FP pass; retuned 2026-08-20).
-  # On grok-4.6 the brief prompt now targets 1,300-1,700w (the old
+  # The brief prompt targets a 1,300-1,700w band (the old
   # write-past-the-floor wording doubled the show's runtime — operator
   # listen verdict: repetitive). The trigger sits BELOW that band so the
   # retry rescues genuinely-thin briefs (~900-1,100w) without firing on
-  # an in-band 1,3xx brief.
+  # an in-band 1,3xx brief. On grok-4.3 (post-trial) briefs land lower
+  # in the band; the same trigger remains the sanctioned length lever.
   min_digest_words: 1200
   digest_expand_below_target: true
   podcast_chain: true

--- a/shows/unintended_consequences.yaml
+++ b/shows/unintended_consequences.yaml
@@ -21,16 +21,17 @@ multilingual:
   enabled: false
 llm:
   provider: xai
-  # 2026-08-18 STAGED grok-4.6 trial (operator-directed; experiment
-  # staged-grok-46-trial, per docs/model_upgrade_playbook.md). Narrative
-  # show: no news fetch — the brief is model-knowledge prose. Measured
-  # 4.6 latency on this show: digest ~215s, script ~208s (both fit the
-  # raised NERRA_LLM_TIMEOUT_SECONDS=600 with margin — this show's Ep093
-  # ran the full pipeline successfully on 4.6 on outage day). These are
-  # FACTUAL history stories, so the sharpest watch is invented
-  # facts/dates: reviewer FACTUAL_ERRORS vs the other shows on the same
-  # reviewer. Revert = delete this line. A/B-listen the first ep (#17).
-  model: grok-4.6
+  # 2026-08-27 WITHDRAWN from the staged grok-4.6 trial (operator-
+  # directed, per the model-upgrade playbook's latency gate): on
+  # 2026-08-27 both of this show's runs died mid-pipeline while its
+  # sibling trial show first_principles hit the 4.6 stall-then-server-
+  # disconnect signature outright (~260s per attempt, three attempts,
+  # twice) — the same operational failure that forced the Aug-18
+  # network-wide 4.6 revert. The deleted `model: grok-4.6` pin means
+  # this show inherits the grok-4.3 network default again; the accepted
+  # 4.3 narrative-length plateau applies and podcast-side retries stay
+  # banned. Do not re-pin 4.6 here without a fresh staged trial per
+  # docs/model_upgrade_playbook.md.
   system_prompt_file: shows/prompts/unintended_consequences_system.txt
   digest_prompt_file: shows/prompts/unintended_consequences_episode.txt
   podcast_prompt_file: shows/prompts/unintended_consequences_podcast.txt

--- a/tests/test_llm_usage_pass.py
+++ b/tests/test_llm_usage_pass.py
@@ -178,7 +178,15 @@ class TestStagedGrok46Trial:
     silent-config drift class this file exists for.
     """
 
-    TRIAL_NARRATIVE_SHOWS = ("first_principles", "unintended_consequences")
+    # 2026-08-27: the two whole-show narrative arms were WITHDRAWN from
+    # the trial (operator-directed, playbook latency gate) after grok-4.6
+    # digest calls stalled ~260s and server-disconnected on both of
+    # first_principles' runs and unintended_consequences died on both of
+    # its runs — the shows missed their slots twice on the same day. They
+    # are pinned BACK to the grok-4.3 network default below; the trial
+    # continues only for dp_pod's script stage and the synth + reviewer
+    # stages.
+    WITHDRAWN_NARRATIVE_SHOWS = ("first_principles", "unintended_consequences")
     NEWS_SHOWS_STAY_43 = (
         "tesla", "spacex", "omni_view", "modern_investing",
         "models_agents", "models_agents_beginners", "planetterrian",
@@ -190,9 +198,14 @@ class TestStagedGrok46Trial:
         from engine.config import load_config
         return load_config(REPO_ROOT / "shows" / f"{slug}.yaml")
 
-    def test_trial_narrative_shows_are_on_46(self):
-        for slug in self.TRIAL_NARRATIVE_SHOWS:
-            assert self._load(slug).llm.model == "grok-4.6", slug
+    def test_withdrawn_narrative_shows_back_on_43(self):
+        for slug in self.WITHDRAWN_NARRATIVE_SHOWS:
+            assert self._load(slug).llm.model == "grok-4.3", (
+                f"{slug} was withdrawn from the grok-4.6 trial on "
+                "2026-08-27 (server-disconnect latency blocked its "
+                "episodes twice in one day) — a 4.6 pin returning here "
+                "needs a fresh staged trial, never a silent re-pin"
+            )
 
     def test_dp_pod_script_stage_only(self):
         """dp_pod's DIGEST must keep inheriting the grok-4.3 network


### PR DESCRIPTION
Operator-directed. The two whole-show grok-4.6 trial arms cost episodes twice each today: first_principles' 4.6 digest calls stalled ~260 s and the **server disconnected without a response** (three tenacity attempts, on both runs [33080123951](https://github.com/Planetterrian/nerranetwork/actions/runs/33080123951) and [33084796001](https://github.com/Planetterrian/nerranetwork/actions/runs/33084796001)), and unintended_consequences died on both of its runs — the same operational signature that forced the Aug-18 same-day revert of the network-wide 4.6 upgrade. Per `docs/model_upgrade_playbook.md`, an arm that costs episodes is over.

- Both show YAMLs: the `model: grok-4.6` pin is **deleted** (the documented rollback), so both inherit the grok-4.3 network default. FPD keeps its sanctioned digest-side length lever (`min_digest_words: 1200` + `digest_expand_below_target`); podcast-side retries stay banned.
- `TestStagedGrok46Trial` now pins both shows **back on 4.3** so a 4.6 pin can't quietly return without a fresh staged trial.
- `docs/experiments.yaml`: interim note records the withdrawal; the dp_pod script arm and synth + reviewer stages continue to the 2026-09-01 readout. The FPD/UC narrative-length question is **unanswered, not answered negative**.
- CLAUDE.md trial bullet updated to match.

After merge I'll dispatch both shows so today's episodes are produced on 4.3 (unless the in-flight third attempts land first — I'll check to avoid double-publishing).

Tests: `test_llm_usage_pass` + 989 model/schedule-adjacent tests green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199jonshZcnncec9ibNmych

---
_Generated by [Claude Code](https://claude.ai/code/session_0199jonshZcnncec9ibNmych)_